### PR TITLE
Fix Zfbfmin dependency and instruction data

### DIFF
--- a/spec/std/isa/ext/Zfbfmin.yaml
+++ b/spec/std/isa/ext/Zfbfmin.yaml
@@ -12,8 +12,8 @@ description: |
   It enables BF16 as an interchange format as it provides conversion between BF16 values and
   FP32 values.
 
-  This extension depends upon the single-precision floating-point extension `F`,
-  and the `flh`, `fsh`, `fmv.x.h`, and `fmv.h.x` instructions as defined in the `Zfh` extension.
+  This extension includes the `flh`, `fsh`, `fmv.x.h`, and `fmv.h.x`
+  instructions defined in the `Zfh` extension.
 
 type: unprivileged
 versions:
@@ -22,6 +22,4 @@ versions:
     ratification_date: 2024-06
 requirements:
   extension:
-    allOf:
-      - name: F
-      - name: Zfh
+    name: F

--- a/spec/std/isa/inst/Zfh/flh.yaml
+++ b/spec/std/isa/inst/Zfh/flh.yaml
@@ -16,7 +16,9 @@ description: |
 
 definedBy:
   extension:
-    name: Zfhmin
+    anyOf:
+      - name: Zfhmin
+      - name: Zfbfmin
 assembly: fd, imm(xs1)
 encoding:
   match: "-----------------001-----0000111"

--- a/spec/std/isa/inst/Zfh/fmv.h.x.yaml
+++ b/spec/std/isa/inst/Zfh/fmv.h.x.yaml
@@ -14,7 +14,9 @@ description: |
   the payloads of non-canonical NaNs are preserved.
 definedBy:
   extension:
-    name: Zfhmin
+    anyOf:
+      - name: Zfhmin
+      - name: Zfbfmin
 assembly: fd, xs1
 encoding:
   match: 111101000000-----000-----1010011

--- a/spec/std/isa/inst/Zfh/fmv.x.h.yaml
+++ b/spec/std/isa/inst/Zfh/fmv.x.h.yaml
@@ -9,7 +9,9 @@ name: fmv.x.h
 long_name: Move half-precision value from floating-point to integer register
 definedBy:
   extension:
-    name: Zfhmin
+    anyOf:
+      - name: Zfhmin
+      - name: Zfbfmin
 assembly: xd, fs1
 description: |
   Moves the half-precision value in floating-point register fs1 represented in IEEE 754-2008

--- a/spec/std/isa/inst/Zfh/fsh.yaml
+++ b/spec/std/isa/inst/Zfh/fsh.yaml
@@ -19,7 +19,9 @@ description: |
 
 definedBy:
   extension:
-    name: Zfhmin
+    anyOf:
+      - name: Zfhmin
+      - name: Zfbfmin
 assembly: fs2, imm(xs1)
 encoding:
   match: "-----------------001-----0100111"

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -21429,15 +21429,10 @@ Decode Variables::
 Included in::
 
 
-[width="100%",cols="1,2",options="header"]
-|===
-| Extension | Version
+This instruction requires the following:
 
-| *Zfhmin*
-| any
-|===
-
-
+xref:exts:Zfhmin.adoc#udb:doc:ext:Zfhmin[Zfhmin]
+xref:exts:Zfbfmin.adoc#udb:doc:ext:Zfbfmin[Zfbfmin]
 
 
 [#udb:doc:inst:fli_d]
@@ -23781,15 +23776,10 @@ Decode Variables::
 Included in::
 
 
-[width="100%",cols="1,2",options="header"]
-|===
-| Extension | Version
+This instruction requires the following:
 
-| *Zfhmin*
-| any
-|===
-
-
+xref:exts:Zfhmin.adoc#udb:doc:ext:Zfhmin[Zfhmin]
+xref:exts:Zfbfmin.adoc#udb:doc:ext:Zfbfmin[Zfbfmin]
 
 
 [#udb:doc:inst:fmv_w_x]
@@ -23947,15 +23937,10 @@ Decode Variables::
 Included in::
 
 
-[width="100%",cols="1,2",options="header"]
-|===
-| Extension | Version
+This instruction requires the following:
 
-| *Zfhmin*
-| any
-|===
-
-
+xref:exts:Zfhmin.adoc#udb:doc:ext:Zfhmin[Zfhmin]
+xref:exts:Zfbfmin.adoc#udb:doc:ext:Zfbfmin[Zfbfmin]
 
 
 [#udb:doc:inst:fmv_x_w]
@@ -25836,15 +25821,10 @@ Decode Variables::
 Included in::
 
 
-[width="100%",cols="1,2",options="header"]
-|===
-| Extension | Version
+This instruction requires the following:
 
-| *Zfhmin*
-| any
-|===
-
-
+xref:exts:Zfhmin.adoc#udb:doc:ext:Zfhmin[Zfhmin]
+xref:exts:Zfbfmin.adoc#udb:doc:ext:Zfbfmin[Zfbfmin]
 
 
 [#udb:doc:inst:fsq]


### PR DESCRIPTION
Corrects Zfbfmin to depend on F, not full Zfh, and marks the included half-width transfer/load/store instructions as also defined by Zfbfmin.

AI-generated.
