### PR TITLE
Add Zkr extension and seed CSR for physical entropy

### DIFF
--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -18,6 +18,9 @@ description: |
   The `seed` CSR exposes physical entropy directly to software. This register is useful for cryptographic
   applications and random number generation. Reads may have side effects depending on the implementation.
 
+sw_read: |
+  return read_entropy();
+
 fields:
   seed_value:
     location_rv32: 31-0
@@ -27,7 +30,4 @@ fields:
       Entropy bits returned from the physical entropy source.
       This field is WARL and read-only. On each read, the value may be consumed
       or updated depending on platform behavior (see `ZKR_READ_SIDE_EFFECTS`).
-    reset_value: UNDEFINED_LEGAL  
-    sw_read: |
-      return read_entropy();
-      
+    reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) Qualcomm Technologies, Inc.
+# Copyright (c) Anirudh Narang
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../schemas/csr_schema.json
@@ -12,6 +12,7 @@ type: unprivileged
 priv_mode: U
 length: XLEN
 definedBy: Zkr
+
 description:
   - id: csr-seed-purpose
     normative: true
@@ -25,23 +26,34 @@ description:
       The entropy value returned by `seed` may change between reads. Some implementations may repeat values,
       return zero if entropy is not available, or exhibit other implementation-defined behavior.
       The returned value must never cause traps or undefined instruction behavior.
-      Only bits [15:0] are guaranteed to contain valid entropy.
+      Only bits [15:0] are guaranteed to contain valid entropy. Bits [31:30] may indicate entropy status.
 
 fields:
   SEED:
     location_rv64: 63-0
     location_rv32: 31-0
     description: |
-      Contains the physical entropy bits. Bits [15:0] are valid entropy; upper bits are zero or undefined.
-      This field is read-only. Reading it may consume entropy.
-    type(): return CsrFieldType::RO;
-    reset_value: UNDEFINED_LEGAL
-    sw_write(_): raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      Contains the physical entropy bits. Bits [15:0] are valid entropy. Bits [31:30] may indicate entropy availability state.
+      Upper bits are reserved or undefined. This field may be read/write with hardware update (RW-H), but writes are ignored.
+    type: RW-H
+    reset_value: UNDEFINED
+    sw_write(_): |
+      # Check permission via mseccfg.USEED or mseccfg.SSEED (implementation-defined)
+      if (!has_seed_write_permission(mode())) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      }
+      # Ignore all written values (read-only from software perspective)
 
 sw_read(): |
-  if (!implemented?(ExtensionName::Zkr)) {
+  # Check access permission via mseccfg.USEED or mseccfg.SSEED
+  if (!has_seed_read_permission(mode())) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  # Provide only the entropy bits in [15:0], rest are zero/undefined
-  return entropy_device.read() & ((1 << ZKR_SEED_WIDTH) - 1);
+  # Optionally: disallow CSRRS/CSRRC reads
+  if (is_read_modify_write_encoding($encoding)) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  # Return entropy value; get_random() is assumed to be a defined IDL function
+  return get_random() & ((1 << ZKR_SEED_WIDTH) - 1);

--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -22,9 +22,11 @@ fields:
   seed_value:
     location_rv32: 31-0
     location_rv64: 63-0
-    type: RO
+    type: RO-H
     description: |
       Entropy bits returned from the physical entropy source.
       This field is WARL and read-only. On each read, the value may be consumed
       or updated depending on platform behavior (see `ZKR_READ_SIDE_EFFECTS`).
-    reset_value: UNDEFINED_LEGAL
+    reset_value: UNDEFINED_LEGAL  
+    sw_read: |
+      return read_entropy();

--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -6,54 +6,25 @@
 $schema: "csr_schema.json#"
 kind: csr
 name: seed
-long_name: Physical Entropy Seed Register
+long_name: Entropy Seed Register
 address: 0x015
-type: unprivileged
 priv_mode: U
-length: XLEN
-definedBy: Zkr
-
-description:
-  - id: csr-seed-purpose
-    normative: true
-    text: |
-      The `seed` register is an XLEN-bit WARL read-only CSR that provides up to 16 bits of physical entropy.
-      Software can read this CSR to obtain entropy for cryptographic use. If no entropy is available, the value
-      may return 0 or an undefined pattern. Reading from `seed` may have side effects, depending on implementation.
-  - id: csr-seed-behavior
-    normative: false
-    text: |
-      The entropy value returned by `seed` may change between reads. Some implementations may repeat values,
-      return zero if entropy is not available, or exhibit other implementation-defined behavior.
-      The returned value must never cause traps or undefined instruction behavior.
-      Only bits [15:0] are guaranteed to contain valid entropy. Bits [31:30] may indicate entropy status.
+length: 64
+writable: false
+definedBy:
+  name: Zkr
+  version: ">=1.0.0"
+description: |
+  The `seed` CSR exposes physical entropy directly to software. This register is useful for cryptographic
+  applications and random number generation. Reads may have side effects depending on the implementation.
 
 fields:
-  SEED:
-    location_rv64: 63-0
+  seed_value:
     location_rv32: 31-0
+    location_rv64: 63-0
+    type: RO
     description: |
-      Contains the physical entropy bits. Bits [15:0] are valid entropy. Bits [31:30] may indicate entropy availability state.
-      Upper bits are reserved or undefined. This field may be read/write with hardware update (RW-H), but writes are ignored.
-    type: RW-H
-    reset_value: UNDEFINED
-    sw_write(_): |
-      # Check permission via mseccfg.USEED or mseccfg.SSEED (implementation-defined)
-      if (!has_seed_write_permission(mode())) {
-        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
-      }
-      # Ignore all written values (read-only from software perspective)
-
-sw_read(): |
-  # Check access permission via mseccfg.USEED or mseccfg.SSEED
-  if (!has_seed_read_permission(mode())) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
-  }
-
-  # Optionally: disallow CSRRS/CSRRC reads
-  if (is_read_modify_write_encoding($encoding)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
-  }
-
-  # Return entropy value; get_random() is assumed to be a defined IDL function
-  return get_random() & ((1 << ZKR_SEED_WIDTH) - 1);
+      Entropy bits returned from the physical entropy source.
+      This field is WARL and read-only. On each read, the value may be consumed
+      or updated depending on platform behavior (see `ZKR_READ_SIDE_EFFECTS`).
+    reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -30,3 +30,4 @@ fields:
     reset_value: UNDEFINED_LEGAL  
     sw_read: |
       return read_entropy();
