### PR TITLE
Fix vector crypto base-vector requirements

### DIFF
--- a/spec/std/isa/ext/Zvbc.yaml
+++ b/spec/std/isa/ext/Zvbc.yaml
@@ -17,3 +17,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve64x

--- a/spec/std/isa/ext/Zvkb.yaml
+++ b/spec/std/isa/ext/Zvkb.yaml
@@ -14,3 +14,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvkg.yaml
+++ b/spec/std/isa/ext/Zvkg.yaml
@@ -24,3 +24,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvkned.yaml
+++ b/spec/std/isa/ext/Zvkned.yaml
@@ -20,3 +20,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvknha.yaml
+++ b/spec/std/isa/ext/Zvknha.yaml
@@ -15,3 +15,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvknhb.yaml
+++ b/spec/std/isa/ext/Zvknhb.yaml
@@ -17,5 +17,7 @@ versions:
     ratification_date: 2023-09
     requirements:
       extension:
-        name: Zvknha
-        version: "= 1.0.0"
+        allOf:
+          - name: Zvknha
+            version: "= 1.0.0"
+          - name: Zve64x

--- a/spec/std/isa/ext/Zvksed.yaml
+++ b/spec/std/isa/ext/Zvksed.yaml
@@ -22,3 +22,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvksh.yaml
+++ b/spec/std/isa/ext/Zvksh.yaml
@@ -18,3 +18,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvkt.yaml
+++ b/spec/std/isa/ext/Zvkt.yaml
@@ -26,3 +26,6 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2023-09
+requirements:
+  extension:
+    name: Zve32x

--- a/spec/std/isa/ext/Zvkt.yaml
+++ b/spec/std/isa/ext/Zvkt.yaml
@@ -28,4 +28,4 @@ versions:
     ratification_date: 2023-09
 requirements:
   extension:
-    name: Zve32x
+    name: Zvl32b


### PR DESCRIPTION
Adds missing Zve32x/Zve64x requirements for vector crypto extensions.

AI-generated.
