### PR TITLE
Fix Zkt data-independent timing metadata

### DIFF
--- a/spec/std/isa/ext/Zkt.yaml
+++ b/spec/std/isa/ext/Zkt.yaml
@@ -203,6 +203,21 @@ description: |
   |          | &#10003; | sraw  _rd_, _rs1_, _rs2_ |  'sraw'
   |===
 
+  ===  Zicond (Conditional Zero)
+
+  All instructions are included.
+
+  [%header,cols="^1,^1,4,8"]
+  |===
+  |RV32
+  |RV64
+  |Mnemonic
+  |Instruction
+
+  | &#10003; | &#10003; | czero.eqz _rd_, _rs1_, _rs2_ | 'czero.eqz'
+  | &#10003; | &#10003; | czero.nez _rd_, _rs1_, _rs2_ | 'czero.nez'
+  |===
+
   ===	RVM (Multiply)
 
   Multiplication is included; division and remaindering excluded.
@@ -221,7 +236,7 @@ description: |
   |          | &#10003; | mulw   _rd_, _rs1_, _rs2_ | 'mulw'
   |===
 
-  ===	RVC (Compressed)
+  ===	Zca (Compressed)
 
   Same criteria as in RVI. Organised by quadrants.
 
@@ -248,6 +263,23 @@ description: |
   | &#10003; | &#10003; | c.slli     | 'c_slli'
   | &#10003; | &#10003; | c.mv       | 'c_mv'
   | &#10003; | &#10003; | c.add      | 'c_add'
+  |===
+
+  ===	Zcb Extension
+
+  These instructions are compressed versions of `I` and `M` instructions that are
+  included in `Zkt`.
+
+  [%header,cols="^1,^1,4,8"]
+  |===
+  |RV32
+  |RV64
+  |Mnemonic
+  |Instruction
+
+  | &#10003; | &#10003; | c.mul       | 'c_mul'
+  | &#10003; | &#10003; | c.not       | 'c_not'
+  | &#10003; | &#10003; | c.zext.b    | 'c_zext_b'
   |===
 
   ===	RVK (Scalar Cryptography)

