### PR TITLE
fix(prm): exec asciidoctor-pdf directly instead of through a shell

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/prm_generator.rb
+++ b/tools/ruby-gems/udb/lib/udb/prm_generator.rb
@@ -665,12 +665,15 @@ module PrmGenerator
       puts "[INFO] Running command: #{cmd.join(' ')}"
 
       success = T.let(nil, T.nilable(T::Boolean))
-      output = ""
-      error_output = ""
+      output = T.let("", T.untyped)
+      error_output = T.let("", T.untyped)
 
       Dir.chdir(@root_dir) do
         # Capture both stdout and stderr for better error reporting
-        Open3.popen3(cmd.join(" ")) do |stdin, stdout, stderr, wait_thr|
+        # Pass argv directly rather than a joined string: Open3 then execs the
+        # command without a shell, so path components containing spaces stay a
+        # single argument and shell metacharacters are not interpreted.
+        Open3.popen3(*cmd) do |stdin, stdout, stderr, wait_thr|
           stdin.close
           output = stdout.read
           error_output = stderr.read


### PR DESCRIPTION
build_asciidoctor_command returns a correct argv array, but the call site flattened it with cmd.join(" ") and handed the result to Open3, which then ran it through a shell.

Any path component containing a space was word-split. The theme directory is derived from the checkout location, so `-a pdf-themesdir=#{@template_dir / 'pdf-theme'}` becomes two arguments for anyone whose clone sits under a directory with a space in its name, and asciidoctor-pdf receives a truncated theme dir plus a stray positional. Shell metacharacters in the output path were likewise interpreted rather than passed through.

Splat the array so Open3 execs the command without a shell. The two cmd.join(' ') uses in the log and error messages are unchanged, since those are for display.

Refs #2141