### PR TITLE
Add Sspmp, Sspmpen, and Smpmpdeleg extension definitions

### DIFF
--- a/spec/std/isa/ext/Smpmpdeleg.yaml
+++ b/spec/std/isa/ext/Smpmpdeleg.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) Shanghai Jiao Tong University
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Smpmpdeleg
+type: privileged
+long_name: Machine PMP Delegation to SPMP
+description: |
+  The Smpmpdeleg extension provides the mpmpdeleg CSR, which controls how many
+  PMP entries are delegated to SPMP.
+
+  The mpmpdeleg CSR contains a pmpnum field in bits [6:0]. Entries 0 through
+  pmpnum-1 remain as PMP entries, while entries pmpnum through max_pmp-1 are
+  delegated to SPMP.
+
+  When pmpnum = 0, all entries are delegated to SPMP.
+  When pmpnum = max_pmp, no entries are delegated to SPMP.
+
+  Writes to SPMP CSRs are ignored when no entries are delegated to SPMP. 
+versions:
+  - version: "0.8.18"
+    state: frozen
+    url: "https://github.com/riscv/riscv-spmp"
+requirements:
+  extension:
+    allOf:
+      - name: S
+      - name: Sm
+
+

--- a/spec/std/isa/ext/Sspmp.yaml
+++ b/spec/std/isa/ext/Sspmp.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) Shanghai Jiao Tong University
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Sspmp
+type: privileged
+long_name: Supervisor Physical Memory Protection
+description: |
+  The Sspmp extension defines a Supervisor-level Physical Memory Protection (SPMP)
+  mechanism that allows S-mode software to configure memory protection regions.
+
+  SPMP entries are accessed indirectly via the Sscsrind/Smcsrind extension.
+  The siselect CSR selects the SPMP entry (0x100-0x13F), and sireg/sireg2 access 
+  the corresponding spmpaddr/spmpcfg values.
+
+  SPMP provides memory protection for S-mode and U-mode accesses when satp.MODE
+  is Bare. It does not apply when virtual memory translation is active.
+
+  Key behaviors:
+  * SPMP entries are delegated from PMP entries via the mpmpdeleg CSR
+  * Each SPMP entry has address (spmpaddr) and configuration (spmpcfg) registers
+  * spmpcfg includes R, W, X permissions, address matching mode (A), lock bit (L),
+    U-mode bit (U), and SHARED bit
+  * Out-of-bounds siselect values read as 0 and writes are ignored
+versions:
+  - version: "0.8.18"
+    state: frozen
+    url: "https://github.com/riscv/riscv-spmp"
+requirements:
+  extension:
+    allOf:
+      - name: S
+      - name: Sm
+      - name: Sscsrind
+      - name: Smcsrind
+      - name: Smpmpdeleg

--- a/spec/std/isa/ext/Sspmpen.yaml
+++ b/spec/std/isa/ext/Sspmpen.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) Shanghai Jiao Tong University
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Sspmpen
+type: privileged
+long_name: SPMP Enable Register
+description: |
+  The Sspmpen extension adds the spmpen CSR, which provides per-entry enable bits
+  for SPMP regions.
+
+  Each bit spmpen[i] controls whether SPMP entry i is active. An entry is active
+  only when both spmpen[i] is set and spmpcfg[i].A != 0 (address matching mode
+  is not OFF).
+
+  When spmpcfg[i].L (lock bit) is set, spmpen[i] becomes read-only.
+
+  The spmpen CSR is a WARL register. Bits beyond the number of implemented SPMP
+  entries are read-only-zero.
+versions:
+  - version: "0.8.18"
+    state: frozen
+    url: "https://github.com/riscv/riscv-spmp"
+requirements:
+  extension:
+    name: Sspmp
+


### PR DESCRIPTION
This PR adds Unified Database extension definitions for RISC-V S-level Physical Memory Protection (SPMP), consisting of three extensions:

Sspmp: Core SPMP mechanism for S-mode memory protection.
Sspmpen: Per-entry enable bits via the spmpen CSR.
Smpmpdeleg: PMP-to-SPMP resource sharing via the mpmpdeleg CSR.

References:
SPMP specification: https://github.com/riscv/riscv-isa-manual/pull/2573
SPMP arch test suites: https://github.com/riscv/riscv-arch-test/pull/1166