### PR TITLE
Align `hpmcounter` names with indexes

### DIFF
--- a/spec/std/isa/csr/Zihpm/hpmcounter10.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter10.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter10
-long_name: Unprivileged Hardware Performance Counter 7
+long_name: Unprivileged Hardware Performance Counter 10
 address: 0xC0A
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter10h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter10h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter10h
-long_name: Unprivileged Hardware Performance Counter 7, high half
+long_name: Unprivileged Hardware Performance Counter 10, high half
 address: 0xC8A
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter11.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter11.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter11
-long_name: Unprivileged Hardware Performance Counter 8
+long_name: Unprivileged Hardware Performance Counter 11
 address: 0xC0B
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter11h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter11h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter11h
-long_name: Unprivileged Hardware Performance Counter 8, high half
+long_name: Unprivileged Hardware Performance Counter 11, high half
 address: 0xC8B
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter12.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter12.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter12
-long_name: Unprivileged Hardware Performance Counter 9
+long_name: Unprivileged Hardware Performance Counter 12
 address: 0xC0C
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter12h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter12h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter12h
-long_name: Unprivileged Hardware Performance Counter 9, high half
+long_name: Unprivileged Hardware Performance Counter 12, high half
 address: 0xC8C
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter13.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter13.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter13
-long_name: Unprivileged Hardware Performance Counter 10
+long_name: Unprivileged Hardware Performance Counter 13
 address: 0xC0D
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter13h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter13h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter13h
-long_name: Unprivileged Hardware Performance Counter 10, high half
+long_name: Unprivileged Hardware Performance Counter 13, high half
 address: 0xC8D
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter14.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter14.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter14
-long_name: Unprivileged Hardware Performance Counter 11
+long_name: Unprivileged Hardware Performance Counter 14
 address: 0xC0E
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter14h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter14h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter14h
-long_name: Unprivileged Hardware Performance Counter 11, high half
+long_name: Unprivileged Hardware Performance Counter 14, high half
 address: 0xC8E
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter15.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter15.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter15
-long_name: Unprivileged Hardware Performance Counter 12
+long_name: Unprivileged Hardware Performance Counter 15
 address: 0xC0F
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter15h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter15h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter15h
-long_name: Unprivileged Hardware Performance Counter 12, high half
+long_name: Unprivileged Hardware Performance Counter 15, high half
 address: 0xC8F
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter16.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter16.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter16
-long_name: Unprivileged Hardware Performance Counter 13
+long_name: Unprivileged Hardware Performance Counter 16
 address: 0xC10
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter16h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter16h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter16h
-long_name: Unprivileged Hardware Performance Counter 13, high half
+long_name: Unprivileged Hardware Performance Counter 16, high half
 address: 0xC90
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter17.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter17.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter17
-long_name: Unprivileged Hardware Performance Counter 14
+long_name: Unprivileged Hardware Performance Counter 17
 address: 0xC11
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter17h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter17h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter17h
-long_name: Unprivileged Hardware Performance Counter 14, high half
+long_name: Unprivileged Hardware Performance Counter 17, high half
 address: 0xC91
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter18.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter18.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter18
-long_name: Unprivileged Hardware Performance Counter 15
+long_name: Unprivileged Hardware Performance Counter 18
 address: 0xC12
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter18h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter18h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter18h
-long_name: Unprivileged Hardware Performance Counter 15, high half
+long_name: Unprivileged Hardware Performance Counter 18, high half
 address: 0xC92
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter19.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter19.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter19
-long_name: Unprivileged Hardware Performance Counter 16
+long_name: Unprivileged Hardware Performance Counter 19
 address: 0xC13
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter19h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter19h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter19h
-long_name: Unprivileged Hardware Performance Counter 16, high half
+long_name: Unprivileged Hardware Performance Counter 19, high half
 address: 0xC93
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter20.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter20.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter20
-long_name: Unprivileged Hardware Performance Counter 17
+long_name: Unprivileged Hardware Performance Counter 20
 address: 0xC14
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter20h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter20h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter20h
-long_name: Unprivileged Hardware Performance Counter 17, high half
+long_name: Unprivileged Hardware Performance Counter 20, high half
 address: 0xC94
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter21.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter21.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter21
-long_name: Unprivileged Hardware Performance Counter 18
+long_name: Unprivileged Hardware Performance Counter 21
 address: 0xC15
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter21h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter21h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter21h
-long_name: Unprivileged Hardware Performance Counter 18, high half
+long_name: Unprivileged Hardware Performance Counter 21, high half
 address: 0xC95
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter22.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter22.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter22
-long_name: Unprivileged Hardware Performance Counter 19
+long_name: Unprivileged Hardware Performance Counter 22
 address: 0xC16
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter22h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter22h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter22h
-long_name: Unprivileged Hardware Performance Counter 19, high half
+long_name: Unprivileged Hardware Performance Counter 22, high half
 address: 0xC96
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter23.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter23.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter23
-long_name: Unprivileged Hardware Performance Counter 20
+long_name: Unprivileged Hardware Performance Counter 23
 address: 0xC17
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter23h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter23h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter23h
-long_name: Unprivileged Hardware Performance Counter 20, high half
+long_name: Unprivileged Hardware Performance Counter 23, high half
 address: 0xC97
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter24.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter24.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter24
-long_name: Unprivileged Hardware Performance Counter 21
+long_name: Unprivileged Hardware Performance Counter 24
 address: 0xC18
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter24h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter24h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter24h
-long_name: Unprivileged Hardware Performance Counter 21, high half
+long_name: Unprivileged Hardware Performance Counter 24, high half
 address: 0xC98
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter25.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter25.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter25
-long_name: Unprivileged Hardware Performance Counter 22
+long_name: Unprivileged Hardware Performance Counter 25
 address: 0xC19
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter25h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter25h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter25h
-long_name: Unprivileged Hardware Performance Counter 22, high half
+long_name: Unprivileged Hardware Performance Counter 25, high half
 address: 0xC99
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter26.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter26.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter26
-long_name: Unprivileged Hardware Performance Counter 23
+long_name: Unprivileged Hardware Performance Counter 26
 address: 0xC1A
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter26h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter26h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter26h
-long_name: Unprivileged Hardware Performance Counter 23, high half
+long_name: Unprivileged Hardware Performance Counter 26, high half
 address: 0xC9A
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter27.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter27.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter27
-long_name: Unprivileged Hardware Performance Counter 24
+long_name: Unprivileged Hardware Performance Counter 27
 address: 0xC1B
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter27h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter27h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter27h
-long_name: Unprivileged Hardware Performance Counter 24, high half
+long_name: Unprivileged Hardware Performance Counter 27, high half
 address: 0xC9B
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter28.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter28.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter28
-long_name: Unprivileged Hardware Performance Counter 25
+long_name: Unprivileged Hardware Performance Counter 28
 address: 0xC1C
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter28h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter28h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter28h
-long_name: Unprivileged Hardware Performance Counter 25, high half
+long_name: Unprivileged Hardware Performance Counter 28, high half
 address: 0xC9C
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter29.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter29.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter29
-long_name: Unprivileged Hardware Performance Counter 26
+long_name: Unprivileged Hardware Performance Counter 29
 address: 0xC1D
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter29h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter29h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter29h
-long_name: Unprivileged Hardware Performance Counter 26, high half
+long_name: Unprivileged Hardware Performance Counter 29, high half
 address: 0xC9D
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter3.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter3.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter3
-long_name: Unprivileged Hardware Performance Counter 0
+long_name: Unprivileged Hardware Performance Counter 3
 address: 0xC03
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter30.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter30.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter30
-long_name: Unprivileged Hardware Performance Counter 27
+long_name: Unprivileged Hardware Performance Counter 30
 address: 0xC1E
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter30h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter30h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter30h
-long_name: Unprivileged Hardware Performance Counter 27, high half
+long_name: Unprivileged Hardware Performance Counter 30, high half
 address: 0xC9E
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter31.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter31.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter31
-long_name: Unprivileged Hardware Performance Counter 28
+long_name: Unprivileged Hardware Performance Counter 31
 address: 0xC1F
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter31h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter31h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter31h
-long_name: Unprivileged Hardware Performance Counter 28, high half
+long_name: Unprivileged Hardware Performance Counter 31, high half
 address: 0xC9F
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter3h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter3h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter3h
-long_name: Unprivileged Hardware Performance Counter 0, high half
+long_name: Unprivileged Hardware Performance Counter 3, high half
 address: 0xC83
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter4.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter4.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter4
-long_name: Unprivileged Hardware Performance Counter 1
+long_name: Unprivileged Hardware Performance Counter 4
 address: 0xC04
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter4h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter4h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter4h
-long_name: Unprivileged Hardware Performance Counter 1, high half
+long_name: Unprivileged Hardware Performance Counter 4, high half
 address: 0xC84
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter5.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter5.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter5
-long_name: Unprivileged Hardware Performance Counter 2
+long_name: Unprivileged Hardware Performance Counter 5
 address: 0xC05
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter5h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter5h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter5h
-long_name: Unprivileged Hardware Performance Counter 2, high half
+long_name: Unprivileged Hardware Performance Counter 5, high half
 address: 0xC85
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter6.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter6.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter6
-long_name: Unprivileged Hardware Performance Counter 3
+long_name: Unprivileged Hardware Performance Counter 6
 address: 0xC06
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter6h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter6h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter6h
-long_name: Unprivileged Hardware Performance Counter 3, high half
+long_name: Unprivileged Hardware Performance Counter 6, high half
 address: 0xC86
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter7.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter7.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter7
-long_name: Unprivileged Hardware Performance Counter 4
+long_name: Unprivileged Hardware Performance Counter 7
 address: 0xC07
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter7h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter7h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter7h
-long_name: Unprivileged Hardware Performance Counter 4, high half
+long_name: Unprivileged Hardware Performance Counter 7, high half
 address: 0xC87
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter8.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter8.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter8
-long_name: Unprivileged Hardware Performance Counter 5
+long_name: Unprivileged Hardware Performance Counter 8
 address: 0xC08
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter8h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter8h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter8h
-long_name: Unprivileged Hardware Performance Counter 5, high half
+long_name: Unprivileged Hardware Performance Counter 8, high half
 address: 0xC88
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter9.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter9.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter9
-long_name: Unprivileged Hardware Performance Counter 6
+long_name: Unprivileged Hardware Performance Counter 9
 address: 0xC09
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounter9h.yaml
+++ b/spec/std/isa/csr/Zihpm/hpmcounter9h.yaml
@@ -9,7 +9,7 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter9h
-long_name: Unprivileged Hardware Performance Counter 6, high half
+long_name: Unprivileged Hardware Performance Counter 9, high half
 address: 0xC89
 writable: false
 description: |

