### PR TITLE
fix(param): constrain ELEN to power-of-two element widths

### DIFF
--- a/spec/std/isa/param/ELEN.yaml
+++ b/spec/std/isa/param/ELEN.yaml
@@ -8,13 +8,35 @@ kind: parameter
 name: ELEN
 description: |
   The maximum size in bits of a vector element that any operation can produce or consume.
-long_name: TODO
+long_name: maximum vector element bit width
 schema:
+  description: |
+    An unsigned power of 2 that is at least 8. The ISA states no maximum; the
+    absolute upper bound is (max VLEN) * (#VRs) = 64Ki * 32 = 2Mi, since an
+    element cannot exceed the total vector register state.
   type: integer
-#    requirements:
-#      idl(): |
-#        -> (ELEN >='h8) && (popcount(ELEN) == 1);
-#      reason: ELEN >= 8, which must be a power of 2.
+  enum:
+    [
+      0x8,
+      0x10,
+      0x20,
+      0x40,
+      0x80,
+      0x100,
+      0x200,
+      0x400,
+      0x800,
+      0x1000,
+      0x2000,
+      0x4000,
+      0x8000,
+      0x10000,
+      0x20000,
+      0x40000,
+      0x80000,
+      0x100000,
+      0x200000,
+    ]
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/param/VLEN.yaml
+++ b/spec/std/isa/param/VLEN.yaml
@@ -8,15 +8,24 @@ kind: parameter
 name: VLEN
 description: |
   The number of bits in a single vector register.
-long_name: TODO
+long_name: vector register bit width
 schema:
   type: integer
-  minimum: 32
-  maximum: 65536
-#    requirements:
-#      idl(): |
-#        -> (VLEN >= ELEN) && (VLEN <='h10000) && (popcount(VLEN) == 1);
-#      reason: VLEN >= ELEN, which must be a power of 2, and must be no greater than 2^16.
+  enum:
+    [
+      0x20,
+      0x40,
+      0x80,
+      0x100,
+      0x200,
+      0x400,
+      0x800,
+      0x1000,
+      0x2000,
+      0x4000,
+      0x8000,
+      0x10000,
+    ]
 definedBy:
   extension:
     name: Zvl32b


### PR DESCRIPTION
ELEN was declared as a bare `type: integer`, so any value validated, including 0, 7 and negatives. VLEN used `minimum: 32` / `maximum: 65536`, which admitted every non-power-of-two in between. Both quantities are powers of two.

Both now use explicit hex power-of-two enums, matching the convention already used by MTVEC_BASE_ALIGNMENT_DIRECT. ELEN runs 0x8 to 0x200000, the theoretical maximum of (max VLEN) * (#VRs) = 64Ki * 32, since the ISA states no maximum for ELEN itself. VLEN runs 0x20 to 0x10000.

This also retires the commented-out `requirements` block in each file. Neither could be enabled as written: they call `popcount`, which does not exist in the IDL, and they are indented inside `schema:`, so uncommenting them is a YAML parse error. The `VLEN >= ELEN` constraint in VLEN's block was additionally incorrect, since the spec explicitly admits ELEN > VLEN with an element held across multiple vector registers.

Closes #2170