### PR TITLE
fix(csr): set priv_mode VS on vstval and vstvec

### DIFF
--- a/spec/std/isa/csr/vstval.yaml
+++ b/spec/std/isa/csr/vstval.yaml
@@ -11,7 +11,7 @@ address: 0x243
 writable: true
 virtual_address: 0x143
 description: Holds trap-specific information
-priv_mode: S
+priv_mode: VS
 length: VSXLEN
 definedBy:
   extension:

--- a/spec/std/isa/csr/vstvec.yaml
+++ b/spec/std/isa/csr/vstvec.yaml
@@ -10,7 +10,7 @@ long_name: Supervisor Trap Vector
 address: 0x205
 writable: true
 virtual_address: 0x105
-priv_mode: S
+priv_mode: VS
 length: 64
 description: Controls where traps jump.
 definedBy:


### PR DESCRIPTION
`vstval` and `vstvec` are marked `priv_mode: S`, but should be `VS` like all of the other `vs` CSRs.

Closes #2226.