### PR TITLE
Split all instructions

### DIFF
--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -155,19 +155,24 @@ def increment_heading_levels(text)
   text.gsub(/^(=+) /) { "#{$1}= " }
 end
 
-# Add an insn: alias anchor before each udb:doc:inst anchor so that the
+# Add an insn: alias anchor for each instruction heading so that the
 # riscv-isa-manual's insnlink: macro can cross-reference the appendix entry.
 #
-# insnlink:add[] targets #insn:add.  The display name is taken from the
-# === heading that immediately follows the anchor (preserving dots, e.g. lr.w),
-# which is what insnlink: uses (name.downcase, no sanitize).
+# insnlink:add[] targets #insn:add.  AsciiDoc only attaches one block anchor
+# to a heading (last one wins), so we cannot stack [#insn:add] as a second
+# block anchor — it would silently drop the udb:doc:inst: anchor or vice versa.
+# Instead, embed a raw HTML anchor inline inside the heading title via a
+# passthrough so both IDs exist in the output:
 #
-#   [#udb:doc:inst:rv32:add]      [#insn:add]
-#   === add                   →   [#udb:doc:inst:rv32:add]
-#                                 === add
+#   [#udb:doc:inst:rv32:add]
+#   === add
+#     →
+#   [#udb:doc:inst:rv32:add]
+#   === pass:[<a id="insn:add"></a>]add
 def add_insn_alias(text)
   text.gsub(/(\[#udb:doc:inst:rv(?:32|64):[^\]]+\]\n)(={3,} )(.+\n)/) do
-    "[#insn:#{$3.chomp.downcase}]\n#{$1}#{$2}#{$3}"
+    name = $3.chomp.downcase
+    "#{$1}#{$2}pass:[<a id=\"insn:#{name}\"></a>]#{$3}"
   end
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -155,6 +155,22 @@ def increment_heading_levels(text)
   text.gsub(/^(=+) /) { "#{$1}= " }
 end
 
+# Add an insn: alias anchor before each udb:doc:inst anchor so that the
+# riscv-isa-manual's insnlink: macro can cross-reference the appendix entry.
+#
+# insnlink:add[] targets #insn:add.  The display name is taken from the
+# === heading that immediately follows the anchor (preserving dots, e.g. lr.w),
+# which is what insnlink: uses (name.downcase, no sanitize).
+#
+#   [#udb:doc:inst:rv32:add]      [#insn:add]
+#   === add                   →   [#udb:doc:inst:rv32:add]
+#                                 === add
+def add_insn_alias(text)
+  text.gsub(/(\[#udb:doc:inst:rv(?:32|64):[^\]]+\]\n)(={3,} )(.+\n)/) do
+    "[#insn:#{$3.chomp.downcase}]\n#{$1}#{$2}#{$3}"
+  end
+end
+
 # Convert Antora-style extension xrefs to the riscv-isa-manual ext: macro.
 #
 # The generated adoc uses Antora cross-references for extensions:
@@ -182,11 +198,11 @@ sections.each do |sect|
   text       = sect.join
 
   if priv
-    buckets[:priv_rv32] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32"))) if rv32
-    buckets[:priv_rv64] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64"))) if rv64
+    buckets[:priv_rv32] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32")))) if rv32
+    buckets[:priv_rv64] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64")))) if rv64
   else
-    buckets[:unpriv_rv32] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32"))) if rv32
-    buckets[:unpriv_rv64] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64"))) if rv64
+    buckets[:unpriv_rv32] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32")))) if rv32
+    buckets[:unpriv_rv64] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64")))) if rv64
   end
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -146,6 +146,15 @@ def qualify_anchors(text, base)
   text.gsub(ANCHOR_RE, "[#udb:doc:inst:#{base}:\\1]")
 end
 
+# Increment every heading level in a section body by one = sign so that
+# instruction headings (== name) are subordinate to the appendix title (== Title).
+#
+#   == add   →  === add
+#   === foo  →  ==== foo
+def increment_heading_levels(text)
+  text.gsub(/^(=+) /) { "#{$1}= " }
+end
+
 # Convert Antora-style extension xrefs to the riscv-isa-manual ext: macro.
 #
 # The generated adoc uses Antora cross-references for extensions:
@@ -173,11 +182,11 @@ sections.each do |sect|
   text       = sect.join
 
   if priv
-    buckets[:priv_rv32] << convert_ext_xrefs(qualify_anchors(text, "rv32")) if rv32
-    buckets[:priv_rv64] << convert_ext_xrefs(qualify_anchors(text, "rv64")) if rv64
+    buckets[:priv_rv32] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32"))) if rv32
+    buckets[:priv_rv64] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64"))) if rv64
   else
-    buckets[:unpriv_rv32] << convert_ext_xrefs(qualify_anchors(text, "rv32")) if rv32
-    buckets[:unpriv_rv64] << convert_ext_xrefs(qualify_anchors(text, "rv64")) if rv64
+    buckets[:unpriv_rv32] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32"))) if rv32
+    buckets[:unpriv_rv64] << increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64"))) if rv64
   end
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -26,6 +26,7 @@
 #               Default: same directory as INPUT
 
 require "fileutils"
+require "set"
 
 HELP = <<~HELP
   Usage: ruby split_instructions.rb [OPTIONS] [INPUT] [OUTPUT_DIR]
@@ -144,18 +145,33 @@ def increment_heading_levels(text)
   text.gsub(/^(=+) /) { "#{$1}= " }
 end
 
+# Returns the lowercase instruction name from a section's anchor/heading pair.
+def insn_name_from_section(sect)
+  idx = sect.find_index { |l| l.start_with?("[#udb:doc:inst:") }
+  return nil unless idx
+
+  heading = sect[idx + 1]
+  m = heading&.match(/^=+ (.+)/)
+  m ? m[1].strip.downcase : nil
+end
+
 # Replace the udb:doc:inst: block anchor with a plain insn: anchor so that
 # the riscv-isa-manual's insnlink: macro can cross-reference the appendix.
 #
-# The split files are only used in riscv-isa-manual, not in UDB, so the
-# udb:doc:inst: anchor scheme is unnecessary here.  insnlink:add[] targets
-# #insn:add; the display name from the === heading preserves dots (e.g. lr.w).
+# When skip_set is provided, instructions whose name is in that set get their
+# anchor stripped rather than replaced — this prevents duplicate-ID warnings
+# for instructions that appear in both the rv32 and rv64 split files.
 #
 #   [#udb:doc:inst:rv32:add]  →  [[insn:add]]
 #   === add                      === add
-def replace_udb_anchors(text)
+def replace_udb_anchors(text, skip_set = nil)
   text.gsub(/\[#udb:doc:inst:[^\]]+\]\n(={3,} )(.+\n)/) do
-    "[[insn:#{$2.chomp.downcase}]]\n#{$1}#{$2}"
+    name = $2.chomp.downcase
+    if skip_set&.include?(name)
+      "#{$1}#{$2}"
+    else
+      "[[insn:#{name}]]\n#{$1}#{$2}"
+    end
   end
 end
 
@@ -180,16 +196,34 @@ end
 
 buckets = { unpriv_rv32: [], unpriv_rv64: [], priv_rv32: [], priv_rv64: [] }
 
+# Pre-pass: collect instruction names that appear in each rv64 bucket so we
+# can suppress duplicate anchors in the corresponding rv32 file.  An instruction
+# valid in both bases must carry [[insn:name]] in exactly one included file;
+# we arbitrarily pick rv64 as the canonical home.
+rv64_unpriv_names = Set.new
+rv64_priv_names   = Set.new
+
+sections.each do |sect|
+  _rv32, rv64 = base_support(sect)
+  next unless rv64
+
+  name = insn_name_from_section(sect)
+  next unless name
+
+  privileged?(sect) ? rv64_priv_names.add(name) : rv64_unpriv_names.add(name)
+end
+
 sections.each do |sect|
   rv32, rv64 = base_support(sect)
   priv       = privileged?(sect)
   text       = sect.join
+  skip       = priv ? rv64_priv_names : rv64_unpriv_names
 
   if priv
-    buckets[:priv_rv32] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv32
+    buckets[:priv_rv32] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text)), skip) if rv32
     buckets[:priv_rv64] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv64
   else
-    buckets[:unpriv_rv32] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv32
+    buckets[:unpriv_rv32] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text)), skip) if rv32
     buckets[:unpriv_rv64] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv64
   end
 end

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -131,7 +131,7 @@ end
 def titled_header(header, title)
   header
     .reject { |l| l.start_with?(":wavedrom:") }
-    .map    { |l| l.start_with?("= ") ? "= #{title}\n" : l }
+    .map    { |l| l.start_with?("= ") ? "== #{title}\n" : l }
     .join
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -146,6 +146,23 @@ def qualify_anchors(text, base)
   text.gsub(ANCHOR_RE, "[#udb:doc:inst:#{base}:\\1]")
 end
 
+# Convert Antora-style extension xrefs to the riscv-isa-manual ext: macro.
+#
+# The generated adoc uses Antora cross-references for extensions:
+#   xref:exts:D.adoc#udb:doc:ext:D[D]
+#
+# riscv-isa-manual registers ext: as a custom inline macro (macros.rb).
+# AsciiDoc's scanner finds ext:D[D] embedded inside those xref targets and
+# errors with "macro ext:D[] does not accept arguments". Converting to the
+# native macro fixes the error and renders the extension name correctly.
+#
+#   xref:exts:D.adoc#udb:doc:ext:D[D]  →  ext:D[]
+EXT_XREF_RE = /xref:exts:[^.]+\.adoc#udb:doc:ext:[^\[]+\[([^\]]+)\]/
+
+def convert_ext_xrefs(text)
+  text.gsub(EXT_XREF_RE, 'ext:\1[]')
+end
+
 # ── Partition ─────────────────────────────────────────────────────────────────
 
 buckets = { unpriv_rv32: [], unpriv_rv64: [], priv_rv32: [], priv_rv64: [] }
@@ -156,11 +173,11 @@ sections.each do |sect|
   text       = sect.join
 
   if priv
-    buckets[:priv_rv32] << qualify_anchors(text, "rv32") if rv32
-    buckets[:priv_rv64] << qualify_anchors(text, "rv64") if rv64
+    buckets[:priv_rv32] << convert_ext_xrefs(qualify_anchors(text, "rv32")) if rv32
+    buckets[:priv_rv64] << convert_ext_xrefs(qualify_anchors(text, "rv64")) if rv64
   else
-    buckets[:unpriv_rv32] << qualify_anchors(text, "rv32") if rv32
-    buckets[:unpriv_rv64] << qualify_anchors(text, "rv64") if rv64
+    buckets[:unpriv_rv32] << convert_ext_xrefs(qualify_anchors(text, "rv32")) if rv32
+    buckets[:unpriv_rv64] << convert_ext_xrefs(qualify_anchors(text, "rv64")) if rv64
   end
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -131,7 +131,7 @@ end
 def titled_header(header, title)
   header
     .reject { |l| l.start_with?(":wavedrom:") }
-    .map    { |l| l.start_with?("= ") ? "== #{title}\n" : l }
+    .map    { |l| l.start_with?("= ") ? "[appendix]\n== #{title}\n" : l }
     .join
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -1,0 +1,186 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# split_instructions.rb
+#
+# Splits an AsciiDoc instruction appendix produced by the riscv-unified-db
+# `gen:instruction_appendix_adoc` task into four files:
+#
+#   unpriv_rv32.adoc  — Unprivileged instructions valid in RV32
+#   unpriv_rv64.adoc  — Unprivileged instructions valid in RV64
+#   priv_rv32.adoc    — Privileged instructions valid in RV32
+#   priv_rv64.adoc    — Privileged instructions valid in RV64
+#
+# Instructions valid in both RV32 and RV64 appear in both width files.
+#
+# Privilege classification: an instruction is privileged if any of its
+# "Included in" extensions begins with 'S' (supervisor/machine-mode in the
+# RISC-V naming convention: Sm*, Ss*, Sh*, Sv*, or bare S) or 'H' (hypervisor).
+#
+# Usage:
+#   ruby split_instructions.rb [INPUT] [OUTPUT_DIR]
+#
+#   INPUT       Path to all_instructions.adoc
+#               Default: ./gen/instructions_appendix/all_instructions.adoc
+#   OUTPUT_DIR  Directory to write the four output files
+#               Default: same directory as INPUT
+
+require "fileutils"
+
+HELP = <<~HELP
+  Usage: ruby split_instructions.rb [OPTIONS] [INPUT] [OUTPUT_DIR]
+
+  Splits all_instructions.adoc into four files by ISA base and privilege level.
+
+  Arguments:
+    INPUT       Path to all_instructions.adoc
+                (default: ./gen/instructions_appendix/all_instructions.adoc)
+    OUTPUT_DIR  Directory to write the four output files
+                (default: same directory as INPUT)
+
+  Options:
+    -h, --help  Show this message
+
+  Output files:
+    unpriv_rv32.adoc  Unprivileged instructions for RV32
+    unpriv_rv64.adoc  Unprivileged instructions for RV64
+    priv_rv32.adoc    Privileged instructions for RV32
+    priv_rv64.adoc    Privileged instructions for RV64
+
+  Instructions supported in both RV32 and RV64 appear in both width output files.
+
+  Privilege detection:
+    An instruction is privileged if any required extension starts with 'S'
+    (supervisor/machine-mode: Sm*, Ss*, Sh*, Sv*, or bare S) or 'H' (hypervisor).
+HELP
+
+if ARGV.include?("--help") || ARGV.include?("-h")
+  puts HELP
+  exit
+end
+
+# Extensions whose names match this pattern are privileged.
+# RISC-V spec naming: all S-prefixed extensions are supervisor- or machine-mode;
+# H is the hypervisor extension.
+PRIV_EXT_RE = /\A[SH]/
+
+input  = ARGV[0] || File.join("gen", "instructions_appendix", "all_instructions.adoc")
+outdir = ARGV[1] || File.dirname(File.expand_path(input))
+
+abort "Error: input file not found: #{input}" unless File.exist?(input)
+FileUtils.mkdir_p(outdir)
+
+# ── Parse ─────────────────────────────────────────────────────────────────────
+
+lines    = File.readlines(input, encoding: "UTF-8")
+header   = []
+current  = nil
+sections = []
+
+lines.each do |line|
+  if line.start_with?("[#udb:doc:inst:")
+    current = [line]
+    sections << current
+  elsif current
+    current << line
+  else
+    header << line
+  end
+end
+
+warn "Parsed #{sections.size} instruction sections from #{input}"
+
+# ── Classification helpers ────────────────────────────────────────────────────
+
+# Returns [rv32_supported, rv64_supported] by inspecting the Base table:
+#
+#   | RV32 | RV64          <- header row
+#                          <- blank separator
+#   | &#x2713;             <- RV32 cell  (checkmark = supported, blank = not)
+#   | &#x2713;             <- RV64 cell
+#
+def base_support(section)
+  idx = section.find_index { |l| l.strip == "| RV32 | RV64" }
+  return [false, false] unless idx
+
+  # Skip the blank separator between the header row and the data rows.
+  data = idx + 1
+  data += 1 while data < section.size && section[data].strip.empty?
+  return [false, false] if data >= section.size
+
+  rv32 = section[data].include?("&#x2713;")
+  rv64 = (data + 1) < section.size && section[data + 1].include?("&#x2713;")
+  [rv32, rv64]
+end
+
+# Returns true if any "Included in" extension matches PRIV_EXT_RE.
+# Extension lines in the table look like:  | *ExtName*
+def privileged?(section)
+  in_included = false
+  section.each do |line|
+    in_included = true if line.strip == "Included in::"
+    next unless in_included
+    return true if line =~ /^\| \*([^*]+)\*/ && $1.match?(PRIV_EXT_RE)
+  end
+  false
+end
+
+# Replace the document-level title (= Some Title) while preserving all attrs.
+# Also strips the :wavedrom: attribute line because it contains a machine-local
+# absolute path that must not be committed to riscv-isa-manual.
+def titled_header(header, title)
+  header
+    .reject { |l| l.start_with?(":wavedrom:") }
+    .map    { |l| l.start_with?("= ") ? "= #{title}\n" : l }
+    .join
+end
+
+# Qualify a bare instruction anchor with a base prefix so that the same
+# instruction appearing in both RV32 and RV64 appendixes has a unique ID.
+#
+#   [#udb:doc:inst:add]      → [#udb:doc:inst:rv32:add]
+#   [#udb:doc:inst:rv32:add] → unchanged (already qualified)
+ANCHOR_RE = /\[#udb:doc:inst:(?!rv(?:32|64):)([^\]]+)\]/
+
+def qualify_anchors(text, base)
+  text.gsub(ANCHOR_RE, "[#udb:doc:inst:#{base}:\\1]")
+end
+
+# ── Partition ─────────────────────────────────────────────────────────────────
+
+buckets = { unpriv_rv32: [], unpriv_rv64: [], priv_rv32: [], priv_rv64: [] }
+
+sections.each do |sect|
+  rv32, rv64 = base_support(sect)
+  priv       = privileged?(sect)
+  text       = sect.join
+
+  if priv
+    buckets[:priv_rv32] << qualify_anchors(text, "rv32") if rv32
+    buckets[:priv_rv64] << qualify_anchors(text, "rv64") if rv64
+  else
+    buckets[:unpriv_rv32] << qualify_anchors(text, "rv32") if rv32
+    buckets[:unpriv_rv64] << qualify_anchors(text, "rv64") if rv64
+  end
+end
+
+# ── Write output files ────────────────────────────────────────────────────────
+
+TITLES = {
+  unpriv_rv32: "Unprivileged RV32 Instructions",
+  unpriv_rv64: "Unprivileged RV64 Instructions",
+  priv_rv32:   "Privileged RV32 Instructions",
+  priv_rv64:   "Privileged RV64 Instructions"
+}.freeze
+
+buckets.each do |key, blocks|
+  path = File.join(outdir, "#{key}.adoc")
+  File.open(path, "w", encoding: "UTF-8") do |f|
+    f.write(titled_header(header, TITLES[key]))
+    blocks.each { |b| f.write(b) }
+  end
+  puts "  #{path}  (#{blocks.size} instructions)"
+end
+
+total = buckets.values.sum(&:size)
+warn "Done. #{total} instruction-file entries written (instructions in both bases counted twice)."

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -242,7 +242,11 @@ buckets.each do |key, blocks|
   File.open(path, "w", encoding: "UTF-8") do |f|
     f.write(titled_header(header, TITLES[key]))
     blocks.each { |b| f.write(b) }
+    f.write("\n") # ensure single trailing newline
   end
+  # Rewrite via String to strip any trailing blank lines before the final newline
+  content = File.read(path, encoding: "UTF-8")
+  File.write(path, content.rstrip + "\n", encoding: "UTF-8")
   puts "  #{path}  (#{blocks.size} instructions)"
 end
 

--- a/backends/instructions_appendix/split_instructions.rb
+++ b/backends/instructions_appendix/split_instructions.rb
@@ -135,17 +135,6 @@ def titled_header(header, title)
     .join
 end
 
-# Qualify a bare instruction anchor with a base prefix so that the same
-# instruction appearing in both RV32 and RV64 appendixes has a unique ID.
-#
-#   [#udb:doc:inst:add]      → [#udb:doc:inst:rv32:add]
-#   [#udb:doc:inst:rv32:add] → unchanged (already qualified)
-ANCHOR_RE = /\[#udb:doc:inst:(?!rv(?:32|64):)([^\]]+)\]/
-
-def qualify_anchors(text, base)
-  text.gsub(ANCHOR_RE, "[#udb:doc:inst:#{base}:\\1]")
-end
-
 # Increment every heading level in a section body by one = sign so that
 # instruction headings (== name) are subordinate to the appendix title (== Title).
 #
@@ -155,24 +144,18 @@ def increment_heading_levels(text)
   text.gsub(/^(=+) /) { "#{$1}= " }
 end
 
-# Add an insn: alias anchor for each instruction heading so that the
-# riscv-isa-manual's insnlink: macro can cross-reference the appendix entry.
+# Replace the udb:doc:inst: block anchor with a plain insn: anchor so that
+# the riscv-isa-manual's insnlink: macro can cross-reference the appendix.
 #
-# insnlink:add[] targets #insn:add.  AsciiDoc only attaches one block anchor
-# to a heading (last one wins), so we cannot stack [#insn:add] as a second
-# block anchor — it would silently drop the udb:doc:inst: anchor or vice versa.
-# Instead, embed a raw HTML anchor inline inside the heading title via a
-# passthrough so both IDs exist in the output:
+# The split files are only used in riscv-isa-manual, not in UDB, so the
+# udb:doc:inst: anchor scheme is unnecessary here.  insnlink:add[] targets
+# #insn:add; the display name from the === heading preserves dots (e.g. lr.w).
 #
-#   [#udb:doc:inst:rv32:add]
-#   === add
-#     →
-#   [#udb:doc:inst:rv32:add]
-#   === pass:[<a id="insn:add"></a>]add
-def add_insn_alias(text)
-  text.gsub(/(\[#udb:doc:inst:rv(?:32|64):[^\]]+\]\n)(={3,} )(.+\n)/) do
-    name = $3.chomp.downcase
-    "#{$1}#{$2}pass:[<a id=\"insn:#{name}\"></a>]#{$3}"
+#   [#udb:doc:inst:rv32:add]  →  [[insn:add]]
+#   === add                      === add
+def replace_udb_anchors(text)
+  text.gsub(/\[#udb:doc:inst:[^\]]+\]\n(={3,} )(.+\n)/) do
+    "[[insn:#{$2.chomp.downcase}]]\n#{$1}#{$2}"
   end
 end
 
@@ -203,11 +186,11 @@ sections.each do |sect|
   text       = sect.join
 
   if priv
-    buckets[:priv_rv32] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32")))) if rv32
-    buckets[:priv_rv64] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64")))) if rv64
+    buckets[:priv_rv32] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv32
+    buckets[:priv_rv64] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv64
   else
-    buckets[:unpriv_rv32] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv32")))) if rv32
-    buckets[:unpriv_rv64] << add_insn_alias(increment_heading_levels(convert_ext_xrefs(qualify_anchors(text, "rv64")))) if rv64
+    buckets[:unpriv_rv32] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv32
+    buckets[:unpriv_rv64] << replace_udb_anchors(increment_heading_levels(convert_ext_xrefs(text))) if rv64
   end
 end
 

--- a/backends/instructions_appendix/tasks.rake
+++ b/backends/instructions_appendix/tasks.rake
@@ -2,13 +2,34 @@
 # frozen_string_literal: true
 
 # Define the instructions manual generation directory constant.
-INST_MANUAL_GEN_DIR = $root / "gen" / "instructions_appendix"
+INST_MANUAL_GEN_DIR = $root / “gen” / “instructions_appendix”
 
 # Define the path to the merged instructions output.
-MERGED_INSTRUCTIONS_FILE = INST_MANUAL_GEN_DIR / "all_instructions.adoc"
+MERGED_INSTRUCTIONS_FILE = INST_MANUAL_GEN_DIR / “all_instructions.adoc”
 
 # Define the path to the ERB template that renders the merged instructions.
-TEMPLATE_FILE = $root / "backends" / "instructions_appendix" / "templates" / "instructions.adoc.erb"
+TEMPLATE_FILE = $root / “backends” / “instructions_appendix” / “templates” / “instructions.adoc.erb”
+
+# The four split appendix files produced by split_instructions.rb.
+SPLIT_APPENDIX_NAMES = %w[unpriv_rv32 unpriv_rv64 priv_rv32 priv_rv64].freeze
+SPLIT_APPENDIX_FILES = SPLIT_APPENDIX_NAMES.map { |n| INST_MANUAL_GEN_DIR / “#{n}.adoc” }.freeze
+
+# Stamp file used to track whether all four split files are up to date.
+SPLIT_APPENDIX_STAMP = INST_MANUAL_GEN_DIR / “split.stamp”
+
+# Path to split_instructions.rb, used to invalidate outputs when the script changes.
+SPLIT_SCRIPT = $root / “backends” / “instructions_appendix” / “split_instructions.rb”
+
+# Root of the riscv-isa-manual checkout. Override with ISA_MANUAL_DIR env var.
+ISA_MANUAL_DIR = Pathname.new(ENV.fetch(“ISA_MANUAL_DIR”, $root / “..” / “riscv-isa-manual”))
+
+# Destination paths for each split file inside riscv-isa-manual.
+ISA_MANUAL_DESTINATIONS = {
+  “unpriv_rv32” => ISA_MANUAL_DIR / “src” / “unpriv” / “unpriv_rv32.adoc”,
+  “unpriv_rv64” => ISA_MANUAL_DIR / “src” / “unpriv” / “unpriv_rv64.adoc”,
+  “priv_rv32”   => ISA_MANUAL_DIR / “src” / “priv”   / “priv_rv32.adoc”,
+  “priv_rv64”   => ISA_MANUAL_DIR / “src” / “priv”   / “priv_rv64.adoc”
+}.freeze
 
 # Declare a file task for the template so Rake knows it exists.
 file TEMPLATE_FILE.to_s do
@@ -17,14 +38,14 @@ end
 
 # File task that generates the merged instructions adoc.
 file MERGED_INSTRUCTIONS_FILE.to_s => [__FILE__, TEMPLATE_FILE.to_s] do |t|
-  cfg_arch = $resolver.cfg_arch_for("_")
+  cfg_arch = $resolver.cfg_arch_for(“_”)
   instructions = cfg_arch.possible_instructions
 
   # Load and process the template (which renders both an index and details).
-  erb = ERB.new(File.read(TEMPLATE_FILE), trim_mode: "-")
+  erb = ERB.new(File.read(TEMPLATE_FILE), trim_mode: “-”)
   erb.filename = TEMPLATE_FILE.to_s
 
-  Udb.logger.info "Generating asciidoc for instruction appendix"
+  Udb.logger.info “Generating asciidoc for instruction appendix”
   FileUtils.mkdir_p(File.dirname(t.name))
   File.write(
     t.name,
@@ -32,26 +53,39 @@ file MERGED_INSTRUCTIONS_FILE.to_s => [__FILE__, TEMPLATE_FILE.to_s] do |t|
   )
 end
 
+# Stamp file task: runs split_instructions.rb to produce all four split files in
+# one pass, then touches the stamp so Rake knows the outputs are current.
+file SPLIT_APPENDIX_STAMP.to_s => [MERGED_INSTRUCTIONS_FILE.to_s, SPLIT_SCRIPT.to_s] do |t|
+  Udb.logger.info “Splitting instruction appendix into four base/privilege files”
+  sh “#{RbConfig.ruby} #{SPLIT_SCRIPT} #{MERGED_INSTRUCTIONS_FILE} #{INST_MANUAL_GEN_DIR}”
+  touch t.name
+end
+
+# Each split file depends on the stamp (i.e., on the splitter having run).
+SPLIT_APPENDIX_FILES.each do |f|
+  file f.to_s => SPLIT_APPENDIX_STAMP.to_s
+end
+
 # Define the path to the output PDF file.
-MERGED_INSTRUCTIONS_PDF = INST_MANUAL_GEN_DIR / "instructions_appendix.pdf"
+MERGED_INSTRUCTIONS_PDF = INST_MANUAL_GEN_DIR / “instructions_appendix.pdf”
 
 # File task to generate the PDF from the merged adoc.
 file MERGED_INSTRUCTIONS_PDF.to_s => [
   MERGED_INSTRUCTIONS_FILE.to_s,
-  "#{$root}/ext/docs-resources/themes/riscv-pdf.yml"
+  “#{$root}/ext/docs-resources/themes/riscv-pdf.yml”
 ] do |t|
   sh [
-    "asciidoctor-pdf",
-    "-a toc",
-    "-a pdf-theme=#{ENV['THEME'] || "#{$root}/ext/docs-resources/themes/riscv-pdf.yml"}",
-    "-a pdf-fontsdir=#{$root}/ext/docs-resources/fonts",
-    "-a imagesdir=#{$root}/ext/docs-resources/images",
-    "-r asciidoctor-diagram",
-    "-o #{t.name}",
+    “asciidoctor-pdf”,
+    “-a toc”,
+    “-a pdf-theme=#{ENV['THEME'] || “#{$root}/ext/docs-resources/themes/riscv-pdf.yml”}”,
+    “-a pdf-fontsdir=#{$root}/ext/docs-resources/fonts”,
+    “-a imagesdir=#{$root}/ext/docs-resources/images”,
+    “-r asciidoctor-diagram”,
+    “-o #{t.name}”,
     MERGED_INSTRUCTIONS_FILE.to_s
-  ].join(" ")
+  ].join(“ “)
 
-  puts "SUCCESS: PDF generated at #{t.name}"
+  puts “SUCCESS: PDF generated at #{t.name}”
 end
 
 namespace :gen do
@@ -59,6 +93,57 @@ namespace :gen do
     Generate the instruction appendix (merged .adoc)
   DESC
   task instruction_appendix_adoc: MERGED_INSTRUCTIONS_FILE.to_s
+
+  desc <<~DESC
+    Generate the four split instruction appendix adoc files.
+
+    Produces:
+      gen/instructions_appendix/unpriv_rv32.adoc
+      gen/instructions_appendix/unpriv_rv64.adoc
+      gen/instructions_appendix/priv_rv32.adoc
+      gen/instructions_appendix/priv_rv64.adoc
+
+    Each file contains only the instructions applicable to that base ISA and
+    privilege level.  Anchors are qualified with the base (e.g.
+    [#udb:doc:inst:rv32:add]) so that instructions present in both RV32 and
+    RV64 appendixes have unique IDs.
+  DESC
+  task split_instruction_appendixes: SPLIT_APPENDIX_FILES.map(&:to_s)
+
+  desc <<~DESC
+    Copy the four split instruction appendix files into a riscv-isa-manual checkout.
+
+    The destination checkout is determined by the ISA_MANUAL_DIR environment
+    variable (default: ../riscv-isa-manual relative to the repo root).
+
+    Prerequisites: gen:split_instruction_appendixes must have been run first, or
+    this task will run it automatically.
+
+    Environment flags:
+
+     * ISA_MANUAL_DIR - path to the riscv-isa-manual checkout
+                        (default: #{ISA_MANUAL_DIR})
+
+    Examples:
+
+     # Sync using the default sibling checkout:
+     $ do gen:sync_isa_manual_appendixes
+
+     # Sync to an explicit path:
+     $ do gen:sync_isa_manual_appendixes ISA_MANUAL_DIR=/path/to/riscv-isa-manual
+
+  DESC
+  task sync_isa_manual_appendixes: :split_instruction_appendixes do
+    abort “riscv-isa-manual not found at #{ISA_MANUAL_DIR}” unless ISA_MANUAL_DIR.directory?
+
+    ISA_MANUAL_DESTINATIONS.each do |name, dest|
+      src = INST_MANUAL_GEN_DIR / “#{name}.adoc”
+      FileUtils.cp(src, dest)
+      puts “  #{src.basename} -> #{dest}”
+    end
+
+    puts “SUCCESS: Instruction appendixes synced to #{ISA_MANUAL_DIR}”
+  end
 
   desc <<~DESC
     Generate the instruction appendix (merged .adoc and PDF)
@@ -85,21 +170,21 @@ namespace :gen do
     Rake::Task[MERGED_INSTRUCTIONS_FILE.to_s].invoke
     # Then generate the PDF.
     Rake::Task[MERGED_INSTRUCTIONS_PDF.to_s].invoke
-    puts "SUCCESS: Instruction appendix generated at '#{MERGED_INSTRUCTIONS_FILE}' and PDF at '#{MERGED_INSTRUCTIONS_PDF}'"
+    puts “SUCCESS: Instruction appendix generated at '#{MERGED_INSTRUCTIONS_FILE}' and PDF at '#{MERGED_INSTRUCTIONS_PDF}'”
   end
 end
 
 namespace :test do
-  desc "Check the instruction appendix output vs. stored golden output"
-  task instruction_appendix: "gen:instruction_appendix_adoc" do
+  desc “Check the instruction appendix output vs. stored golden output”
+  task instruction_appendix: “gen:instruction_appendix_adoc” do
     files = {
       golden: {
-        file: Tempfile.new("golden"),
-        path: "#{$root}/tests/golden/all_instructions.golden.adoc"
+        file: Tempfile.new(“golden”),
+        path: “#{$root}/tests/golden/all_instructions.golden.adoc”
       },
       output: {
-        file: Tempfile.new("output"),
-        path: "gen/instructions_appendix/all_instructions.adoc"
+        file: Tempfile.new(“output”),
+        path: “gen/instructions_appendix/all_instructions.adoc”
       }
     }
 
@@ -108,14 +193,14 @@ namespace :test do
       file = files[which][:file]
       path = files[which][:path]
       orig = File.read(path)
-      filtered = orig.lines.reject { |l| l =~ /^:wavedrom:/ }.join("\n")
+      filtered = orig.lines.reject { |l| l =~ /^:wavedrom:/ }.join(“\n”)
       file.write(filtered)
       file.flush
     end
 
-    sh "diff -u #{files[:golden][:file].path} #{files[:output][:file].path}"
+    sh “diff -u #{files[:golden][:file].path} #{files[:output][:file].path}”
     if $? == 0
-      puts "PASSED"
+      puts “PASSED”
     else
       warn <<~MSG
         The golden output for the instruction appendix has changed. If this is expected, run

--- a/backends/instructions_appendix/tasks.rake
+++ b/backends/instructions_appendix/tasks.rake
@@ -2,33 +2,33 @@
 # frozen_string_literal: true
 
 # Define the instructions manual generation directory constant.
-INST_MANUAL_GEN_DIR = $root / “gen” / “instructions_appendix”
+INST_MANUAL_GEN_DIR = $root / "gen" / "instructions_appendix"
 
 # Define the path to the merged instructions output.
-MERGED_INSTRUCTIONS_FILE = INST_MANUAL_GEN_DIR / “all_instructions.adoc”
+MERGED_INSTRUCTIONS_FILE = INST_MANUAL_GEN_DIR / "all_instructions.adoc"
 
 # Define the path to the ERB template that renders the merged instructions.
-TEMPLATE_FILE = $root / “backends” / “instructions_appendix” / “templates” / “instructions.adoc.erb”
+TEMPLATE_FILE = $root / "backends" / "instructions_appendix" / "templates" / "instructions.adoc.erb"
 
 # The four split appendix files produced by split_instructions.rb.
 SPLIT_APPENDIX_NAMES = %w[unpriv_rv32 unpriv_rv64 priv_rv32 priv_rv64].freeze
-SPLIT_APPENDIX_FILES = SPLIT_APPENDIX_NAMES.map { |n| INST_MANUAL_GEN_DIR / “#{n}.adoc” }.freeze
+SPLIT_APPENDIX_FILES = SPLIT_APPENDIX_NAMES.map { |n| INST_MANUAL_GEN_DIR / "#{n}.adoc" }.freeze
 
 # Stamp file used to track whether all four split files are up to date.
-SPLIT_APPENDIX_STAMP = INST_MANUAL_GEN_DIR / “split.stamp”
+SPLIT_APPENDIX_STAMP = INST_MANUAL_GEN_DIR / "split.stamp"
 
 # Path to split_instructions.rb, used to invalidate outputs when the script changes.
-SPLIT_SCRIPT = $root / “backends” / “instructions_appendix” / “split_instructions.rb”
+SPLIT_SCRIPT = $root / "backends" / "instructions_appendix" / "split_instructions.rb"
 
 # Root of the riscv-isa-manual checkout. Override with ISA_MANUAL_DIR env var.
-ISA_MANUAL_DIR = Pathname.new(ENV.fetch(“ISA_MANUAL_DIR”, $root / “..” / “riscv-isa-manual”))
+ISA_MANUAL_DIR = Pathname.new(ENV.fetch("ISA_MANUAL_DIR", $root / ".." / "riscv-isa-manual"))
 
 # Destination paths for each split file inside riscv-isa-manual.
 ISA_MANUAL_DESTINATIONS = {
-  “unpriv_rv32” => ISA_MANUAL_DIR / “src” / “unpriv” / “unpriv_rv32.adoc”,
-  “unpriv_rv64” => ISA_MANUAL_DIR / “src” / “unpriv” / “unpriv_rv64.adoc”,
-  “priv_rv32”   => ISA_MANUAL_DIR / “src” / “priv”   / “priv_rv32.adoc”,
-  “priv_rv64”   => ISA_MANUAL_DIR / “src” / “priv”   / “priv_rv64.adoc”
+  "unpriv_rv32" => ISA_MANUAL_DIR / "src" / "unpriv" / "unpriv_rv32.adoc",
+  "unpriv_rv64" => ISA_MANUAL_DIR / "src" / "unpriv" / "unpriv_rv64.adoc",
+  "priv_rv32"   => ISA_MANUAL_DIR / "src" / "priv"   / "priv_rv32.adoc",
+  "priv_rv64"   => ISA_MANUAL_DIR / "src" / "priv"   / "priv_rv64.adoc"
 }.freeze
 
 # Declare a file task for the template so Rake knows it exists.
@@ -38,14 +38,14 @@ end
 
 # File task that generates the merged instructions adoc.
 file MERGED_INSTRUCTIONS_FILE.to_s => [__FILE__, TEMPLATE_FILE.to_s] do |t|
-  cfg_arch = $resolver.cfg_arch_for(“_”)
+  cfg_arch = $resolver.cfg_arch_for("_")
   instructions = cfg_arch.possible_instructions
 
   # Load and process the template (which renders both an index and details).
-  erb = ERB.new(File.read(TEMPLATE_FILE), trim_mode: “-”)
+  erb = ERB.new(File.read(TEMPLATE_FILE), trim_mode: "-")
   erb.filename = TEMPLATE_FILE.to_s
 
-  Udb.logger.info “Generating asciidoc for instruction appendix”
+  Udb.logger.info "Generating asciidoc for instruction appendix"
   FileUtils.mkdir_p(File.dirname(t.name))
   File.write(
     t.name,
@@ -56,8 +56,8 @@ end
 # Stamp file task: runs split_instructions.rb to produce all four split files in
 # one pass, then touches the stamp so Rake knows the outputs are current.
 file SPLIT_APPENDIX_STAMP.to_s => [MERGED_INSTRUCTIONS_FILE.to_s, SPLIT_SCRIPT.to_s] do |t|
-  Udb.logger.info “Splitting instruction appendix into four base/privilege files”
-  sh “#{RbConfig.ruby} #{SPLIT_SCRIPT} #{MERGED_INSTRUCTIONS_FILE} #{INST_MANUAL_GEN_DIR}”
+  Udb.logger.info "Splitting instruction appendix into four base/privilege files"
+  sh "#{RbConfig.ruby} #{SPLIT_SCRIPT} #{MERGED_INSTRUCTIONS_FILE} #{INST_MANUAL_GEN_DIR}"
   touch t.name
 end
 
@@ -67,25 +67,25 @@ SPLIT_APPENDIX_FILES.each do |f|
 end
 
 # Define the path to the output PDF file.
-MERGED_INSTRUCTIONS_PDF = INST_MANUAL_GEN_DIR / “instructions_appendix.pdf”
+MERGED_INSTRUCTIONS_PDF = INST_MANUAL_GEN_DIR / "instructions_appendix.pdf"
 
 # File task to generate the PDF from the merged adoc.
 file MERGED_INSTRUCTIONS_PDF.to_s => [
   MERGED_INSTRUCTIONS_FILE.to_s,
-  “#{$root}/ext/docs-resources/themes/riscv-pdf.yml”
+  "#{$root}/ext/docs-resources/themes/riscv-pdf.yml"
 ] do |t|
   sh [
-    “asciidoctor-pdf”,
-    “-a toc”,
-    “-a pdf-theme=#{ENV['THEME'] || “#{$root}/ext/docs-resources/themes/riscv-pdf.yml”}”,
-    “-a pdf-fontsdir=#{$root}/ext/docs-resources/fonts”,
-    “-a imagesdir=#{$root}/ext/docs-resources/images”,
-    “-r asciidoctor-diagram”,
-    “-o #{t.name}”,
+    "asciidoctor-pdf",
+    "-a toc",
+    "-a pdf-theme=#{ENV['THEME'] || "#{$root}/ext/docs-resources/themes/riscv-pdf.yml"}",
+    "-a pdf-fontsdir=#{$root}/ext/docs-resources/fonts",
+    "-a imagesdir=#{$root}/ext/docs-resources/images",
+    "-r asciidoctor-diagram",
+    "-o #{t.name}",
     MERGED_INSTRUCTIONS_FILE.to_s
-  ].join(“ “)
+  ].join(" ")
 
-  puts “SUCCESS: PDF generated at #{t.name}”
+  puts "SUCCESS: PDF generated at #{t.name}"
 end
 
 namespace :gen do
@@ -134,26 +134,26 @@ namespace :gen do
 
   DESC
   task sync_isa_manual_appendixes: :split_instruction_appendixes do
-    abort “riscv-isa-manual not found at #{ISA_MANUAL_DIR}” unless ISA_MANUAL_DIR.directory?
+    abort "riscv-isa-manual not found at #{ISA_MANUAL_DIR}" unless ISA_MANUAL_DIR.directory?
 
     ISA_MANUAL_DESTINATIONS.each do |name, dest|
-      src = INST_MANUAL_GEN_DIR / “#{name}.adoc”
+      src = INST_MANUAL_GEN_DIR / "#{name}.adoc"
       FileUtils.cp(src, dest)
-      puts “  #{src.basename} -> #{dest}”
+      puts "  #{src.basename} -> #{dest}"
     end
 
-    puts “SUCCESS: Instruction appendixes synced to #{ISA_MANUAL_DIR}”
+    puts "SUCCESS: Instruction appendixes synced to #{ISA_MANUAL_DIR}"
   end
 
   desc <<~DESC
     Generate the instruction appendix (merged .adoc and PDF)
 
-    By default this will produce the “merged instructions” AsciiDoc file and
+    By default this will produce the "merged instructions" AsciiDoc file and
     then render it to PDF.
 
     Environment flags:
 
-     * ASSEMBLY - set to `1` to include an “Assembly” line (instruction mnemonic + operands)
+     * ASSEMBLY - set to `1` to include an "Assembly" line (instruction mnemonic + operands)
                   before the Encoding section for each instruction.
 
     Examples:
@@ -170,21 +170,21 @@ namespace :gen do
     Rake::Task[MERGED_INSTRUCTIONS_FILE.to_s].invoke
     # Then generate the PDF.
     Rake::Task[MERGED_INSTRUCTIONS_PDF.to_s].invoke
-    puts “SUCCESS: Instruction appendix generated at '#{MERGED_INSTRUCTIONS_FILE}' and PDF at '#{MERGED_INSTRUCTIONS_PDF}'”
+    puts "SUCCESS: Instruction appendix generated at '#{MERGED_INSTRUCTIONS_FILE}' and PDF at '#{MERGED_INSTRUCTIONS_PDF}'"
   end
 end
 
 namespace :test do
-  desc “Check the instruction appendix output vs. stored golden output”
-  task instruction_appendix: “gen:instruction_appendix_adoc” do
+  desc "Check the instruction appendix output vs. stored golden output"
+  task instruction_appendix: "gen:instruction_appendix_adoc" do
     files = {
       golden: {
-        file: Tempfile.new(“golden”),
-        path: “#{$root}/tests/golden/all_instructions.golden.adoc”
+        file: Tempfile.new("golden"),
+        path: "#{$root}/tests/golden/all_instructions.golden.adoc"
       },
       output: {
-        file: Tempfile.new(“output”),
-        path: “gen/instructions_appendix/all_instructions.adoc”
+        file: Tempfile.new("output"),
+        path: "gen/instructions_appendix/all_instructions.adoc"
       }
     }
 
@@ -193,14 +193,14 @@ namespace :test do
       file = files[which][:file]
       path = files[which][:path]
       orig = File.read(path)
-      filtered = orig.lines.reject { |l| l =~ /^:wavedrom:/ }.join(“\n”)
+      filtered = orig.lines.reject { |l| l =~ /^:wavedrom:/ }.join("\n")
       file.write(filtered)
       file.flush
     end
 
-    sh “diff -u #{files[:golden][:file].path} #{files[:output][:file].path}”
+    sh "diff -u #{files[:golden][:file].path} #{files[:output][:file].path}"
     if $? == 0
-      puts “PASSED”
+      puts "PASSED"
     else
       warn <<~MSG
         The golden output for the instruction appendix has changed. If this is expected, run


### PR DESCRIPTION
Breaks all_instructions.adoc into four files, unpriv_rv32.adoc, unpriv_rv64.adoc, priv_rv32.adoc, and priv_rv64.adoc.  These are then synced to riscv-isa-manual.  Note that this is currently manual, however, could be automated once the ISA manual changes are accepted.