### PR TITLE
fix(z3): support anyOf for integer, boolean, and string parameters

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/z3.rb
+++ b/tools/ruby-gems/udb/lib/udb/z3.rb
@@ -433,6 +433,7 @@ module Udb
     # Handles JSON schema keywords:
     # - const: exact boolean value
     # - allOf: conjunction of subschemas
+    # - anyOf: disjunction of subschemas
     #
     # @param solver [Z3Solver] The solver to add assertions to
     # @param term [Z3::BoolExpr] The Z3 boolean term to constrain
@@ -458,12 +459,15 @@ module Udb
 
       if schema_hsh.key?("allOf")
         schema_hsh.fetch("allOf").each do |h|
-          assertions += constrain_bool(solver, term, h)
+          assertions += constrain_bool(solver, term, h, assert: false)
         end
       end
 
       if schema_hsh.key?("anyOf")
-        raise "TODO: anyOf not yet implemented for boolean constraints"
+        branches = schema_hsh.fetch("anyOf").map do |h|
+          constrain_bool(solver, term, h, assert: false)
+        end
+        assertions << any_of_constraint(branches)
       end
 
       if schema_hsh.key?("oneOf")
@@ -492,6 +496,7 @@ module Udb
     # Handles JSON schema keywords:
     # - const: exact string value (compared via hash)
     # - enum: one of several string values (compared via hash)
+    # - anyOf: disjunction of subschemas
     #
     # @param solver [Z3Solver] The solver to add assertions to
     # @param term [Z3::IntExpr] The Z3 integer term representing the string hash
@@ -526,7 +531,10 @@ module Udb
       end
 
       if schema_hsh.key?("anyOf")
-        raise "TODO: anyOf not yet implemented for string constraints"
+        branches = schema_hsh.fetch("anyOf").map do |h|
+          constrain_string(solver, term, h, assert: false)
+        end
+        assertions << any_of_constraint(branches)
       end
 
       if schema_hsh.key?("oneOf")
@@ -546,6 +554,15 @@ module Udb
       end
       assertions
     end
+
+    sig { params(branches: T::Array[T::Array[Z3::BoolExpr]]).returns(Z3::BoolExpr) }
+    def self.any_of_constraint(branches)
+      expressions = branches.map do |branch|
+        branch.reduce(Z3.True) { |expression, assertion| expression & assertion }
+      end
+      expressions.reduce(Z3.False) { |expression, branch| expression | branch }
+    end
+    private_class_method :any_of_constraint
 
     # Extract array constraints from JSON schema
     #

--- a/tools/ruby-gems/udb/lib/udb/z3.rb
+++ b/tools/ruby-gems/udb/lib/udb/z3.rb
@@ -318,12 +318,12 @@ module Udb
   # Supported JSON schema features:
   # - Type constraints (boolean, integer, string, array)
   # - Value constraints (const, enum, minimum, maximum)
-  # - Composition (allOf; anyOf for boolean and string)
+  # - Composition (allOf; anyOf for boolean, integer, and string)
   # - References ($ref to uint32/uint64)
   # - Array constraints (items, minItems, maxItems, contains, uniqueItems)
   #
   # Not yet supported (TODO):
-  # - anyOf for integer and array
+  # - anyOf for array
   # - oneOf, noneOf
   # - if/then/else (conditional schemas)
   class Z3ParameterTerm
@@ -342,6 +342,7 @@ module Udb
     # - enum: one of several values
     # - minimum/maximum: range bounds (unsigned comparison)
     # - allOf: conjunction of subschemas
+    # - anyOf: inclusive disjunction of subschemas (at least one must hold)
     # - $ref: references to uint32/uint64 types
     #
     # @param solver [Z3Solver] The solver to add assertions to
@@ -386,12 +387,15 @@ module Udb
 
       if schema_hsh.key?("allOf")
         schema_hsh.fetch("allOf").each do |h|
-          assertions += constrain_int(solver, term, h)
+          assertions += constrain_int(solver, term, h, assert: false)
         end
       end
 
       if schema_hsh.key?("anyOf")
-        raise "TODO: anyOf not yet implemented for integer constraints"
+        branches = schema_hsh.fetch("anyOf").map do |h|
+          constrain_int(solver, term, h, assert: false)
+        end
+        assertions << any_of_constraint(branches)
       end
 
       if schema_hsh.key?("oneOf")

--- a/tools/ruby-gems/udb/lib/udb/z3.rb
+++ b/tools/ruby-gems/udb/lib/udb/z3.rb
@@ -318,12 +318,13 @@ module Udb
   # Supported JSON schema features:
   # - Type constraints (boolean, integer, string, array)
   # - Value constraints (const, enum, minimum, maximum)
-  # - Composition (allOf)
+  # - Composition (allOf; anyOf for boolean and string)
   # - References ($ref to uint32/uint64)
   # - Array constraints (items, minItems, maxItems, contains, uniqueItems)
   #
   # Not yet supported (TODO):
-  # - anyOf, oneOf, noneOf (would require disjunctive constraints)
+  # - anyOf for integer and array
+  # - oneOf, noneOf
   # - if/then/else (conditional schemas)
   class Z3ParameterTerm
     extend T::Sig
@@ -433,7 +434,7 @@ module Udb
     # Handles JSON schema keywords:
     # - const: exact boolean value
     # - allOf: conjunction of subschemas