--- a/spec/std/isa/inst/C/c.add.yaml
+++ b/spec/std/isa/inst/C/c.add.yaml
@@ -28,6 +28,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 hints:
   - { $ref: inst/Zihintntl/c.ntl.p1.yaml# }
   - { $ref: inst/Zihintntl/c.ntl.pall.yaml# }

--- a/spec/std/isa/inst/C/c.addi.yaml
+++ b/spec/std/isa/inst/C/c.addi.yaml
@@ -31,6 +31,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.addiw.yaml
+++ b/spec/std/isa/inst/C/c.addiw.yaml
@@ -32,6 +32,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.addw.yaml
+++ b/spec/std/isa/inst/C/c.addw.yaml
@@ -29,6 +29,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   Bits<32> t0 = X[creg2reg(xd)][31:0];
   Bits<32> t1 = X[creg2reg(xs2)][31:0];

--- a/spec/std/isa/inst/C/c.and.yaml
+++ b/spec/std/isa/inst/C/c.and.yaml
@@ -27,6 +27,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/C/c.andi.yaml
+++ b/spec/std/isa/inst/C/c.andi.yaml
@@ -28,6 +28,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   # shamt is between 0-63
   X[creg2reg(xd)] = X[creg2reg(xd)] & $signed(imm);

--- a/spec/std/isa/inst/C/c.lui.yaml
+++ b/spec/std/isa/inst/C/c.lui.yaml
@@ -31,6 +31,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.mv.yaml
+++ b/spec/std/isa/inst/C/c.mv.yaml
@@ -28,6 +28,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.nop.yaml
+++ b/spec/std/isa/inst/C/c.nop.yaml
@@ -30,6 +30,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.or.yaml
+++ b/spec/std/isa/inst/C/c.or.yaml
@@ -27,6 +27,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/C/c.slli.yaml
+++ b/spec/std/isa/inst/C/c.slli.yaml
@@ -36,6 +36,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   # shamt is between 0-63
   X[xd] = X[xd] << shamt;

--- a/spec/std/isa/inst/C/c.srai.yaml
+++ b/spec/std/isa/inst/C/c.srai.yaml
@@ -37,6 +37,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   # shamt is between 0-63
   X[creg2reg(xd)] = X[creg2reg(xd)] >>> shamt;

--- a/spec/std/isa/inst/C/c.srli.yaml
+++ b/spec/std/isa/inst/C/c.srli.yaml
@@ -37,6 +37,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   # shamt is between 0-63
   X[creg2reg(xd)] = X[creg2reg(xd)] >> shamt;

--- a/spec/std/isa/inst/C/c.sub.yaml
+++ b/spec/std/isa/inst/C/c.sub.yaml
@@ -27,6 +27,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/C/c.subw.yaml
+++ b/spec/std/isa/inst/C/c.subw.yaml
@@ -29,6 +29,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   Bits<32> t0 = X[creg2reg(xd)][31:0];
   Bits<32> t1 = X[creg2reg(xs2)][31:0];

--- a/spec/std/isa/inst/C/c.xor.yaml
+++ b/spec/std/isa/inst/C/c.xor.yaml
@@ -27,6 +27,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/F/fadd.s.yaml
+++ b/spec/std/isa/inst/F/fadd.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.l.s.yaml
+++ b/spec/std/isa/inst/F/fcvt.l.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.lu.s.yaml
+++ b/spec/std/isa/inst/F/fcvt.lu.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.s.l.yaml
+++ b/spec/std/isa/inst/F/fcvt.s.l.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.s.lu.yaml
+++ b/spec/std/isa/inst/F/fcvt.s.lu.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.s.wu.yaml
+++ b/spec/std/isa/inst/F/fcvt.s.wu.yaml
@@ -37,7 +37,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.w.s.yaml
+++ b/spec/std/isa/inst/F/fcvt.w.s.yaml
@@ -56,7 +56,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fcvt.wu.s.yaml
+++ b/spec/std/isa/inst/F/fcvt.wu.s.yaml
@@ -55,7 +55,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fdiv.s.yaml
+++ b/spec/std/isa/inst/F/fdiv.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/feq.s.yaml
+++ b/spec/std/isa/inst/F/feq.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fle.s.yaml
+++ b/spec/std/isa/inst/F/fle.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fleq.s.yaml
+++ b/spec/std/isa/inst/F/fleq.s.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/flt.s.yaml
+++ b/spec/std/isa/inst/F/flt.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fltq.s.yaml
+++ b/spec/std/isa/inst/F/fltq.s.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/flw.yaml
+++ b/spec/std/isa/inst/F/flw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fmadd.s.yaml
+++ b/spec/std/isa/inst/F/fmadd.s.yaml
@@ -31,7 +31,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fmax.s.yaml
+++ b/spec/std/isa/inst/F/fmax.s.yaml
@@ -37,7 +37,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fmin.s.yaml
+++ b/spec/std/isa/inst/F/fmin.s.yaml
@@ -37,7 +37,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fmsub.s.yaml
+++ b/spec/std/isa/inst/F/fmsub.s.yaml
@@ -31,7 +31,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fmul.s.yaml
+++ b/spec/std/isa/inst/F/fmul.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fmv.w.x.yaml
+++ b/spec/std/isa/inst/F/fmv.w.x.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fmv.x.w.yaml
+++ b/spec/std/isa/inst/F/fmv.x.w.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fnmadd.s.yaml
+++ b/spec/std/isa/inst/F/fnmadd.s.yaml
@@ -32,7 +32,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fnmsub.s.yaml
+++ b/spec/std/isa/inst/F/fnmsub.s.yaml
@@ -32,7 +32,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fsgnj.s.yaml
+++ b/spec/std/isa/inst/F/fsgnj.s.yaml
@@ -31,7 +31,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 pseudoinstructions:
   - when: (fs2 == fs1)
     to: fmv.s fd, fs1

--- a/spec/std/isa/inst/F/fsgnjn.s.yaml
+++ b/spec/std/isa/inst/F/fsgnjn.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 pseudoinstructions:
   - when: (fs2 == fs1)
     to: fneg.s fd, fs1

--- a/spec/std/isa/inst/F/fsgnjx.s.yaml
+++ b/spec/std/isa/inst/F/fsgnjx.s.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 pseudoinstructions:
   - when: (fs2 == fs1)
     to: fabs.s fd, fs1

--- a/spec/std/isa/inst/F/fsqrt.s.yaml
+++ b/spec/std/isa/inst/F/fsqrt.s.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fsub.s.yaml
+++ b/spec/std/isa/inst/F/fsub.s.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/F/fsw.yaml
+++ b/spec/std/isa/inst/F/fsw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -28,6 +28,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
 
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {

--- a/spec/std/isa/inst/Zcb/c.not.yaml
+++ b/spec/std/isa/inst/Zcb/c.not.yaml
@@ -25,6 +25,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |
 
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {

--- a/spec/std/isa/inst/Zcb/c.zext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.b.yaml
@@ -26,6 +26,7 @@ access:
   u: always
   vs: always
   vu: always
+data_independent_timing: true
 operation(): |2
 
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {

--- a/spec/std/isa/inst/Zfa/fli.s.yaml
+++ b/spec/std/isa/inst/Zfa/fli.s.yaml
@@ -25,5 +25,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/Zfa/fmaxm.s.yaml
+++ b/spec/std/isa/inst/Zfa/fmaxm.s.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/Zfa/fminm.s.yaml
+++ b/spec/std/isa/inst/Zfa/fminm.s.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/Zfa/fround.s.yaml
+++ b/spec/std/isa/inst/Zfa/fround.s.yaml
@@ -33,7 +33,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);

--- a/spec/std/isa/inst/Zfa/froundnx.s.yaml
+++ b/spec/std/isa/inst/Zfa/froundnx.s.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/Zicond/czero.eqz.yaml
+++ b/spec/std/isa/inst/Zicond/czero.eqz.yaml
@@ -30,6 +30,6 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   X[xd] = (X[xs2] == 0) ? 0 : X[xs1];

--- a/spec/std/isa/inst/Zicond/czero.nez.yaml
+++ b/spec/std/isa/inst/Zicond/czero.nez.yaml
@@ -30,6 +30,6 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   X[xd] = (X[xs2] != 0) ? 0 : X[xs1];


### PR DESCRIPTION
Aligns Zkt data-independent timing metadata with the Zkt instruction listing, including Zicond/Zca/Zcb instructions and excluding F/Zfa instructions.

AI-generated.
