### PR TITLE
fix(idlc): correct bits_needed for negative powers of two

### DIFF
--- a/tools/ruby-gems/idlc/lib/idlc/ast.rb
+++ b/tools/ruby-gems/idlc/lib/idlc/ast.rb
@@ -4799,27 +4799,12 @@ module Idl
     # @return [Integer] the number of bits needed to represent value in two's complement
     def bits_needed(value, signed)
       if signed
-        case value
-        when 0
-          1
-        when 1
-          2
-        else
-          if value > 0
-            # need bit_legnth plus a sign bit
-            bits = value.bit_length + 1
-          else
-            # need bit_length plus a sign bit, unless value is a power of 2
-            if (value.abs & (value.abs - 1)) == 0
-              value.bit_length
-            else
-              value.bit_length + 1
-            end
-          end
-        end
+        # add sign bit
+        value.bit_length + 1
       else
         internal_error "unsigned value is negative" if value < 0
 
+        # 0 needs a single bit; `0.bit_length` returns 0.
         value == 0 ? 1 : value.bit_length
       end
     end


### PR DESCRIPTION
## What

`bits_needed` under-counted signed negative powers of two: the special case
`(value.abs & (value.abs - 1)) == 0 -> value.bit_length` dropped the sign bit, so
e.g. `-16` returned 4 instead of 5 (it is the most-negative value of a 5-bit
signed type). In two's complement a signed value always needs `bit_length + 1`
bits, so the whole signed branch reduces to that; the unsigned branch keeps the
`value == 0 -> 1` guard since `0.bit_length` is 0.