-    # - anyOf: disjunction of subschemas
+    # - anyOf: inclusive disjunction of subschemas (at least one must hold)
     #
     # @param solver [Z3Solver] The solver to add assertions to
     # @param term [Z3::BoolExpr] The Z3 boolean term to constrain
@@ -496,7 +497,7 @@ module Udb
     # Handles JSON schema keywords:
     # - const: exact string value (compared via hash)
     # - enum: one of several string values (compared via hash)
-    # - anyOf: disjunction of subschemas
+    # - anyOf: inclusive disjunction of subschemas (at least one must hold)
     #
     # @param solver [Z3Solver] The solver to add assertions to
     # @param term [Z3::IntExpr] The Z3 integer term representing the string hash

--- a/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
+++ b/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
@@ -204,6 +204,105 @@ class TestZ3ParameterConstraints < Minitest::Test
     assert @solver.satisfiable?
   end
 
+  def test_constrain_int_with_anyof_const
+    schema = {
+      "anyOf" => [
+        { "const" => 1 },
+        { "const" => 2 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("anyof_const_param", @solver, schema)
+
+    assert @solver.satisfiable?
+
+    # Only 1 or 2 should be allowed
+    [1, 2].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 3)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_int_with_anyof_ranges
+    schema = {
+      "anyOf" => [
+        { "minimum" => 0, "maximum" => 10 },
+        { "minimum" => 100, "maximum" => 110 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("anyof_range_param", @solver, schema)
+
+    assert @solver.satisfiable?
+
+    # A value inside either range is allowed
+    [5, 105].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    # A value in the gap between the two ranges is not
+    @solver.push
+    @solver.assert(param == 50)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_int_with_anyof_and_other_constraints
+    # anyOf combined with a sibling minimum: the value must satisfy the
+    # minimum *and* fall into one of the anyOf subschemas.
+    schema = {
+      "minimum" => 1,
+      "anyOf" => [
+        { "const" => 0 },
+        { "const" => 5 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("anyof_combined_param", @solver, schema)
+
+    # const 0 satisfies anyOf but violates the sibling minimum, so only 5 remains
+    @solver.push
+    @solver.assert(param == 0)
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == 5)
+    assert @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_int_with_anyof_nested_allof
+    # A nested allOf must stay branch-local. If it leaked straight into the
+    # solver, the 10..20 branch would become mandatory and 105 unsatisfiable.
+    schema = {
+      "anyOf" => [
+        { "allOf" => [{ "minimum" => 10 }, { "maximum" => 20 }] },
+        { "minimum" => 100, "maximum" => 110 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("anyof_nested_allof_param", @solver, schema)
+
+    [15, 105].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 50)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
   def test_constrain_bool_with_anyof
     schema = {
       "type" => "boolean",

--- a/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
+++ b/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
@@ -204,6 +204,47 @@ class TestZ3ParameterConstraints < Minitest::Test
     assert @solver.satisfiable?
   end
 
+  def test_constrain_bool_with_anyof
+    schema = {
+      "type" => "boolean",
+      "anyOf" => [
+        { "allOf" => [{ "const" => true }] },
+        { "const" => false }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("anyof_bool", @solver, schema)
+
+    [true, false].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+  end
+
+  def test_constrain_string_with_anyof
+    schema = {
+      "type" => "string",
+      "anyOf" => [
+        { "const" => "alpha" },
+        { "enum" => ["beta", "gamma"] }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("anyof_string", @solver, schema)
+
+    ["alpha", "beta", "gamma"].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == "delta")
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
   # Type detection tests
   def test_detect_type_from_allof_integer
     schema = {


### PR DESCRIPTION
## Summary

- implement JSON Schema `anyOf` for integer, boolean, and string Z3 parameter constraints
- route all three through one shared `any_of_constraint` helper (conjoin within a branch, disjoin across branches)
- fix a latent leak where a nested `allOf` recursed with the default `assert: true`, pushing branch-local assertions straight into the solver
- add satisfiability coverage for integer const/range/sibling-constraint branches, boolean alternatives, and string const/enum branches

Supersedes #1932, which implemented the integer case only. This PR now covers the whole scalar half of #1890; array constraints and the other combinators (`oneOf`, `noneOf`, `if`/`then`/`else`) remain out of scope.

### The nested `allOf` leak

`constrain_int` and `constrain_bool` both recursed into their `allOf` subschemas without forwarding `assert: false`. At top level that is harmless, since the caller asserts the collected array anyway. Inside an `anyOf` branch it is not: the nested assertions land in the solver unconditionally, so a branch that should have been one alternative of a disjunction becomes mandatory.

`test_constrain_int_with_anyof_nested_allof` pins this. With the `assert: false` forwarding reverted, it fails.

Part of #1890

## Testing

- `./bin/regress -n regress-udb-unit-test --matrix=test=z3_parameter_constraints` - 42 runs, 64 assertions, 0 failures
- `./bin/regress -n regress-udb-unit-test --matrix=test=z3` - 38 runs, 55 assertions, 0 failures
- `./bin/regress -n regress-udb-unit-test --matrix=test=z3_finite_array` - 37 runs, 44 assertions, 0 failures
- `./bin/regress -n regress-sorbet` - no errors
- `./bin/prek run --files tools/ruby-gems/udb/lib/udb/z3.rb tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb` - passed
- `./bin/regress --all` - attempted locally; remaining failures are existing macOS setup limitations, chiefly the Linux-only `must`/`eqntott` binaries, plus cascading schema/submodule/docs host failures. The changed Z3 suites pass independently.
