### PR TITLE
schema(inst): enforce access_detail when any access mode is 'sometimes'

### DIFF
--- a/doc/docs/schemas/index.mdx
+++ b/doc/docs/schemas/index.mdx
@@ -54,6 +54,11 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.3/inst_schema">Inst Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.3</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/inst_subtype_schema">Inst Subtype Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
 </div>

--- a/doc/docs/schemas/v0.1/_category_.json
+++ b/doc/docs/schemas/v0.1/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "v0.1",
-  "position": 2,
+  "position": 3,
   "collapsible": true,
   "collapsed": false
 }

--- a/doc/docs/schemas/v0.2/_category_.json
+++ b/doc/docs/schemas/v0.2/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "v0.2",
-  "position": 1,
+  "position": 2,
   "collapsible": true,
   "collapsed": false
 }

--- a/doc/docs/schemas/v0.3/_category_.json
+++ b/doc/docs/schemas/v0.3/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "v0.3",
+  "position": 1,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/doc/docs/schemas/v0.3/inst_schema.mdx
+++ b/doc/docs/schemas/v0.3/inst_schema.mdx
@@ -1,0 +1,106 @@
+---
+title: Inst Schema (v0.3)
+sidebar_label: Inst Schema
+custom_edit_url: null
+# This file is auto-generated from inst_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+import AnchorOpenDetails from '@site/src/components/AnchorOpenDetails';
+
+<AnchorOpenDetails />
+
+# Inst Schema
+
+<span class="badge badge--secondary">v0.3</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`inst_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/inst_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+
+## Schema Structure
+
+This schema requires **all of** the following:
+
+- (Complex type)
+
+
+## Definitions
+
+<details>
+<summary><a id="fully-resolved-opcodes"></a><strong><code>fully_resolved_opcodes</code></strong></summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `location` | `schema_defs.json#/$defs/field_location` | ✓ |  |
+| `display_name` | `string` | ✓ | field name, displayed in encoding drawings |
+| `value` | One of: An integer, either native to JSON or a number-like string \| `object` | ✓ |  |
+| `$child_of` | One of: `string` \| Array&lt;`string`&gt; |  |  |
+
+</details>
+
+<details>
+<summary><a id="fully-resolved-variables"></a><strong><code>fully_resolved_variables</code></strong></summary>
+
+
+</details>
+
+<details>
+<summary><a id="fully-resolved-format"></a><strong><code>fully_resolved_format</code></strong></summary>
+
+</details>
+
+<details>
+<summary><a id="old-encoding"></a><strong><code>old_encoding</code></strong></summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `match` | One of: `string` \| `string` \| `string` |  |  |
+| `variables` | Array&lt;[`field`](#field)&gt; |  |  |
+| `additionalProperties` | `never` |  |  |
+
+</details>
+
+<details>
+<summary><a id="type"></a><strong><code>type</code></strong></summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$ref` | `string` | ✓ | Reference to an instruction type definition |
+
+</details>
+
+<details>
+<summary><a id="subtype"></a><strong><code>subtype</code></strong></summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$ref` | `string` | ✓ | Reference to an instruction subtype definition |
+
+</details>
+
+<details>
+<summary><a id="variable-metadata"></a><strong><code>variable_metadata</code></strong></summary>
+
+</details>
+
+<details>
+<summary><a id="field"></a><strong><code>field</code></strong> — Decode field</summary>
+
+Decode field
+
+
+</details>
+
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.3` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/spec/schemas/inst_schema.json
+++ b/spec/schemas/inst_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.2",
+  "$id": "v0.3",
   "$defs": {
     "fully_resolved_opcodes": {
       "type": "object",
@@ -492,5 +492,61 @@
   },
   "patternProperties": {
     "^custom_[A-Za-z0-9_]+$": {}
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["access"],
+        "properties": {
+          "access": {
+            "anyOf": [
+              {
+                "required": ["m"],
+                "properties": {
+                  "m": {
+                    "const": "sometimes"
+                  }
+                }
+              },
+              {
+                "required": ["s"],
+                "properties": {
+                  "s": {
+                    "const": "sometimes"
+                  }
+                }
+              },
+              {
+                "required": ["u"],
+                "properties": {
+                  "u": {
+                    "const": "sometimes"
+                  }
+                }
+              },
+              {
+                "required": ["vs"],
+                "properties": {
+                  "vs": {
+                    "const": "sometimes"
+                  }
+                }
+              },
+              {
+                "required": ["vu"],
+                "properties": {
+                  "vu": {
+                    "const": "sometimes"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": ["access_detail"]
+      }
+    }
+  ]
 }

--- a/spec/std/isa/inst/Svinval/hinval.gvma.yaml
+++ b/spec/std/isa/inst/Svinval/hinval.gvma.yaml
@@ -27,6 +27,18 @@ access:
   u: never
   vs: never
   vu: never
+access_detail: |
+  `hinval.gvma` is accessible from M-mode and HS-mode.
+  In HS-mode, access is further controlled by `mstatus.TVM`:
+
+  [%autowidth]
+  |===
+  | [.rotate]#`mstatus.TVM`# | `hinval.gvma` in HS-mode
+  | 0 | executes
+  | 1 | `Illegal Instruction`
+  |===
+
+  VS-mode and VU-mode always raise a `Virtual Instruction` exception.
 assembly: xs1, xs2
 operation(): |
   XReg gpa = X[xs1];

--- a/spec/std/isa/inst/Svinval/sfence.inval.ir.yaml
+++ b/spec/std/isa/inst/Svinval/sfence.inval.ir.yaml
@@ -21,6 +21,10 @@ access:
   u: never
   vs: sometimes
   vu: never
+access_detail: |
+  `sfence.inval.ir` is accessible from M-mode, HS-mode, and VS-mode.
+  It raises `Illegal Instruction` when executed in U-mode, and
+  `Virtual Instruction` when executed in VU-mode (when the H extension is implemented).
 assembly: ""
 operation(): |
   if (mode() == PrivilegeMode::U) {

--- a/spec/std/isa/inst/Svinval/sfence.w.inval.yaml
+++ b/spec/std/isa/inst/Svinval/sfence.w.inval.yaml
@@ -21,6 +21,10 @@ access:
   u: never
   vs: sometimes
   vu: never
+access_detail: |
+  `sfence.w.inval` is accessible from M-mode, HS-mode, and VS-mode.
+  It raises `Illegal Instruction` when executed in U-mode, and
+  `Virtual Instruction` when executed in VU-mode (when the H extension is implemented).
 assembly: ""
 operation(): |
   if (mode() == PrivilegeMode::U) {

--- a/spec/std/isa/inst/Svinval/sinval.vma.yaml
+++ b/spec/std/isa/inst/Svinval/sinval.vma.yaml
@@ -27,6 +27,18 @@ access:
   u: never
   vs: sometimes
   vu: never
+access_detail: |
+  Access is controlled by `mstatus.TVM` and (when the H extension is implemented) `hstatus.VTVM`.
+
+  [%autowidth]
+  |===
+  .2+| [.rotate]#`mstatus.TVM`# .2+| [.rotate]#`hstatus.VTVM`# 4+^.>| `sinval.vma` behavior
+  h| M-mode h| S-mode h| VS-mode h| U/VU-mode
+
+  | 0 | 0 | executes | executes | executes | `Illegal`/`Virtual Instruction`
+  | 0 | 1 | executes | executes | `Virtual Instruction` | `Illegal`/`Virtual Instruction`
+  | 1 | - | executes | `Illegal Instruction` | `Illegal Instruction` | `Illegal`/`Virtual Instruction`
+  |===
 assembly: xs1, xs2
 operation(): |
   XReg vaddr = X[xs1];


### PR DESCRIPTION
Fixes #2098

### Summary of Changes

1. **Schema ()**: Added a conditional `allOf` (`if-then`) rule requiring `access_detail` whenever any mode in `access` (`m`, `s`, `u`, `vs`, `vu`) is set to `sometimes`.
2. **Data ()**: Added missing `access_detail` documentation to `sinval.vma.yaml`, `hinval.gvma.yaml`, `sfence.w.inval.yaml`, and `sfence.inval.ir.yaml`.

### Verification

- `./do test:schema` passes.
- `./do test:sorbet` passes.
- `./do test:idl CFG=_` passes.