### PR TITLE
fix(udb): default PartialConfig param_values to an empty Hash

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/config.rb
+++ b/tools/ruby-gems/udb/lib/udb/config.rb
@@ -238,7 +238,7 @@ module Udb
     def initialize(data, info)
       super(data, info)
 
-      @param_values = @data.key?("params") ? @data["params"] : [].freeze
+      @param_values = @data.key?("params") ? @data["params"] : {}.freeze
 
       @mxlen = @data.dig("params", "MXLEN")
 


### PR DESCRIPTION
`Udb::PartialConfig#param_values` returns an empty **Array** (`[].freeze`)
instead of an empty **Hash** when a partially configured config has no `params`
key. `param_values` is declared as `Hash<String, ParamValueType>` on the abstract
base (`AbstractConfig#param_values`) and is consumed as a Hash everywhere.

Make the empty default a Hash (`{}.freeze`).

Closes #2116