### PR TITLE
fix: don't report success when asciidoctor-pdf fails in ext-doc

### DIFF
--- a/tools/ruby-gems/udb-gen/lib/udb-gen/generators/ext_doc/generator.rb
+++ b/tools/ruby-gems/udb-gen/lib/udb-gen/generators/ext_doc/generator.rb
@@ -187,7 +187,9 @@ module UdbGen
       ].join(" ")
 
       Udb.logger.debug cmd
-      system cmd
+      unless system(cmd)
+        exit_with(:software_error, "asciidoctor-pdf failed while generating #{pdf_filename}")
+      end
 
       puts "SUCCESS! Wrote result to #{pdf_filename}"
     end


### PR DESCRIPTION
`gen_pdf` ignored the return value of `system`, so it printed `SUCCESS! Wrote result to ...` even when asciidoctor-pdf exited non-zero and produced no PDF. The log in #1781 shows exactly this: `asciidoctor: FAILED: 'idl_highlighter' could not be loaded` immediately followed by `SUCCESS!`.

Now the generator exits with a software error and a clear message instead.

Verified locally:
- normal `ext-doc` generation still produces a PDF and prints `SUCCESS!`
- forcing asciidoctor-pdf to fail (by adding an unloadable `-r` library) exits 70 with `asciidoctor-pdf failed while generating <path>` and no `SUCCESS!` line

Relates to #1781
