### PR TITLE
fix: correct InterruptCode type references in exception_code.rb

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/exception_code.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/exception_code.rb
@@ -82,9 +82,9 @@ module Udb
 
     sig { override.params(other: BasicObject).returns(T.nilable(Integer)) }
     def <=>(other)
-      return nil unless T.cast(other, Object).is_a?(ExceptionCode)
+      return nil unless T.cast(other, Object).is_a?(InterruptCode)
 
-      num <=> T.cast(other, ExceptionCode).num
+      num <=> T.cast(other, InterruptCode).num
     end
 
     sig { override.params(other: BasicObject).returns(T::Boolean) }
@@ -93,6 +93,6 @@ module Udb
     end
 
     sig { override.returns(Integer) }
-    def hash = [ExceptionCode, num].hash
+    def hash = [InterruptCode, num].hash
   end
 end


### PR DESCRIPTION
Fix two copy-paste errors in InterruptCode where ExceptionCode was
used instead of InterruptCode.

Closes #1979