### PR TITLE
schema(param,inst): require 'name' property in param_schema and inst_opcode_schema

### DIFF
--- a/doc/docs/schemas/v0.1/inst_opcode_schema.mdx
+++ b/doc/docs/schemas/v0.1/inst_opcode_schema.mdx
@@ -26,8 +26,8 @@ Schema for instruction opcode definitions
 |----------|------|----------|-------------|
 | `$schema` | `any` | ✓ |  |
 | `kind` | `any` | ✓ |  |
+| `name` | `string` | ✓ |  |
 | `data` | `object` | ✓ |  |
-| `name` | `string` |  |  |
 
 
 ## Schema Information

--- a/doc/docs/schemas/v0.1/param_schema.mdx
+++ b/doc/docs/schemas/v0.1/param_schema.mdx
@@ -24,11 +24,11 @@ This page is generated from [`param_schema.json`](https://github.com/riscv/riscv
 |----------|------|----------|-------------|
 | `$schema` | `any` | ✓ |  |
 | `kind` | `any` | ✓ |  |
+| `name` | `string` (pattern: `^[A-Z][A-Z_0-9]*$`) | ✓ |  |
 | `long_name` | `string` | ✓ | Short description of the parameter |
 | `description` | `string` \| Array&lt;[`conditional_text`](#conditional-text)&gt; | ✓ | Parameter description, including list of valid values |
 | `definedBy` | A condition (YAML structure or IDL function). See the conditions reference for details. | ✓ | Extension requirement condition that must be met for parameter to exist. The condition that the defining extension is implemented is implicit, and does not need to be explicitly listed |
 | `schema` | [`json-schema-draft-07`](http://json-schema.org/draft-07/schema#) | ✓ |  |
-| `name` | `string` (pattern: `^[A-Z][A-Z_0-9]*$`) |  |  |
 | `requirements` | A condition (YAML structure or IDL function). See the conditions reference for details. |  |  |
 
 :::note Tooling field

--- a/spec/schemas/inst_opcode_schema.json
+++ b/spec/schemas/inst_opcode_schema.json
@@ -4,7 +4,7 @@
   "title": "Instruction Opcode Schema",
   "description": "Schema for instruction opcode definitions",
   "type": "object",
-  "required": ["$schema", "kind", "data"],
+  "required": ["$schema", "kind", "name", "data"],
   "properties": {
     "$schema": {
       "const": "inst_opcode_schema.json#"

--- a/spec/schemas/param_schema.json
+++ b/spec/schemas/param_schema.json
@@ -5,6 +5,7 @@
   "required": [
     "$schema",
     "kind",
+    "name",
     "description",
     "long_name",
     "definedBy",


### PR DESCRIPTION
### Problem
In `spec/schemas/param_schema.json` and `spec/schemas/inst_opcode_schema.json`, the `name` property is defined under `properties` (`schema_defs.json#/$defs/param_name` and `type: string` respectively), but was accidentally omitted from the top-level `required` array.

As a result, a parameter or instruction opcode YAML file that omitted the `name` field would pass schema validation without an error.

### Solution
Add `"name"` to the `required` properties array in both `param_schema.json` and `inst_opcode_schema.json`.

### Impact & Relevance to Parameter Infrastructure
All 228 parameter files in `spec/std/isa/param/` and 2 instruction opcode files in `spec/std/isa/inst_opcode/` already specify `name`. Enforcing this in the schema prevents future parameter definitions from omitting identifier metadata during automated validation and AI-assisted parameter extraction workflows.

### Verification
- Ran `./do test:schema` — all 228 parameter files and architecture files validate 100% cleanly.
- Pre-commit JSON schema validation and linters passed cleanly.