+      

--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -18,7 +18,7 @@ description: |
   The `seed` CSR exposes physical entropy directly to software. This register is useful for cryptographic
   applications and random number generation. Reads may have side effects depending on the implementation.
 
-sw_read: |
+sw_read(): |
   return read_entropy();
 
 fields:

--- a/spec/std/isa/csr/seed.yaml
+++ b/spec/std/isa/csr/seed.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) Qualcomm Technologies, Inc.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: seed
+long_name: Physical Entropy Seed Register
+address: 0x015
+type: unprivileged
+priv_mode: U
+length: XLEN
+definedBy: Zkr
+description:
+  - id: csr-seed-purpose
+    normative: true
+    text: |
+      The `seed` register is an XLEN-bit WARL read-only CSR that provides up to 16 bits of physical entropy.
+      Software can read this CSR to obtain entropy for cryptographic use. If no entropy is available, the value
+      may return 0 or an undefined pattern. Reading from `seed` may have side effects, depending on implementation.
+  - id: csr-seed-behavior
+    normative: false
+    text: |
+      The entropy value returned by `seed` may change between reads. Some implementations may repeat values,
+      return zero if entropy is not available, or exhibit other implementation-defined behavior.
+      The returned value must never cause traps or undefined instruction behavior.
+      Only bits [15:0] are guaranteed to contain valid entropy.
+
+fields:
+  SEED:
+    location_rv64: 63-0
+    location_rv32: 31-0
+    description: |
+      Contains the physical entropy bits. Bits [15:0] are valid entropy; upper bits are zero or undefined.
+      This field is read-only. Reading it may consume entropy.
+    type(): return CsrFieldType::RO;
+    reset_value: UNDEFINED_LEGAL
+    sw_write(_): raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+
+sw_read(): |
+  if (!implemented?(ExtensionName::Zkr)) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  # Provide only the entropy bits in [15:0], rest are zero/undefined
+  return entropy_device.read() & ((1 << ZKR_SEED_WIDTH) - 1);

--- a/spec/std/isa/ext/Zkr.yaml
+++ b/spec/std/isa/ext/Zkr.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# Copyright (c) Qualcomm Technologies, Inc.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/ext_schema.json
@@ -6,12 +6,64 @@
 $schema: "ext_schema.json#"
 kind: extension
 name: Zkr
-long_name: Entropy Source
+long_name: Entropy Source Extension
 description: |
-  Defines the `seed` CSR.
-  This CSR provides up to 16 physical entropy bits that can be used to seed cryptographic random bit generators.
+  The Zkr extension defines the `seed` CSR, which provides physical entropy directly to software.
+  This register is useful for cryptographic applications and random number generation.
+  It is a read-only, WARL register visible to unprivileged software.
+
 type: unprivileged
+
 versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: null
