### PR TITLE
Clarify CSR field "location" expectation

### DIFF
--- a/spec/schemas/csr_schema.json
+++ b/spec/schemas/csr_schema.json
@@ -129,7 +129,7 @@
 
       "allOf": [
         {
-          "$comment": "Location is required, but it can either be a static value or a function",
+          "$comment": "Location is required, but it can either be a single XLEN-independent value or a value for each XLEN",
           "oneOf": [
             {
               "required": ["location"]


### PR DESCRIPTION
A CSR field's location is represented as a single XLEN-independent value, or one value per XLEN. Clarify that in the schema. (It's not a function, as currently stated.)