### PR TITLE
Correct cbo.inval self-reference and htval field description

### DIFF
--- a/spec/std/isa/csr/H/htval.yaml
+++ b/spec/std/isa/csr/H/htval.yaml
@@ -38,5 +38,5 @@ fields:
         return CsrFieldType::RO;
       }
     description: |
-      Exception-specific information for a trap into M-mode.
+      Exception-specific information for a trap into HS-mode.
     reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/inst/Zicbom/cbo.inval.yaml
+++ b/spec/std/isa/inst/Zicbom/cbo.inval.yaml
@@ -52,7 +52,7 @@ description: |
   `cbo.inval` is ordered by `FENCE` instructions but not `FENCE.I` or `SFENCE.VMA`.
 
   <%- if CACHE_BLOCK_SIZE.bit_length > [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
-  Both PMP and PMA access control must be the same for all bytes in the block; otherwise, `cbo.zero` has UNSPECIFIED behavior.
+  Both PMP and PMA access control must be the same for all bytes in the block; otherwise, `cbo.inval` has UNSPECIFIED behavior.
   <%- end -%>
 
   Invalidate operations are treated as stores for page and access permissions. If permission checks fail,


### PR DESCRIPTION
Fix two copy-paste errors in description fields:
1. cbo.inval.yaml incorrectly referenced `cbo.zero` instead of `cbo.inval`
2. htval.yaml said "trap into M-mode" but should say "HS-mode"

Fixes #2066