### PR TITLE
fix(cpp_hart_gen): vector register writes silently dropped to 0 (runtime bit_insert)

### DIFF
--- a/backends/cpp_hart_gen/cpp/include/udb/util.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/util.hpp
@@ -48,8 +48,17 @@ namespace udb {
   >
   void bit_insert(BitsClass<T, Signed> &target, const MsbType &msb, const LsbType &lsb,
                   const ValueType &value) {
-    BitsClass<T, Signed> mask = ((BitsClass<T + 1, Signed>{1_b} << (msb - lsb + _Bits<1, false>{1_b})) - 1_b) << lsb;
-    target = (target & ~mask) | ((BitsClass<T, Signed>{value} << lsb) & mask);
+    // Derive the "1" and the value from `target` so that they carry the register's
+    // full (runtime) width. For runtime-width Bits (e.g. vector registers wider than 64
+    // bits) a non-widening left shift by an amount >= the operand's width yields 0; building
+    // the mask from a 1-bit literal (BitsClass<T+1>{1_b}, width 1) would therefore collapse
+    // the mask — and likewise `{value} << lsb` would collapse — to 0. The final assignment
+    // re-masks `target` to its own width, so intermediate widths are harmless.
+    BitsClass<T, Signed> zero = target ^ target;
+    BitsClass<T, Signed> one = zero | _Bits<1, false>{1_b};
+    BitsClass<T, Signed> field = zero | value;
+    BitsClass<T, Signed> mask = ((one << (msb - lsb + _Bits<1, false>{1_b})) - one) << lsb;
+    target = (target & ~mask) | ((field << lsb) & mask);
   }
 
   template <unsigned FirstExtendedBit, unsigned ResultWidth,


### PR DESCRIPTION
Vector register writes on the ISS were silently dropping to `0`. For example `vle8.v v2, (x5)` (unit-stride load of 8-bit elements from the address in `x5` into `v2`) left `v2 = 0` instead of the loaded bytes; `vmv.v.i v1, 5` (broadcast the sign-extended immediate `5` into every element of `v1`) wrote the wrong value; and `vadd.vv vd, vs2, vs1` failed the same way. Scalar loads like `lb`/`lw` were fine, which is what made it puzzling at first.

Caused by #1813, which changed vector register width from compile-time-known to the weaker runtime-known.

Concretely, once `V` became a runtime-width register file, every `V[vd][msb:lsb] = value` write started going through the runtime overload of `bit_insert()` in `util.hpp`, which builds its field mask like:

```c++
BitsClass<T + 1, Signed>{1_b} << (msb - lsb + 1)
```

The problem stems from `{1_b}` having a runtime width of 1: for runtime-width Bits, a non-widening left shift by an amount `>=` the operand's width returns `0` (the bits fall off the end), so `1 << 8` becomes `0` and the whole mask collapses to `0`. `BitsClass<T>{value} << lsb` collapses the same way. With a zero mask the write is a no-op. Fixed-width `X` registers are `PossiblyUnknownBits<MXLEN>`, so their shift width is the compile-time template width and never collapses — which is why scalar worked and vector didn't.

The fix materializes the `1` and the value at the register's own (runtime) width before shifting, so nothing collapses:

```c++
BitsClass<T, Signed> zero  = target ^ target;   // zero, same width as the register
BitsClass<T, Signed> one   = zero | 1_b;        // 1,     same width
BitsClass<T, Signed> field = zero | value;      // value, same width
BitsClass<T, Signed> mask  = ((one << (msb - lsb + 1)) - one) << lsb;
target = (target & ~mask) | ((field << lsb) & mask);
```

This works for both the fixed-width and runtime-width instantiations, so `X` behaves exactly as before.

Generated with [Claude Code](https://claude.com/claude-code)