### PR TITLE
fix(generators): fail loudly when resolved exception codes cannot be loaded

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -314,6 +314,16 @@ jobs:
       - name: Run tools/scripts unit tests
         run: ./bin/ruby -Itools/scripts tools/scripts/test/run.rb
 
+  regress-generators-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Github Repo Action
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up mise environment
+        uses: ./.github/actions/mise-setup
+      - name: Run backends/generators unit tests
+        run: uv run pytest backends/generators/test_generator.py
+
   regress-idlc-unit:
     runs-on: ubuntu-latest
     steps:
@@ -951,6 +961,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - regress-scripts-unit
+      - regress-generators-unit
       - regress-idlc-unit
       - regress-udb-helpers-unit
       - regress-udb-gen-unit

--- a/backends/generators/c_header/generate_encoding.py
+++ b/backends/generators/c_header/generate_encoding.py
@@ -237,13 +237,7 @@ def main():
     )
 
     # Load exception codes
-    logging.info(f"Loading exception codes from {args.ext_dir}")
-    causes = load_exception_codes(
-        args.ext_dir,
-        args.extensions,
-        include_all=args.include_all,
-        resolved_codes_file=args.resolved_codes,
-    )
+    causes = load_exception_codes(args.resolved_codes)
 
     # Process instructions and calculate masks
     instr_dict = {}

