### PR TITLE
schema(ext): reject ratification_date on non-ratified extension versions

### DIFF
--- a/doc/docs/schemas/index.mdx
+++ b/doc/docs/schemas/index.mdx
@@ -39,6 +39,11 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.2/ext_schema">Ext Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.2</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/inst_opcode_schema">Inst Opcode Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
 </div>

--- a/doc/docs/schemas/v0.2/ext_schema.mdx
+++ b/doc/docs/schemas/v0.2/ext_schema.mdx
@@ -1,0 +1,141 @@
+---
+title: Ext Schema (v0.2)
+sidebar_label: Ext Schema
+custom_edit_url: null
+# This file is auto-generated from ext_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+import AnchorOpenDetails from '@site/src/components/AnchorOpenDetails';
+
+<AnchorOpenDetails />
+
+# Ext Schema
+
+<span class="badge badge--secondary">v0.2</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`ext_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/ext_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+An ISA extension defines a named set of instructions, CSRs, and behaviors that can be implemented by a RISC-V processor. Each extension has one or more versioned releases, with various ratification states (development, frozen, public-review, ratification-ready, ratified, or nonstandard-released).
+
+## Key Fields
+
+- `name`: Short identifier used throughout the database (e.g., `I`, `M`, `Zicsr`, `Smstateen`)
+- `long_name`: Human-readable one-line description
+- `description`: Full AsciiDoc documentation of the extension
+- `type`: Whether the extension is `unprivileged` or `privileged`
+- `versions`: Array of versioned releases, each with a `state` and optional `ratification_date`
+- `requirements`: Optional condition that must be true for the extension to be implementable (e.g., requires another extension)
+- `company`: Organization that developed the extension (defaults to RISC-V International for standard extensions)
+- `doc_license`: License for the extension documentation
+
+
+## Quick Start
+
+**Minimal Extension (Zicsr):**
+```yaml
+"$schema": ext_schema.json#
+kind: extension
+name: Zicsr
+long_name: Control and status register instructions
+description: Control and status register instructions
+type: unprivileged
+versions:
+- version: 2.0.0
+  state: ratified
+  ratification_date: 2019-04
+
+```
+
+
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | `string` (const: `ext_schema.json#`) | ✓ | Schema reference - must be `ext_schema.json#` |
+| `kind` | `string` (const: `extension`) | ✓ | Document type identifier - must be `extension` |
+| `name` | Extension name (e.g., `I`, `M`, `Zicsr`, `Smstateen`) | ✓ |  |
+| `long_name` | `string` | ✓ | One-line human-readable name for the extension (e.g., `Address generation`, `Bit Manipulation`) |
+| `description` | `string` \| Array&lt;[`conditional_text`](#conditional-text)&gt; | ✓ | Full AsciiDoc documentation of the extension. May include multiple paragraphs, code examples, and cross-references. |
+| `type` | `unprivileged` \| `privileged` | ✓ | Privilege level of the extension. `unprivileged` extensions add instructions or behaviors accessible in user mode; `privileged` extensions add supervisor- or machine-mode functionality. |
+| `versions` | Array&lt;object&gt; [↓&nbsp;schema](#versions-schema) | ✓ | Ordered list of versioned releases of this extension, from oldest to newest. |
+| `rvi_jira_issue` | `string` |  | JIRA issue number tracking this extension in the RISC-V International issue tracker |
+| `company` | A company |  | Organization that developed this extension. Omit for RISC-V International standard extensions. |
+| `doc_license` | License that applies to the textual documentation for this extension |  | License for the extension documentation |
+| `requirements` | A condition (YAML structure or IDL function). See the conditions reference for details. |  | Condition that must be true for this extension to be implementable. If the condition is false, the extension cannot be implemented. Typically used to express that one extension requires another (e.g., `D` requires `F`). |
+
+<details style={{padding: '1rem', backgroundColor: 'var(--ifm-color-emphasis-100)', borderLeft: '4px solid var(--ifm-color-primary)', borderRadius: '4px', marginBottom: '1rem'}}>
+<summary style={{cursor: 'pointer', fontWeight: 'bold'}}><a id="versions-schema"></a><code>versions</code> item schema</summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `version` | `string` | ✓ | Version number in `MAJOR.MINOR.PATCH` format (e.g., `1.0.0`, `2.1.0`) |
+| `state` | `development` \| `frozen` \| `public-review` \| `ratification-ready` \| `ratified` \| `nonstandard-released` | ✓ | Ratification state of this version. See `spec_state` in schema_defs for all possible values and their meanings. |
+| `repositories` | Array&lt;object&gt; |  | Source repositories where this version of the extension is developed |
+| `ratification_date` | One of: `string` \| `string` \| `null` |  | Month when this version was ratified, in `YYYY-MM` format. Use `unknown` if the date is not recorded. Required when `state` is `ratified`. |
+| `release_date` | One of: `string` \| `string` \| `null` |  |  |
+| `changes` | Array&lt;`string`&gt; |  | List of changes introduced in this version relative to the previous version |
+| `url` | `string` |  | URL to the ratified specification document (e.g., a PDF on the RISC-V website) |
+| `contributors` | Array&lt;object&gt; |  | People who contributed to this version of the extension |
+| `requirements` | `object` \| `object` \| `object` \| `object` \| `object` \| `object` |  | Additional condition that must be true for this specific version to be implementable, beyond any requirements on the extension overall. If the condition is false, this version cannot be implemented. |
+
+</details>
+
+
+:::note Tooling field
+`$source` is an optional field set automatically by UDB tooling to record the file path this object was loaded from. You do not need to set it manually.
+:::
+
+
+## Examples
+
+<details style={{padding: '1rem', backgroundColor: 'var(--ifm-color-emphasis-100)', borderLeft: '4px solid var(--ifm-color-primary)', borderRadius: '4px', marginBottom: '1rem'}}>
+<summary style={{cursor: 'pointer', fontWeight: 'bold'}}>Extension with Requirements (B)</summary>
+
+```yaml
+"$schema": ext_schema.json#
+kind: extension
+name: B
+long_name: Bit Manipulation
+description: The B standard extension comprises instructions provided by the Zba,
+  Zbb, and Zbs extensions.
+type: unprivileged
+company:
+  name: RISC-V International
+  url: https://riscv.org
+doc_license:
+  name: Creative Commons Attribution 4.0 International License
+  url: https://creativecommons.org/licenses/by/4.0/
+versions:
+- version: 1.0.0
+  state: ratified
+  ratification_date: 2024-04
+  url: https://drive.google.com/file/d/1SgLoasaBjs5WboQMaU3wpHkjUwV71UZn/view
+  requirements:
+    extension:
+      allOf:
+      - name: Zba
+        version: "= 1.0.0"
+      - name: Zbb
+        version: "= 1.0.0"
+      - name: Zbs
+        version: "= 1.0.0"
+
+```
+
+</details>
+
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.2` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/spec/custom/isa/example/ext/Xcustom.yaml
+++ b/spec/custom/isa/example/ext/Xcustom.yaml
@@ -9,7 +9,6 @@ long_name: A new custom extension
 type: unprivileged
 versions:
   - version: "0.1.0"
-    ratification_date: unknown
     state: development
 description: |
   A new custom extension!

--- a/spec/custom/isa/qc_iu/ext/Xqccmp.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqccmp.yaml
@@ -11,7 +11,6 @@ type: unprivileged
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -31,7 +30,6 @@ versions:
       version: ">= 1.0.0"
 - version: "0.2.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -57,7 +55,6 @@ versions:
       version: ">= 1.0.0"
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqccmt.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqccmt.yaml
@@ -105,7 +105,6 @@ type: unprivileged
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqci.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqci.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm uC extensions
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -34,7 +32,6 @@ versions:
     - Removed shXadd instructions in favor of generic shladd
 - version: "0.3.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -66,7 +63,6 @@ versions:
         - { name: Xqcisls, version: "= 0.1.0" }
 - version: "0.4.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -100,7 +96,6 @@ versions:
         - { name: Xqcisls, version: "= 0.2.0" }
 - version: "0.5.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -146,7 +141,6 @@ versions:
         - { name: Xqcisync, version: "= 0.1.0" }
 - version: "0.6.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -189,7 +183,6 @@ versions:
         - { name: Xqcisync, version: "= 0.2.0" }
 - version: "0.7.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -239,7 +232,6 @@ versions:
         - { name: Xqcisync, version: "= 0.2.0" }
 - version: "0.8.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -280,7 +272,6 @@ versions:
         - { name: Xqcisync, version: "= 0.2.0" }
 - version: "0.9.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -325,7 +316,6 @@ versions:
         - { name: Xqcisync, version: "= 0.2.0" }
 - version: "0.10.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -360,7 +350,6 @@ versions:
         - { name: Xqcisync, version: "= 0.2.0" }
 - version: "0.11.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -407,7 +396,6 @@ versions:
         - { name: Xqcisync, version: "= 0.3.0" }
 - version: "0.12.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcia.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcia.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm arithmetic
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -33,7 +31,6 @@ versions:
     - Add information about instruction formats of each instruction
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -45,7 +42,6 @@ versions:
     - Fix description and functionality of qc.wrapi instruction
 - version: "0.4.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -58,7 +54,6 @@ versions:
     - Rename qc.sllsat -> qc.shlusat
 - version: "0.5.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -72,7 +67,6 @@ versions:
     - Fix clobbering of saturation results in [add|addu|sub]sat instructions
 - version: "0.6.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -85,7 +79,6 @@ versions:
     - Fix wrong exponent calculation in qc.normeu instruction
 - version: "0.7.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqciac.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqciac.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm address calculation
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -36,7 +34,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcibi.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcibi.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm branch immediate
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcibm.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcibm.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm bit manipulation
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -36,7 +34,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -50,7 +47,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.4.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -64,7 +60,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.5.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -80,7 +75,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.6.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -98,7 +92,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.7.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -116,7 +109,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.8.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcicli.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcicli.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm conditional load immediate
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -33,7 +31,6 @@ versions:
     - Add information about instruction formats of each instruction
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcicm.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcicm.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm conditional move
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcics.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcics.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm conditional select
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcicsr.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcicsr.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm CSR instructions
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -33,7 +31,6 @@ versions:
     - Add information about instruction formats of each instruction
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -45,7 +42,6 @@ versions:
     - Remove qc.flags CSR
 - version: "0.4.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqciint.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqciint.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm interrupt prologue/epilogue
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -35,7 +33,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -51,7 +48,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.4.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -75,7 +71,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.5.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -89,7 +84,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.6.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -103,7 +97,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.7.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -117,7 +110,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.8.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -133,7 +125,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.9.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -147,7 +138,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.10.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqciio.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqciio.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm Input/Output device support
 versions:
 - version: "0.1.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcilb.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcilb.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm long branch
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcili.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcili.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm long load immediate
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -23,7 +22,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcilia.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcilia.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm long load immediate
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcilo.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcilo.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm large offset load/store
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -35,7 +33,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcilsm.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcilsm.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm load/store multiple
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -33,7 +31,6 @@ versions:
     - Add information about instruction formats of each instruction
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -45,7 +42,6 @@ versions:
     - Fix description of qc.swmi, qc.lwmi and qc.setwmi instructions
 - version: "0.4.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -57,7 +53,6 @@ versions:
     - Fix encoding of qc.swmi
 - version: "0.5.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -69,7 +64,6 @@ versions:
     - Fix IDL code and description of qc.setwm instruction to state that number of words written 0..31.
 - version: "0.6.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcisim.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcisim.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm simulator support hints
 versions:
 - version: "0.1.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcisls.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcisls.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm scaled load/store
 versions:
 - version: "0.1.0"
   state: development
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/custom/isa/qc_iu/ext/Xqcisync.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqcisync.yaml
@@ -11,7 +11,6 @@ long_name: Qualcomm non-memory-mapped devices synchronization and delay
 versions:
 - version: "0.1.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -21,7 +20,6 @@ versions:
     email: dhower@qti.qualcomm.com
 - version: "0.2.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.
@@ -36,7 +34,6 @@ versions:
     extension: { name: Zca, version: ">= 1.0.0" }
 - version: "0.3.0"
   state: frozen
-  ratification_date: unknown
   contributors:
   - name: Albert Yosher
     company: Qualcomm Technologies, Inc.

--- a/spec/schemas/README.adoc
+++ b/spec/schemas/README.adoc
@@ -33,10 +33,10 @@ published as GitHub releases under the tag `schemas/<schema_name>/<version>`.
 |===
 | Version | Published URL
 
-| 0.1 (current for all schemas except csr_schema.json)
-| https://riscv.github.io/riscv-unified-db/schemas/ext_schema.json/v0.1/ext_schema.json (example)
+| 0.1 (current for all schemas except csr_schema.json and ext_schema.json)
+| https://riscv.github.io/riscv-unified-db/schemas/inst_schema.json/v0.1/inst_schema.json (example)
 
-| 0.2 (current for csr_schema.json)
+| 0.2 (current for csr_schema.json and ext_schema.json)
 | https://riscv.github.io/riscv-unified-db/schemas/csr_schema.json/v0.2/csr_schema.json
 |===
 

--- a/spec/schemas/ext_schema.json
+++ b/spec/schemas/ext_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.1",
+  "$id": "v0.2",
   "description": "An ISA extension defines a named set of instructions, CSRs, and behaviors that can be implemented by a RISC-V processor. Each extension has one or more versioned releases, with various ratification states (development, frozen, public-review, ratification-ready, ratified, or nonstandard-released).\n\n## Key Fields\n\n- `name`: Short identifier used throughout the database (e.g., `I`, `M`, `Zicsr`, `Smstateen`)\n- `long_name`: Human-readable one-line description\n- `description`: Full AsciiDoc documentation of the extension\n- `type`: Whether the extension is `unprivileged` or `privileged`\n- `versions`: Array of versioned releases, each with a `state` and optional `ratification_date`\n- `requirements`: Optional condition that must be true for the extension to be implementable (e.g., requires another extension)\n- `company`: Organization that developed the extension (defaults to RISC-V International for standard extensions)\n- `doc_license`: License for the extension documentation",
   "type": "object",
   "required": [
@@ -150,6 +150,25 @@
                     "type": "null"
                   }
                 }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "state": {
+                  "enum": [
+                    "development",
+                    "frozen",
+                    "public-review",
+                    "ratification-ready"
+                  ]
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "ratification_date": false
               }
             }
           }

--- a/spec/std/isa/ext/Sm.yaml
+++ b/spec/std/isa/ext/Sm.yaml
@@ -62,7 +62,7 @@ versions:
         `pc` to `__x__tval`.
       - Specified relaxed constraints for implicit reads of non-idempotent regions.
   - version: "1.13.0"
-    state: frozen
+    state: ratified
     ratification_date: 2023-12
     changes:
       - Redefined `misa`.MXL to be read-only, making MXLEN a constant.

--- a/tools/ruby-gems/udb/test/test_schema_versioning.rb
+++ b/tools/ruby-gems/udb/test/test_schema_versioning.rb
@@ -103,11 +103,12 @@ class TestSchemaVersioning < Minitest::Test
       resolver = make_resolver(gen_path)
       resolver.resolve_schemas
 
-      out = gen_path / "schemas" / "ext_schema.json" / "v0.1" / "ext_schema.json"
+      ext_version = JSON.parse((SCHEMAS_PATH / "ext_schema.json").read)["$id"]
+      out = gen_path / "schemas" / "ext_schema.json" / ext_version / "ext_schema.json"
       assert out.exist?
       resolved = JSON.parse(out.read)
       assert_equal(
-        "#{Udb::Resolver::SCHEMAS_BASE_URL}/ext_schema.json/v0.1/ext_schema.json",
+        "#{Udb::Resolver::SCHEMAS_BASE_URL}/ext_schema.json/#{ext_version}/ext_schema.json",
         resolved["$id"]
       )
     end
@@ -156,7 +157,8 @@ class TestSchemaVersioning < Minitest::Test
       resolver.resolve_schemas
 
       src = JSON.parse((SCHEMAS_PATH / "ext_schema.json").read)
-      out = JSON.parse((gen_path / "schemas" / "ext_schema.json" / "v0.1" / "ext_schema.json").read)
+      ext_version = src["$id"]
+      out = JSON.parse((gen_path / "schemas" / "ext_schema.json" / ext_version / "ext_schema.json").read)
 
       # All keys except $id should be preserved
       (src.keys - ["$id"]).each do |key|

--- a/tools/ruby-gems/udb/test/test_yaml_resolver.rb
+++ b/tools/ruby-gems/udb/test/test_yaml_resolver.rb
@@ -467,9 +467,12 @@ class TestYamlResolver < Minitest::Test
 
     resolver = Udb::Yaml::Resolver.new(quiet: true, schemas_path: gem_schemas)
 
+    ext_ver = JSON.parse((gem_schemas / "ext_schema.json").read)["$id"]
+    csr_ver = JSON.parse((gem_schemas / "csr_schema.json").read)["$id"]
+
     # Bare ref should get the version prefix
-    assert_equal "v0.1/ext_schema.json#", resolver.versioned_schema_uri("ext_schema.json#")
-    assert_equal "v0.2/csr_schema.json#", resolver.versioned_schema_uri("csr_schema.json#")
+    assert_equal "#{ext_ver}/ext_schema.json#", resolver.versioned_schema_uri("ext_schema.json#")
+    assert_equal "#{csr_ver}/csr_schema.json#", resolver.versioned_schema_uri("csr_schema.json#")
   end
 
   # Test that versioned_schema_uri leaves already-versioned URIs unchanged
@@ -479,7 +482,8 @@ class TestYamlResolver < Minitest::Test
 
     resolver = Udb::Yaml::Resolver.new(quiet: true, schemas_path: gem_schemas)
 
-    already_versioned = "v0.1/ext_schema.json#"
+    ext_ver = JSON.parse((gem_schemas / "ext_schema.json").read)["$id"]
+    already_versioned = "#{ext_ver}/ext_schema.json#"
     assert_equal already_versioned, resolver.versioned_schema_uri(already_versioned)
   end
 
@@ -526,8 +530,9 @@ class TestYamlResolver < Minitest::Test
     resolver.resolve_files(input_dir, output_dir, no_checks: true)
 
     resolved_content = File.read(output_dir / "Xtest.yaml")
+    ext_ver = JSON.parse((gem_schemas / "ext_schema.json").read)["$id"]
     # $schema should be rewritten to include the version prefix
-    assert_includes resolved_content, "$schema: v0.1/ext_schema.json#",
+    assert_includes resolved_content, "$schema: #{ext_ver}/ext_schema.json#",
       "Resolved file should contain versioned $schema"
     refute_includes resolved_content, "$schema: ext_schema.json#",
       "Resolved file should not contain bare (unversioned) $schema"


### PR DESCRIPTION
Added a conditional `allOf` (`if-then`) rule specifying that version entries with non-ratified states (`development`, `frozen`, `public-review`, `ratification-ready`) MUST NOT include a `ratification_date`.

Also, fixed erroneous `state` for "Sm".

Fixes #2099