### PR TITLE
chore: auto-update instruction appendix golden file in autofix

### DIFF
--- a/bin/chore
+++ b/bin/chore
@@ -114,6 +114,7 @@ gen_subcmd_usage() {
   echo "  schema-docs:   Generate schema documentation from JSON Schema files"
   echo "  cfg-headers:   Generate golden cfg header files for regression testing"
   echo "  xqci           Generate Xqci spec used for Golden regressions"
+  echo "  instruction-appendix: Generate golden instruction appendix adoc for regression testing"
   echo "  udb-gen:       Generate test case fixtures for udb-gen"
   echo ""
 }
@@ -372,6 +373,7 @@ do_gen_all() {
   do_ruby_type_def all
   do_gen_profile_cfgs
   do_gen_xqci_golden
+  do_gen_instruction_appendix_golden
   do_gen_schema_docs
   do_gen_cfg_headers_golden
   do_gen_udb_gen_fixtures
@@ -432,6 +434,14 @@ do_gen_xqci_golden() {
   # Remove the commit info line from the golden file
   sed -i '/^This document was created using the http:\/\/github\.org\/riscv\/riscv-unified-db\[RISC-V Unified Database\] at commit/d' \
     "tests/data/golden/Xqci@${xqci_version}.adoc"
+}
+
+#
+# Generate golden instruction appendix adoc file
+#
+do_gen_instruction_appendix_golden() {
+  echo "Generating instruction appendix golden adoc"
+  "$UDB_ROOT/do" chore:update_golden_appendix
 }
 
 #
@@ -674,6 +684,10 @@ case "$subcommand" in
         ;;
       xqci )
         do_gen_xqci_golden
+        exit 0
+        ;;
+      instruction-appendix )
+        do_gen_instruction_appendix_golden
         exit 0
         ;;
       udb-gen )


### PR DESCRIPTION
## Description
Adds a `do_gen_instruction_appendix_golden` step to `bin/chore`, wired into `do_gen_all` (which the `autofix.ci` job already runs on every PR), so `tests/golden/all_instructions.golden.adoc` gets regenerated automatically alongside the other golden files (Xqci, cfg headers) instead of requiring a manual `./do chore:update_golden_appendix` run.

Also adds a standalone `./bin/chore gen instruction-appendix` target for convenience, matching the existing `xqci` / `cfg-headers` targets.

Came up on [#2015](https://github.com/riscv/riscv-unified-db/pull/2015), where a manual regen was needed to unblock CI: https://github.com/riscv/riscv-unified-db/pull/2015#issuecomment-5085170927