+
+csrs:
+  - name: seed
+    long_name: Physical Entropy Seed Register
+    address: 0x015
+    priv_mode: U
+    length: XLEN
+    definedBy: Zkr
+    description:
+      - id: csr-seed-purpose
+        normative: true
+        text: |
+          The `seed` register provides access to up to 16 bits of physical entropy. It is intended to be used
+          by cryptographic algorithms or system-level entropy collection mechanisms to seed deterministic
+          random bit generators (DRBGs) or perform other security functions.
+      - id: csr-seed-behavior
+        normative: false
+        text: |
+          The value returned by `seed` may vary across reads, or remain constant if no new entropy is available.
+          Implementations may return zero if no entropy is currently ready, or return an implementation-defined value.
+    fields:
+      SEED:
+        location_rv64: 63-0
+        location_rv32: 31-0
+        description: |
+          Contains the entropy bits. The least significant 16 bits are valid entropy data, while the remaining
+          bits are reserved or undefined.
+        type(): return CsrFieldType::RO;
+        reset_value: UNDEFINED
+        sw_write(_): raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    sw_read(): |
+      if (!implemented?(ExtensionName::Zkr)) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      }
+      return entropy_device.read() & 0xffff;
+
+params:
+  ZKR_SEED_WIDTH:
+    schema:
+      type: integer
+      minimum: 1
+      maximum: 16
+    description: |
+      Defines the number of valid entropy bits returned in the `seed` CSR. Must be ≤ 16.
+  ZKR_READ_SIDE_EFFECTS:
+    schema:
+      type: boolean
+    description: |
+      If true, reading the `seed` CSR consumes entropy and may affect future read values (e.g., advancing a ring buffer).

--- a/spec/std/isa/ext/Zkr.yaml
+++ b/spec/std/isa/ext/Zkr.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) Qualcomm Technologies, Inc.
+# Copyright (c) Anirudh Narang
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/ext_schema.json
@@ -7,52 +7,17 @@ $schema: "ext_schema.json#"
 kind: extension
 name: Zkr
 long_name: Entropy Source Extension
+type: unprivileged
+
 description: |
   The Zkr extension defines the `seed` CSR, which provides physical entropy directly to software.
   This register is useful for cryptographic applications and random number generation.
-  It is a read-only, WARL register visible to unprivileged software.
-
-type: unprivileged
+  It is a read-only WARL register visible to unprivileged software. It may have side effects on reads.
 
 versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: null
-
-csrs:
-  - name: seed
-    long_name: Physical Entropy Seed Register
-    address: 0x015
-    priv_mode: U
-    length: XLEN
-    definedBy: Zkr
-    description:
-      - id: csr-seed-purpose
-        normative: true
-        text: |
-          The `seed` register provides access to up to 16 bits of physical entropy. It is intended to be used
-          by cryptographic algorithms or system-level entropy collection mechanisms to seed deterministic
-          random bit generators (DRBGs) or perform other security functions.
-      - id: csr-seed-behavior
-        normative: false
-        text: |
-          The value returned by `seed` may vary across reads, or remain constant if no new entropy is available.
-          Implementations may return zero if no entropy is currently ready, or return an implementation-defined value.
-    fields:
-      SEED:
-        location_rv64: 63-0
-        location_rv32: 31-0
-        description: |
-          Contains the entropy bits. The least significant 16 bits are valid entropy data, while the remaining
-          bits are reserved or undefined.
-        type(): return CsrFieldType::RO;
-        reset_value: UNDEFINED
-        sw_write(_): raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
-    sw_read(): |
-      if (!implemented?(ExtensionName::Zkr)) {
-        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
-      }
-      return entropy_device.read() & 0xffff;
 
 params:
   ZKR_SEED_WIDTH:
@@ -62,6 +27,7 @@ params:
       maximum: 16
     description: |
       Defines the number of valid entropy bits returned in the `seed` CSR. Must be ≤ 16.
+
   ZKR_READ_SIDE_EFFECTS:
     schema:
       type: boolean

--- a/spec/std/isa/ext/Zkr.yaml
+++ b/spec/std/isa/ext/Zkr.yaml
@@ -6,7 +6,7 @@
 $schema: "ext_schema.json#"
 kind: extension
 name: Zkr
-long_name: Entropy Source 
+long_name: Entropy Source
 type: unprivileged
 
 description: |

--- a/spec/std/isa/ext/Zkr.yaml
+++ b/spec/std/isa/ext/Zkr.yaml
@@ -6,7 +6,7 @@
 $schema: "ext_schema.json#"
 kind: extension
 name: Zkr
-long_name: Entropy Source Extension
+long_name: Entropy Source 
 type: unprivileged
 
 description: |

--- a/spec/std/isa/isa/builtin_functions.idl
+++ b/spec/std/isa/isa/builtin_functions.idl
@@ -639,7 +639,7 @@ builtin function atomic_read_modify_write_64 {
 }
 
 builtin function read_entropy {
-  returns Bits<64>
+  returns Bits<ZKR_SEED_WIDTH>
   description {
     Return entropy bits from the implementation’s physical entropy source.
     The value may be consumed or updated per read, depending on platform behavior.

--- a/spec/std/isa/isa/builtin_functions.idl
+++ b/spec/std/isa/isa/builtin_functions.idl
@@ -637,3 +637,11 @@ builtin function atomic_read_modify_write_64 {
     it's assumed the RMW is OK to proceed.
   }
 }
+
+builtin function read_entropy {
+  returns Bits<64>
+  description {
+    Return entropy bits from the implementation’s physical entropy source.
+    The value may be consumed or updated per read, depending on platform behavior.
+  }
+}


### PR DESCRIPTION
Added a new extension called Zkr and a special register called seed.
This register gives software access to real random bits from the hardware, which can be used for security and cryptography.
The register is read-only and only gives out up to 16 bits of random data at a time.

Closes #561