### PR TITLE
fix(schema): enforce draft-07 keyword allowlist on param schema blocks

### DIFF
--- a/doc/docs/schemas/index.mdx
+++ b/doc/docs/schemas/index.mdx
@@ -109,6 +109,11 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.2/param_schema">Param Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.2</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/prm_schema">Prm Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
 </div>

--- a/doc/docs/schemas/v0.2/param_schema.mdx
+++ b/doc/docs/schemas/v0.2/param_schema.mdx
@@ -1,0 +1,44 @@
+---
+title: Param Schema (v0.2)
+sidebar_label: Param Schema
+custom_edit_url: null
+# This file is auto-generated from param_schema.json
+# Do not edit manually - run `bin/chore gen schema-docs` to regenerate
+---
+
+
+# Param Schema
+
+<span class="badge badge--secondary">v0.2</span>
+
+<br />
+
+:::note Auto-generated
+This page is generated from [`param_schema.json`](https://github.com/riscv/riscv-unified-db/blob/main/spec/schemas/param_schema.json) by the [schema doc generator](https://github.com/riscv/riscv-unified-db/blob/main/tools/internal-gems/schema_doc_gen/lib/schema_doc_gen.rb). To update this page, edit the schema file and run `bin/chore gen schema-docs`.
+:::
+
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | `any` | ✓ |  |
+| `kind` | `any` | ✓ |  |
+| `long_name` | `string` | ✓ | Short description of the parameter |
+| `description` | `string` \| Array&lt;[`conditional_text`](#conditional-text)&gt; | ✓ | Parameter description, including list of valid values |
+| `definedBy` | A condition (YAML structure or IDL function). See the conditions reference for details. | ✓ | Extension requirement condition that must be met for parameter to exist. The condition that the defining extension is implemented is implicit, and does not need to be explicitly listed |
+| `schema` | `any` | ✓ |  |
+| `name` | `string` (pattern: `^[A-Z][A-Z_0-9]*$`) |  |  |
+| `requirements` | A condition (YAML structure or IDL function). See the conditions reference for details. |  |  |
+
+:::note Tooling field
+`$source` is an optional field set automatically by UDB tooling to record the file path this object was loaded from. You do not need to set it manually.
+:::
+
+
+## Schema Information
+
+| Property | Value |
+|----------|-------|
+| Version | `v0.2` |
+| JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/spec/schemas/param_schema.json
+++ b/spec/schemas/param_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.1",
+  "$id": "v0.2",
   "type": "object",
   "required": [
     "$schema",
@@ -33,8 +33,62 @@
       "$ref": "schema_defs.json#/$defs/condition"
     },
     "schema": {
-      "$ref": "json-schema-draft-07.json#",
-      "additionalProperties": false
+      "allOf": [
+        {
+          "$ref": "json-schema-draft-07.json#"
+        }
+      ],
+      "propertyNames": {
+        "description": "Only JSON Schema draft-07 keywords are permitted. Prevents typos and misplaced keys from being silently ignored.",
+        "enum": [
+          "$comment",
+          "$id",
+          "$ref",
+          "$schema",
+          "additionalItems",
+          "additionalProperties",
+          "allOf",
+          "anyOf",
+          "const",
+          "contains",
+          "contentEncoding",
+          "contentMediaType",
+          "default",
+          "definitions",
+          "dependencies",
+          "description",
+          "else",
+          "enum",
+          "examples",
+          "exclusiveMaximum",
+          "exclusiveMinimum",
+          "format",
+          "if",
+          "items",
+          "maxItems",
+          "maxLength",
+          "maxProperties",
+          "maximum",
+          "minItems",
+          "minLength",
+          "minProperties",
+          "minimum",
+          "multipleOf",
+          "not",
+          "oneOf",
+          "pattern",
+          "patternProperties",
+          "properties",
+          "propertyNames",
+          "readOnly",
+          "required",
+          "then",
+          "title",
+          "type",
+          "uniqueItems",
+          "writeOnly"
+        ]
+      }
     },
     "requirements": {
       "$ref": "schema_defs.json#/$defs/condition"


### PR DESCRIPTION
param_schema.json sets `additionalProperties: false` on the `schema` property, but the keyword sits as a sibling of `$ref`. JSON Schema draft-07 ignores keywords beside `$ref`, so the constraint is inert and every parameter's `schema` block currently accepts arbitrary unknown keys. A misspelled `minimun` is accepted silently, dropping the bound it was meant to express.

Move the `$ref` inside `allOf` so it no longer suppresses siblings, and constrain key names with `propertyNames` against the draft-07 keyword list, read from the vendored metaschema so it cannot drift. `additionalProperties: false` cannot be used here, because the permitted keys come from the referenced metaschema rather than a local `properties` map, so it would reject everything including `type`.

Bumps `$id` to v0.2, since v0.1 is already published as a release asset.

All 462 `kind: parameter` files in the repository still validate, including the udb and idlc test fixtures.

Closes #2173