### PR TITLE
fix(csr): correct misplaced CSR index variable in mhpmcounterNh

### DIFF
--- a/spec/std/isa/csr/Zihpm/mhpmcounter10h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter10h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT10[63:32]
+    alias: mhpmcounter10.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter11h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter11h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT11[63:32]
+    alias: mhpmcounter11.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter12h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter12h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT12[63:32]
+    alias: mhpmcounter12.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter13h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter13h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT13[63:32]
+    alias: mhpmcounter13.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter14h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter14h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT14[63:32]
+    alias: mhpmcounter14.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter15h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter15h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT15[63:32]
+    alias: mhpmcounter15.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter16h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter16h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT16[63:32]
+    alias: mhpmcounter16.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter17h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter17h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT17[63:32]
+    alias: mhpmcounter17.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter18h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter18h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT18[63:32]
+    alias: mhpmcounter18.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter19h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter19h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT19[63:32]
+    alias: mhpmcounter19.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter20h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter20h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT20[63:32]
+    alias: mhpmcounter20.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter21h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter21h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT21[63:32]
+    alias: mhpmcounter21.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter22h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter22h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT22[63:32]
+    alias: mhpmcounter22.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter23h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter23h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT23[63:32]
+    alias: mhpmcounter23.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter24h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter24h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT24[63:32]
+    alias: mhpmcounter24.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter25h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter25h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT25[63:32]
+    alias: mhpmcounter25.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter26h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter26h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT26[63:32]
+    alias: mhpmcounter26.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter27h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter27h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT27[63:32]
+    alias: mhpmcounter27.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter28h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter28h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT28[63:32]
+    alias: mhpmcounter28.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter29h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter29h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT29[63:32]
+    alias: mhpmcounter29.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter30h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter30h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT30[63:32]
+    alias: mhpmcounter30.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter31h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter31h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT31[63:32]
+    alias: mhpmcounter31.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter3h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter3h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT3[63:32]
+    alias: mhpmcounter3.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter4h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter4h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT4[63:32]
+    alias: mhpmcounter4.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter5h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter5h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT5[63:32]
+    alias: mhpmcounter5.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter6h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter6h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT6[63:32]
+    alias: mhpmcounter6.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter7h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter7h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT7[63:32]
+    alias: mhpmcounter7.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter8h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter8h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT8[63:32]
+    alias: mhpmcounter8.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounter9h.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter9h.yaml
@@ -74,7 +74,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT9[63:32]
+    alias: mhpmcounter9.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |

--- a/spec/std/isa/csr/Zihpm/mhpmcounterNh.layout
+++ b/spec/std/isa/csr/Zihpm/mhpmcounterNh.layout
@@ -72,7 +72,7 @@ definedBy:
 fields:
   COUNT:
     location: 31-0
-    alias: mhpmcounter.COUNT<%= hpm_num %>[63:32]
+    alias: mhpmcounter<%= hpm_num %>.COUNT[63:32]
     description: |
       Upper bits of counter.
     type(): |


### PR DESCRIPTION
`mhpmcounter<n>h.COUNT` declared its alias as `mhpmcounter.COUNT<n>[63:32]`, which resolves to nothing: there is no CSR named `mhpmcounter`, and `mhpmcounter<n>` has no field called `COUNT<n>`. The counter index had moved out of the CSR name into the field name. Correct form is `mhpmcounter<n>.COUNT[63:32]`.

The `sw_read()` two lines below returns `read_hpm_counter(<n>)[63:32]`, and the sibling layouts `hpmcounterNh` and `mhpmeventNh` both use `<csr>.<field>`, so the intended target is unambiguous. Fixed in the layout and regenerated the 29 `mhpmcounter{3..31}h.yaml` files.