### PR TITLE
schema: enforce additionalProperties: false across profile_release, inst_opcode, inst_var, and inst_var_type

### DIFF
--- a/doc/docs/schemas/index.mdx
+++ b/doc/docs/schemas/index.mdx
@@ -44,6 +44,11 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.2/inst_opcode_schema">Inst Opcode Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.2</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/inst_schema">Inst Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
 </div>
@@ -69,8 +74,18 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.2/inst_var_schema">Inst Var Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.2</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/inst_var_type_schema">Inst Var Type Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.2/inst_var_type_schema">Inst Var Type Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.2</span>
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
@@ -131,6 +146,11 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/profile_release_schema">Profile Release Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.2/profile_release_schema">Profile Release Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.2</span>
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>

--- a/doc/docs/schemas/v0.2/inst_opcode_schema.mdx
+++ b/doc/docs/schemas/v0.2/inst_opcode_schema.mdx
@@ -1,0 +1,42 @@
+---
+title: Instruction Opcode Schema (v0.2)
+sidebar_label: Instruction Opcode Schema
+custom_edit_url: null
+# This file is auto-generated from inst_opcode_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+# Instruction Opcode Schema
+
+<span class="badge badge--secondary">v0.2</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`inst_opcode_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/inst_opcode_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+Schema for instruction opcode definitions
+
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | `any` | ✓ |  |
+| `kind` | `any` | ✓ |  |
+| `data` | `object` | ✓ |  |
+| `name` | `string` |  |  |
+
+:::note Tooling field
+`$source` is an optional field set automatically by UDB tooling to record the file path this object was loaded from. You do not need to set it manually.
+:::
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.2` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/doc/docs/schemas/v0.2/inst_var_schema.mdx
+++ b/doc/docs/schemas/v0.2/inst_var_schema.mdx
@@ -1,0 +1,73 @@
+---
+title: Instruction Variable Schema (v0.2)
+sidebar_label: Instruction Variable Schema
+custom_edit_url: null
+# This file is auto-generated from inst_var_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+import AnchorOpenDetails from '@site/src/components/AnchorOpenDetails';
+
+<AnchorOpenDetails />
+
+# Instruction Variable Schema
+
+<span class="badge badge--secondary">v0.2</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`inst_var_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/inst_var_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+Schema for instruction decode variable definitions
+
+
+## Definitions
+
+<details>
+<summary><a id="fully-resolved-data"></a><strong><code>fully_resolved_data</code></strong></summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `location` | Location specifier for a field | ✓ |  |
+| `type` | `object` | ✓ |  |
+| `$parent_of` | `string` (pattern: `^.*/.*\.yaml#.*$`) \| Array&lt;[`ref_url`](#ref-url)&gt; |  |  |
+| `$child_of` | `string` (pattern: `^.*/.*\.yaml#.*$`) \| Array&lt;[`ref_url`](#ref-url)&gt; |  |  |
+
+</details>
+
+<details>
+<summary><a id="polymorphic-data"></a><strong><code>polymorphic_data</code></strong></summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `location` | Location specifier for a field |  |  |
+| `$inherits` | One of: `string` \| Array&lt;`string`&gt; |  |  |
+| `type` | `object` |  |  |
+
+</details>
+
+
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | `any` | ✓ |  |
+| `kind` | `any` | ✓ |  |
+| `name` | `string` | ✓ |  |
+| `data` | One of: [`fully_resolved_data`](#fully-resolved-data) \| [`polymorphic_data`](#polymorphic-data) | ✓ |  |
+
+:::note Tooling field
+`$source` is an optional field set automatically by UDB tooling to record the file path this object was loaded from. You do not need to set it manually.
+:::
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.2` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/doc/docs/schemas/v0.2/inst_var_type_schema.mdx
+++ b/doc/docs/schemas/v0.2/inst_var_type_schema.mdx
@@ -1,0 +1,35 @@
+---
+title: Instruction Variable Type Schema (v0.2)
+sidebar_label: Instruction Variable Type Schema
+custom_edit_url: null
+# This file is auto-generated from inst_var_type_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+# Instruction Variable Type Schema
+
+<span class="badge badge--secondary">v0.2</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`inst_var_type_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/inst_var_type_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+Schema for instruction variable type definitions
+
+
+## Schema Structure
+
+This schema requires **all of** the following:
+
+- (Complex type)
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.2` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/doc/docs/schemas/v0.2/profile_release_schema.mdx
+++ b/doc/docs/schemas/v0.2/profile_release_schema.mdx
@@ -1,0 +1,85 @@
+---
+title: Profile Release Schema (v0.2)
+sidebar_label: Profile Release Schema
+custom_edit_url: null
+# This file is auto-generated from profile_release_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+import AnchorOpenDetails from '@site/src/components/AnchorOpenDetails';
+
+<AnchorOpenDetails />
+
+# Profile Release Schema
+
+<span class="badge badge--secondary">v0.2</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`profile_release_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/profile_release_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | `any` | ✓ |  |
+| `kind` | `any` | ✓ |  |
+| `name` | `string` | ✓ | Name (database key) of this Profile Release |
+| `long_name` | `string` | ✓ | One line description of this Profile Release |
+| `description` | `string` \| Array&lt;[`conditional_text`](#conditional-text)&gt; | ✓ | Asciidoc text containing longer description prose for the release |
+| `marketing_name` | `string` |  | The publicly displayed marketing name for this release |
+| `family` | `object` |  | Reference to the profile family this release belongs to |
+| `release` | `integer` |  | Release number (e.g., 20, 22, 23) |
+| `base` | One of: `integer` \| `null` |  | Base ISA XLEN, or null if unconstrained |
+| `state` | Ratification state of a specification or extension version: `development` (actively being worked on), `frozen` (feature-complete, under review), `public-review` (open for public comment), `ratification-ready` (approved by the task group, awaiting board vote), `ratified` (officially approved by RISC-V International), or `nonstandard-released` (released but not part of the RISC-V standard). |  | Ratification state of this release |
+| `ratification_date` | A specific day in YYYY-MM-DD format |  | Date when this profile release was ratified |
+| `versions` | Array&lt;\{`version`\}&gt; [↓&nbsp;schema](#versions-schema) |  | Versions of this profile release |
+| `introduction` | `string` |  | Asciidoc text containing the introduction prose for the release |
+| `contributors` | Array&lt;\{`name`, `email`, `company`\}&gt; [↓&nbsp;schema](#contributors-schema) |  | People who contributed to this profile release |
+| `profiles` | Array&lt;\{`$ref`\}&gt; [↓&nbsp;schema](#profiles-schema) |  | List of profiles included in this release |
+
+<details style={{padding: '1rem', backgroundColor: 'var(--ifm-color-emphasis-100)', borderLeft: '4px solid var(--ifm-color-primary)', borderRadius: '4px', marginBottom: '1rem'}}>
+<summary style={{cursor: 'pointer', fontWeight: 'bold'}}><a id="versions-schema"></a><code>versions</code> item schema</summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `version` | `string` | ✓ | Version string |
+
+</details>
+
+<details style={{padding: '1rem', backgroundColor: 'var(--ifm-color-emphasis-100)', borderLeft: '4px solid var(--ifm-color-primary)', borderRadius: '4px', marginBottom: '1rem'}}>
+<summary style={{cursor: 'pointer', fontWeight: 'bold'}}><a id="contributors-schema"></a><code>contributors</code> item schema</summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | ✓ | Contributor name |
+| `email` | `string` |  | Contributor email address |
+| `company` | `string` |  | Company or organization name |
+
+</details>
+
+<details style={{padding: '1rem', backgroundColor: 'var(--ifm-color-emphasis-100)', borderLeft: '4px solid var(--ifm-color-primary)', borderRadius: '4px', marginBottom: '1rem'}}>
+<summary style={{cursor: 'pointer', fontWeight: 'bold'}}><a id="profiles-schema"></a><code>profiles</code> item schema</summary>
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$ref` | `string` | ✓ |  |
+
+</details>
+
+
+:::note Tooling field
+`$source` is an optional field set automatically by UDB tooling to record the file path this object was loaded from. You do not need to set it manually.
+:::
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.2` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/spec/schemas/inst_opcode_schema.json
+++ b/spec/schemas/inst_opcode_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.1",
+  "$id": "v0.2",
   "title": "Instruction Opcode Schema",
   "description": "Schema for instruction opcode definitions",
   "type": "object",
@@ -32,6 +32,11 @@
           "$ref": "schema_defs.json#/$defs/ref_url_list"
         }
       }
+    },
+    "$source": {
+      "type": "string",
+      "description": "Path to the source file containing this object"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/spec/schemas/inst_var_schema.json
+++ b/spec/schemas/inst_var_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.1",
+  "$id": "v0.2",
   "title": "Instruction Variable Schema",
   "description": "Schema for instruction decode variable definitions",
   "$defs": {
@@ -88,6 +88,11 @@
           "$ref": "#/$defs/polymorphic_data"
         }
       ]
+    },
+    "$source": {
+      "type": "string",
+      "description": "Path to the source file containing this object"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/spec/schemas/inst_var_type_schema.json
+++ b/spec/schemas/inst_var_type_schema.json
@@ -1,10 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.1",
+  "$id": "v0.2",
   "title": "Instruction Variable Type Schema",
   "description": "Schema for instruction variable type definitions",
   "type": "object",
-  "unevaluatedProperties": false,
   "required": ["$schema", "kind", "name", "type"],
   "properties": {
     "$schema": {
@@ -18,8 +17,20 @@
     },
     "type": {
       "enum": ["register_reference", "immediate"]
+    },
+    "register_file": {
+      "enum": ["X", "F", "V"]
+    },
+    "access": {
+      "enum": ["R", "W", "RW"],
+      "description": "Register access type: R - Read only (src) , W - Write only (dst), RW - Read/write (srcdst)"
+    },
+    "$source": {
+      "type": "string",
+      "description": "Path to the source file containing this object"
     }
   },
+  "additionalProperties": false,
   "allOf": [
     {
       "if": {
@@ -30,15 +41,7 @@
         }
       },
       "then": {
-        "properties": {
-          "register_file": {
-            "enum": ["X", "F", "V"]
-          },
-          "access": {
-            "enum": ["R", "W", "RW"],
-            "description": "Register access type: R - Read only (src) , W - Write only (dst), RW - Read/write (srcdst)"
-          }
-        }
+        "required": ["register_file", "access"]
       }
     }
   ]

--- a/spec/schemas/profile_release_schema.json
+++ b/spec/schemas/profile_release_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.1",
+  "$id": "v0.2",
   "type": "object",
   "required": ["$schema", "kind", "name", "long_name", "description"],
   "properties": {
@@ -17,6 +17,112 @@
     "long_name": {
       "type": "string",
       "description": "One line description of this Profile Release"
+    },
+    "marketing_name": {
+      "type": "string",
+      "description": "The publicly displayed marketing name for this release"
+    },
+    "family": {
+      "description": "Reference to the profile family this release belongs to",
+      "type": "object",
+      "required": ["$ref"],
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "pattern": "^profile_family/.*#$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "release": {
+      "type": "integer",
+      "description": "Release number (e.g., 20, 22, 23)"
+    },
+    "base": {
+      "description": "Base ISA XLEN, or null if unconstrained",
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "state": {
+      "$ref": "schema_defs.json#/$defs/spec_state",
+      "description": "Ratification state of this release"
+    },
+    "ratification_date": {
+      "$ref": "schema_defs.json#/$defs/date",
+      "description": "Date when this profile release was ratified"
+    },
+    "versions": {
+      "description": "Versions of this profile release",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["version"],
+        "properties": {
+          "version": {
+            "$ref": "schema_defs.json#/$defs/extension_version",
+            "description": "Version string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "introduction": {
+      "type": "string",
+      "description": "Asciidoc text containing the introduction prose for the release"
+    },
+    "description": {
+      "$ref": "schema_defs.json#/$defs/spec_text",
+      "description": "Asciidoc text containing longer description prose for the release"
+    },
+    "contributors": {
+      "description": "People who contributed to this profile release",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Contributor name"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Contributor email address"
+          },
+          "company": {
+            "type": "string",
+            "description": "Company or organization name"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "profiles": {
+      "description": "List of profiles included in this release",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["$ref"],
+        "properties": {
+          "$ref": {
+            "type": "string",
+            "pattern": "^profile/.*#$"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "$source": {
+      "type": "string",
+      "description": "Path to the source file containing this object"
     }
-  }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
## What
Enforce `additionalProperties: false` and document `$source` properties across 4 core JSON schema files:
1. `profile_release_schema.json`: Added definitions for all 11 properties used across all 5 profile release files (`marketing_name`, `family`, `release`, `base`, `state`, `ratification_date`, `versions`, `introduction`, `description`, `contributors`, `profiles`, `$source`) and enforced `additionalProperties: false` at top-level and in nested item schemas (`family`, `versions`, `contributors`, `profiles`).
2. `inst_opcode_schema.json`: Enforced `additionalProperties: false` and added `$source`.
3. `inst_var_schema.json`: Enforced `additionalProperties: false` and added `$source`.
4. `inst_var_type_schema.json`: Replaced invalid Draft 2019-09 `unevaluatedProperties: false` with Draft-07 compatible `additionalProperties: false` and added `$source`.

Regenerated schema documentation for `profile_release_schema.mdx`, `inst_opcode_schema.mdx`, and `inst_var_schema.mdx`.

## Why
Issue #817 requests adding `additionalProperties: false` across JSON schema files to prevent undocumented keys in data files. `profile_release_schema.json` declared only 4 of the 15 real properties used across all 5 profile release YAML files (`RVA20.yaml`, `RVA22.yaml`, `RVA23.yaml`, `RVB23.yaml`, `RVI20.yaml`), so enforcing `additionalProperties: false` without first documenting those fields would break schema validation. Similarly, several instruction schemas lacked top-level `additionalProperties: false` or used draft-incompatible keywords.

## How
1. Added full property schemas in `profile_release_schema.json` matching reference patterns in `profile_family_schema.json` and `ext_schema.json`.
2. Added `additionalProperties: false` to top-level schemas and nested object schemas.
3. Updated `inst_var_type_schema.json` to use Draft-07 compatible keywords.
4. Ran `./bin/chore gen -f schema-docs` to update generated `.mdx` documentation.

## Testing
- `./do test:schema`: 100% Passed ("All files validate against their schema")
- `./do test:sorbet`: 100% Passed ("No errors! Great job.")
- `./do test:profile_extensions`: 100% Passed
- `./do test:idl CFG=rv64`: 100% Passed
- `./do test:idl CFG=qc_iu`: 100% Passed
- `./bin/pre-commit`: 100% Passed

Partially addresses #817.
