### PR TITLE
fix(deps): verify downloaded binaries before making them executable

### DIFF
--- a/tools/ruby-gems/udb/ext/udb_download/extconf.rb
+++ b/tools/ruby-gems/udb/ext/udb_download/extconf.rb
@@ -82,7 +82,6 @@ unless File.exist?(espresso_file)
   $stderr.puts "Downloading espresso (#{espresso_version}, #{cpu}) from GitHub releases..."
   $stderr.puts "  URL: #{url_str}"
   File.binwrite(espresso_file, download_with_redirects(url_str))
-  File.chmod(0o755, espresso_file)
   $stderr.puts "  Saved to #{espresso_file}"
 
   # Download and verify checksum
@@ -102,10 +101,15 @@ unless File.exist?(espresso_file)
     $stderr.puts "  Expected: #{expected}"
     $stderr.puts "  Got:      #{actual}"
     $stderr.puts "  The downloaded file may be corrupted or tampered with."
+    # Remove the unverified artifact. Leaving it in place makes the next
+    # run skip both the download and this check via File.exist?.
+    FileUtils.rm_f(espresso_file)
     abort "Checksum verification failed"
   end
 
   $stderr.puts "  Checksum verified successfully."
+
+  File.chmod(0o755, espresso_file)
 end
 
 # ---------------------------------------------------------------------------
@@ -121,7 +125,6 @@ unless File.exist?(eqntott_file)
   $stderr.puts "Downloading eqntott (#{eqntott_version}, #{cpu}) from GitHub releases..."
   $stderr.puts "  URL: #{url_str}"
   File.binwrite(eqntott_file, download_with_redirects(url_str))
-  File.chmod(0o755, eqntott_file)
   $stderr.puts "  Saved to #{eqntott_file}"
 
   # Download and verify checksum
@@ -141,10 +144,15 @@ unless File.exist?(eqntott_file)
     $stderr.puts "  Expected: #{expected}"
     $stderr.puts "  Got:      #{actual}"
     $stderr.puts "  The downloaded file may be corrupted or tampered with."
+    # Remove the unverified artifact. Leaving it in place makes the next
+    # run skip both the download and this check via File.exist?.
+    FileUtils.rm_f(eqntott_file)
     abort "Checksum verification failed"
   end
 
   $stderr.puts "  Checksum verified successfully."
+
+  File.chmod(0o755, eqntott_file)
 end
 
 # ---------------------------------------------------------------------------
@@ -160,7 +168,6 @@ unless File.exist?(must_file)
   $stderr.puts "Downloading must (#{must_version}, #{cpu}) from GitHub releases..."
   $stderr.puts "  URL: #{url_str}"
   File.binwrite(must_file, download_with_redirects(url_str))
-  File.chmod(0o755, must_file)
   $stderr.puts "  Saved to #{must_file}"
 
   # Download and verify checksum
@@ -180,10 +187,15 @@ unless File.exist?(must_file)
     $stderr.puts "  Expected: #{expected}"
     $stderr.puts "  Got:      #{actual}"
     $stderr.puts "  The downloaded file may be corrupted or tampered with."
+    # Remove the unverified artifact. Leaving it in place makes the next
+    # run skip both the download and this check via File.exist?.
+    FileUtils.rm_f(must_file)
     abort "Checksum verification failed"
   end
 
   $stderr.puts "  Checksum verified successfully."
+
+  File.chmod(0o755, must_file)
 end
 
 # ---------------------------------------------------------------------------
@@ -221,6 +233,9 @@ unless File.exist?(z3_file)
     $stderr.puts "  Expected: #{expected}"
     $stderr.puts "  Got:      #{actual}"
     $stderr.puts "  The downloaded file may be corrupted or tampered with."
+    # Remove the unverified artifact. Leaving it in place makes the next
+    # run skip both the download and this check via File.exist?.
+    FileUtils.rm_f(z3_file)
     abort "Checksum verification failed"
   end
 

--- a/tools/ruby-gems/udb/lib/udb/dep_paths.rb
+++ b/tools/ruby-gems/udb/lib/udb/dep_paths.rb
@@ -4,6 +4,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "digest"
 require "rbconfig"
 require "fileutils"
 require "net/http"
@@ -54,6 +55,24 @@ module Udb
         $stderr.puts "  URL: #{url_str}"
 
         body = download_with_redirects(url_str)
+
+        # Verify against the published .checksum asset before the file is made
+        # executable. extconf.rb publishes and checks these for the same
+        # artifacts; this path previously skipped verification entirely.
+        checksum_url_str = "#{url_str}.checksum"
+        $stderr.puts "  Verifying checksum..."
+        expected = download_with_redirects(checksum_url_str).strip.split(":")[1]
+        actual = Digest::SHA256.hexdigest(body)
+
+        raise "Could not parse checksum for #{name} from #{checksum_url_str}" if expected.nil? || expected.empty?
+
+        unless expected == actual
+          raise "Checksum verification failed for #{name}!\n" \
+                "  Expected: #{expected}\n" \
+                "  Got:      #{actual}\n" \
+                "  The downloaded file may be corrupted or tampered with."
+        end
+
         File.binwrite(dest_file, body)
         File.chmod(0o755, dest_file)
         $stderr.puts "  Saved to #{dest_file}"
@@ -63,8 +82,10 @@ module Udb
         raise "Too many HTTP redirects" if limit.zero?
 
         uri = URI.parse(url_str)
+        raise "Refusing to download over a non-HTTPS URL: #{url_str}" unless uri.scheme == "https"
+
         http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = (uri.scheme == "https")
+        http.use_ssl = true
         http.open_timeout = 30
         http.read_timeout = 120
 


### PR DESCRIPTION
The 32bit_unsigned_pow2 and 64bit_unsigned_pow2 `$ref` branches of `constrain_int` each build two assertions that are conjoined: the first permits `term == 0`, the second requires `term > 0`. The `(term == 0)` disjunct can therefore never be satisfied, so it is dead code. Behaviour does not change by removing it — zero is still excluded, by the lower bound rather than by the bit identity.

It is worth removing because of what it communicates. It reads as "zero is an accepted power of two" to anyone maintaining the function, and the uint32/uint64 branches immediately above genuinely do use `unsigned_ge(0)`, which makes the inconsistency easy to misread as intentional and to "fix" in the wrong direction.

Also adds tests characterising which values these branches accept, which was previously unpinned: the two existing tests in test_conditions.rb assert only that such a schema is satisfiable, never which values are admitted, so any change to the assertions would pass silently. The new tests cover in-range powers of two, zero, non-powers-of-two including 4095, and the 32-bit upper bound.

I could not run these locally — ./bin/ruby reports `unsupported OS: MINGW64_NT` — so CI is their first execution.

Refs #2176