--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -488,10 +488,13 @@ def load_csrs(csr_root, enabled_extensions, include_all=False, target_arch="RV64
 def load_exception_codes(resolved_codes_file):
     """Load exception codes from a pre-resolved JSON file.
 
-    Exception code names in the raw YAML contain unresolved ERB templates, so they
-    must be resolved by the Ruby side first (see with_resolved_exception_codes in
-    backends/generators/tasks.rake). There is deliberately no fallback to reading
-    the YAML directly: it emitted identifiers containing literal template markers.
+    The file is a temporary Ruby-to-Python handoff, written by
+    with_resolved_exception_codes in backends/generators/tasks.rake and unlinked as
+    soon as the generator exits. It is never checked in. Only the Ruby side holds a
+    cfg_arch, which is what decides *which* codes apply to the configuration (the
+    defined_by_condition filtering in Extension#exception_codes) and renders any ERB
+    in a code name. Reading spec/std/isa/exception_code/*.yaml here instead would
+    skip both steps, so there is deliberately no fallback to the raw YAML.
 
     Raises ValueError if the file is missing or cannot be parsed, so a broken
     exception code list fails the build instead of silently generating none.

--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -485,57 +485,37 @@ def load_csrs(csr_root, enabled_extensions, include_all=False, target_arch="RV64
     return csrs
 
 
-def load_exception_codes(
-    ext_dir, enabled_extensions=None, include_all=False, resolved_codes_file=None
-):
-    """Load exception codes from extension YAML files or pre-resolved JSON file."""
+def load_exception_codes(resolved_codes_file):
+    """Load exception codes from a pre-resolved JSON file.
+
+    Exception code names in the raw YAML contain unresolved ERB templates, so they
+    must be resolved by the Ruby side first (see with_resolved_exception_codes in
+    backends/generators/tasks.rake). There is deliberately no fallback to reading
+    the YAML directly: it emitted identifiers containing literal template markers.
+
+    Raises ValueError if the file is missing or cannot be parsed, so a broken
+    exception code list fails the build instead of silently generating none.
+    """
+    if not resolved_codes_file:
+        raise ValueError("A resolved exception codes file is required (--resolved-codes)")
+
+    try:
+        with open(resolved_codes_file, encoding="utf-8") as f:
+            resolved_codes = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        raise ValueError(f"Could not load resolved exception codes from {resolved_codes_file}: {e}")
+
     exception_codes = []
-    found_extensions = 0
-    found_files = 0
+    for code in resolved_codes:
+        num = code.get("num")
+        name = code.get("name")
+        if num is not None and name is not None:
+            sanitized_name = name.lower().replace(" ", "_").replace("/", "_").replace("-", "_")
+            exception_codes.append((num, sanitized_name))
 
-    if enabled_extensions is None:
-        enabled_extensions = []
-    # If we have a resolved codes file, use it instead of processing YAML files
-    if resolved_codes_file and os.path.exists(resolved_codes_file):
-        try:
-            with open(resolved_codes_file, encoding="utf-8") as f:
-                resolved_codes = json.load(f)
-
-            for code in resolved_codes:
-                num = code.get("num")
-                name = code.get("name")
-                if num is not None and name is not None:
-                    sanitized_name = (
-                        name.lower().replace(" ", "_").replace("/", "_").replace("-", "_")
-                    )
-                    exception_codes.append((num, sanitized_name))
-
-            logging.info(
-                f"Loaded {len(exception_codes)} pre-resolved exception codes from {resolved_codes_file}"
-            )
-
-            # Sort by exception code number and deduplicate
-            seen_nums = set()
-            unique_codes = []
-            for num, name in sorted(exception_codes, key=lambda x: x[0]):
-                if num not in seen_nums:
-                    seen_nums.add(num)
-                    unique_codes.append((num, name))
-
-            return unique_codes
-
-        except Exception as e:
-            logging.error(f"Error loading resolved codes file {resolved_codes_file}: {e}")
-    # Logging an error and skipping the exception cause generation if no resolved codes file found
-    else:
-        logging.error(f"Resolved codes file not found: {resolved_codes_file}")
-        return
-
-    if found_extensions > 0:
-        logging.info(f"Found {found_extensions} extension definitions in {found_files} files")
-        logging.info(f"Added {len(exception_codes)} exception codes to the output")
-    else:
-        logging.warning(f"No extension definitions found in {ext_dir}")
+    logging.info(
+        f"Loaded {len(exception_codes)} pre-resolved exception codes from {resolved_codes_file}"
+    )
 
     # Sort by exception code number and deduplicate
     seen_nums = set()

--- a/backends/generators/sverilog/sverilog_generator.py
+++ b/backends/generators/sverilog/sverilog_generator.py
@@ -177,12 +177,7 @@ def main():
     logging.info(f"Loaded {len(csrs)} CSRs")
 
     # Load exception codes
-    causes = load_exception_codes(
-        args.ext_dir,
-        args.extensions,
-        include_all=args.include_all,
-        resolved_codes_file=args.resolved_codes,
-    )
+    causes = load_exception_codes(args.resolved_codes)
     logging.info(f"Loaded {len(causes)} exception codes")
 
     # Generate the SystemVerilog file

--- a/backends/generators/test_generator.py
+++ b/backends/generators/test_generator.py
@@ -1,0 +1,55 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""Tests for backends/generators/generator.py."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from generator import load_exception_codes
+
+
+def test_loads_and_sanitizes_codes(tmp_path):
+    codes_file = tmp_path / "codes.json"
+    codes_file.write_text(
+        json.dumps(
+            [
+                {"num": 9, "name": "Environment Call from HS-mode"},
+                {"num": 8, "name": "Environment Call from VU/U-mode"},
+                {"num": 8, "name": "Duplicate that should be dropped"},
+            ]
+        )
+    )
+
+    assert load_exception_codes(str(codes_file)) == [
+        (8, "environment_call_from_vu_u_mode"),
+        (9, "environment_call_from_hs_mode"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "make_arg",
+    [
+        pytest.param(lambda tmp_path: None, id="none"),
+        pytest.param(lambda tmp_path: "", id="empty"),
+        pytest.param(lambda tmp_path: str(tmp_path / "does_not_exist.json"), id="missing"),
+        pytest.param(lambda tmp_path: str(_write(tmp_path / "bad.json", "not json")), id="corrupt"),
+    ],
+)
+def test_raises_instead_of_returning_empty(tmp_path, make_arg):
+    """A missing or unparseable file must fail loudly, not yield zero exception codes.
+
+    Returning an empty list here silently generates a header with no CAUSE_* entries.
+    """
+    with pytest.raises(ValueError):
+        load_exception_codes(make_arg(tmp_path))
+
+
+def _write(path, text):
+    path.write_text(text)
+    return path

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -14,6 +14,15 @@ tests:
       - name: Run tools/scripts unit tests
         run: ./bin/ruby -Itools/scripts tools/scripts/test/run.rb
 
+  regress-generators-unit:
+    ci_stage: pr
+    tags:
+      - unit
+      - smoke
+    test:
+      - name: Run backends/generators unit tests
+        run: uv run pytest backends/generators/test_generator.py
+
   regress-idlc-unit:
     ci_stage: pr
     tags:


### PR DESCRIPTION
Closes #2111

`load_exception_codes` wrapped the resolved-codes JSON parsing in a bare `except Exception` that logged the error and did not re-raise. Execution then fell through into code left over from when the raw YAML fallback was removed in #1233. That trailing block is unreachable on the success and missing-file paths, but the parse-failure path reached it and returned the still-empty `exception_codes` list. The result was a generated header or SystemVerilog package with zero `CAUSE_*` definitions, exit code 0, and only an ERROR line in the log.

This raises `ValueError` for both the missing and the unparseable case, and deletes the unreachable block. The missing-file case previously returned `None`, which showed up as `TypeError: object of type 'NoneType' has no len()` in the caller rather than a clear message; it is the same root cause and the same few lines, so it is fixed here too.

`ext_dir`, `enabled_extensions` and `include_all` are gone from the signature since only the deleted code referenced them. The `--ext-dir` CLI flags are untouched.

This does not change the fallback behavior discussed in #1145, which was already removed in #1233.

## Testing

Added `backends/generators/test_generator.py` and a `regress-generators-unit` target that runs it. It covers the happy path plus four ways the load can fail: `None`, empty string, missing file, and corrupt JSON.

To confirm the test actually catches this regression, I reintroduced the old swallow-and-return-empty behavior and re-ran it. All four failure cases failed with `Failed: DID NOT RAISE ValueError`, and the happy-path test still passed. Restoring the fix returned all 5 to green.

End to end, with the fix applied, running `sverilog_generator.py` with `--resolved-codes` omitted and again with a deliberately corrupt JSON file both abort with a clear `ValueError` and write no output file. Previously the first crashed with a `TypeError` and the second silently emitted a package with no exception causes.

Ran locally, all passing:

- `./bin/regress -n regress-generators-unit`
- `./bin/regress -n regress-gen-sverilog`
- `./bin/regress -n regress-gen-c-header`
- `./bin/regress -n regress-gen-go`
- `./bin/regress -n regress-sorbet`
- `./bin/prek run --files` on all changed files

`.github/workflows/regress.yml` is regenerated by the `generate regress.yml` hook because of the new target; I did not hand-edit it.

I did not run `./bin/regress --all`, since some targets need Linux-only binaries that are unavailable on macOS.
