### PR TITLE
add in param ZAWRS_NTO_IS_NOP

### DIFF
--- a/spec/std/isa/inst/Zawrs/wrs.nto.yaml
+++ b/spec/std/isa/inst/Zawrs/wrs.nto.yaml
@@ -73,5 +73,7 @@ operation(): |
     }
   }
 
-  # stall while the reservation set is valid and no interrupt is pending
-  wrs_nto();
+  if (!ZAWRS_NTO_IS_NOP) {
+    # stall while the reservation set is valid and no interrupt is pending
+    wrs_nto();
+  }

--- a/spec/std/isa/param/ZAWRS_NTO_IS_NOP.yaml
+++ b/spec/std/isa/param/ZAWRS_NTO_IS_NOP.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025-26 Harvey Mudd College
+# Author: Ellen Yu (ellyu@hmc.edu)
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/param_schema.json
+
+$schema: param_schema.json#
+kind: parameter
+name: ZAWRS_NTO_IS_NOP
+description: |
+  When true, WRS.NTO completes immediately, behaving as a no-op, rather than
+  stalling the hart.
+
+long_name: TODO
+schema:
+  type: boolean
+definedBy:
+  extension:
+    name: Zawrs


### PR DESCRIPTION
Added in parameter ZAWRS_NTO_IS_NOP, which can configure to behave as a no-op instruction. 