### PR TITLE
Revert attempt to start using new instruction encoding schema

### DIFF
--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -16,17 +16,15 @@ definedBy:
       - name: Zbb
       - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: ANDN
-      value: 0b0100000
-    funct3:
-      display_name: ANDN
-      value: 0b111
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0100000----------111-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/clmul.yaml
+++ b/spec/std/isa/inst/B/clmul.yaml
@@ -15,17 +15,15 @@ definedBy:
       - name: Zbc
       - name: Zbkc
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: CLMUL
-      value: 0b0000101
-    funct3:
-      display_name: CLMUL
-      value: 0b001
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0000101----------001-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -15,17 +15,15 @@ definedBy:
       - name: Zbc
       - name: Zbkc
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: CLMUL
-      value: 0b0000101
-    funct3:
-      display_name: CLMULH
-      value: 0b011
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0000101----------011-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/orn.yaml
+++ b/spec/std/isa/inst/B/orn.yaml
@@ -15,17 +15,15 @@ definedBy:
       - name: Zbb
       - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: ORN
-      value: 0b0100000
-    funct3:
-      display_name: ORN
-      value: 0b110
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0100000----------110-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/rol.yaml
+++ b/spec/std/isa/inst/B/rol.yaml
@@ -15,17 +15,15 @@ definedBy:
       - name: Zbb
       - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: ROL
-      value: 0b0110000
-    funct3:
-      display_name: ROL
-      value: 0b001
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0110000----------001-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/rolw.yaml
+++ b/spec/std/isa/inst/B/rolw.yaml
@@ -18,17 +18,15 @@ definedBy:
           - name: Zbb
           - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: ROLW
-      value: 0b0110000
-    funct3:
-      display_name: ROLW
-      value: 0b001
-    opcode: { $inherits: inst_opcode/OP-32.yaml#/data }
+encoding:
+  match: 0110000----------001-----0111011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/ror.yaml
+++ b/spec/std/isa/inst/B/ror.yaml
@@ -15,17 +15,15 @@ definedBy:
       - name: Zbb
       - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: ROR
-      value: 0b0110000
-    funct3:
-      display_name: ROR
-      value: 0b101
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0110000----------101-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -19,17 +19,15 @@ definedBy:
           - name: Zbb
           - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: RORW
-      value: 0b0110000
-    funct3:
-      display_name: RORW
-      value: 0b101
-    opcode: { $inherits: inst_opcode/OP-32.yaml#/data }
+encoding:
+  match: 0110000----------101-----0111011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/xnor.yaml
+++ b/spec/std/isa/inst/B/xnor.yaml
@@ -15,17 +15,15 @@ definedBy:
       - name: Zbb
       - name: Zbkb
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: XNOR
-      value: 0b0100000
-    funct3:
-      display_name: XNOR
-      value: 0b100
-    opcode: { $inherits: inst_opcode/OP.yaml#/data }
+encoding:
+  match: 0100000----------100-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zba/add.uw.yaml
+++ b/spec/std/isa/inst/Zba/add.uw.yaml
@@ -16,17 +16,15 @@ definedBy:
     - extension:
         name: Zba
 assembly: xd, xs1, xs2
-format:
-  $inherits:
-    - inst_subtype/R/R-x.yaml#/data
-  opcodes:
-    funct7:
-      display_name: ADD.UW
-      value: 0b0000100
-    funct3:
-      display_name: ADD.UW
-      value: 0b000
-    opcode: { $inherits: inst_opcode/OP-32.yaml#/data }
+encoding:
+  match: 0000100----------000-----0111011
+  variables:
+    - name: xs2
+      location: 24-20
+    - name: xs1
+      location: 19-15
+    - name: xd
+      location: 11-7
 access:
   s: always
   u: always


### PR DESCRIPTION
## Summary

This change restores the legacy `encoding` representation for the affected ISA instruction YAML files under `spec/std/isa`.

The previous migration replaced the `encoding` block with the newer `format` representation. This PR restores the original `encoding` representation while preserving all subsequent updates

The intent is to restore the original encoding format without reverting unrelated improvements introduced after the migration.

## Scope

- Replaced `format` with `encoding` for the affected instruction YAML files.
- Kept the current operand naming (`xd`, `xs1`, `xs2`) and existing instruction behavior unchanged.
- No functional changes to instruction semantics are intended.

## Notes

This is a targeted restoration of the encoding representation only and is not a full revert of the original migration.