--- a/spec/std/isa/csr/Zihpm/hpmcounterN.layout
+++ b/spec/std/isa/csr/Zihpm/hpmcounterN.layout
@@ -7,8 +7,8 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter<%= hpm_num %>
-long_name: Unprivileged Hardware Performance Counter <%= hpm_num - 3 %>
-address: 0x<%= (0xC03 + (hpm_num - 3)).to_s(16).upcase %>
+long_name: Unprivileged Hardware Performance Counter <%= hpm_num %>
+address: 0x<%= (0xC00 + (hpm_num)).to_s(16).upcase %>
 writable: false
 description: |
   Alias for M-mode CSR `mhpmcounter<%= hpm_num %>`.

--- a/spec/std/isa/csr/Zihpm/hpmcounterNh.layout
+++ b/spec/std/isa/csr/Zihpm/hpmcounterNh.layout
@@ -7,8 +7,8 @@
 $schema: csr_schema.json#
 kind: csr
 name: hpmcounter<%= hpm_num %>h
-long_name: Unprivileged Hardware Performance Counter <%= hpm_num - 3 %>, high half
-address: 0x<%= (0xC83 + (hpm_num - 3)).to_s(16).upcase %>
+long_name: Unprivileged Hardware Performance Counter <%= hpm_num %>, high half
+address: 0x<%= (0xC80 + (hpm_num)).to_s(16).upcase %>
 writable: false
 description: |
   Alias for M-mode CSR `mhpmcounter<%= hpm_num %>h`.


### PR DESCRIPTION
Non-dedicated M mode HPM counters are indexed 3-31 and named identically.
For example, the "long_name" for `mhpmcounter10` is
"Machine Hardware Performance Counter 10".

Non-dedicated unprivileged HPM counters are indexed 3-31, but named 0-28.
For example, the "long_name" for `hpmcounter10` is
"Machine Hardware Performance Counter 7".

This seems very wrong. Fix it.