### PR TITLE
Add seed CSR data for Zkr

### DIFF
--- a/spec/std/isa/csr/Zkr/seed.yaml
+++ b/spec/std/isa/csr/Zkr/seed.yaml
@@ -1,0 +1,94 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: seed
+long_name: Seed for cryptographic random bit generators
+address: 0x015
+writable: true
+priv_mode: M
+length: 32
+description: |
+  The `seed` CSR provides an interface to a physical Entropy Source.
+
+  The CSR provides up to 16 physical entropy bits that can be used to seed
+  cryptographic random bit generators. The write value is ignored by
+  implementations; the write is used to signal polling and flushing.
+definedBy:
+  extension:
+    name: Zkr
+fields:
+  OPST:
+    location: 31-30
+    description: |
+      Status bits returned by the entropy source.
+
+      Encodings are:
+
+      * 0 - BIST
+      * 1 - WAIT
+      * 2 - ES16
+      * 3 - DEAD
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (mode() == PrivilegeMode::U && CSR[mseccfg].USEED == 1'b0) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      } else if (mode() == PrivilegeMode::S && CSR[mseccfg].SSEED == 1'b0) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      } else if (mode() == PrivilegeMode::VS || mode() == PrivilegeMode::VU) {
+        if (CSR[mseccfg].SSEED == 1'b1) {
+          raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+        } else {
+          raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+        }
+      }
+      return CSR[seed].OPST;
+  ENTROPY:
+    location: 15-0
+    description: |
+      Sixteen bits of randomness.
+
+      This field is valid only when `OPST` is ES16. When `OPST` is not ES16,
+      `ENTROPY` must be zero.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (mode() == PrivilegeMode::U && CSR[mseccfg].USEED == 1'b0) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      } else if (mode() == PrivilegeMode::S && CSR[mseccfg].SSEED == 1'b0) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      } else if (mode() == PrivilegeMode::VS || mode() == PrivilegeMode::VU) {
+        if (CSR[mseccfg].SSEED == 1'b1) {
+          raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+        } else {
+          raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+        }
+      }
+      return CSR[seed].ENTROPY;
+sw_read(): |
+  Bits<3> csr_funct3 = $encoding[14:12];
+  Bits<5> csr_rs1_uimm = $encoding[19:15];
+
+  if (((csr_funct3 == 3'b010) || (csr_funct3 == 3'b011) ||
+       (csr_funct3 == 3'b110) || (csr_funct3 == 3'b111)) &&
+      (csr_rs1_uimm == 5'b00000)) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  if (mode() == PrivilegeMode::U && CSR[mseccfg].USEED == 1'b0) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (mode() == PrivilegeMode::S && CSR[mseccfg].SSEED == 1'b0) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (mode() == PrivilegeMode::VS || mode() == PrivilegeMode::VU) {
+    if (CSR[mseccfg].SSEED == 1'b1) {
+      raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+    } else {
+      raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    }
+  }
+
+  return $bits(CSR[seed]);

--- a/spec/std/isa/csr/Zkr/seed.yaml
+++ b/spec/std/isa/csr/Zkr/seed.yaml
@@ -9,10 +9,11 @@ name: seed
 long_name: Seed for cryptographic random bit generators
 address: 0x015
 writable: true
-priv_mode: M
+priv_mode: U
 length: 32
 description: |
-  The `seed` CSR provides an interface to a physical Entropy Source.
+  The seed CSR provides an interface to a NIST SP 800-90B (Turan et al., 2018)
+  or BSI AIS-31 (Killmann & Schindler, 2011) compliant physical Entropy Source (ES).
 
   The CSR provides up to 16 physical entropy bits that can be used to seed
   cryptographic random bit generators. The write value is ignored by
@@ -46,7 +47,7 @@ fields:
           raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
         }
       }
-      return CSR[seed].OPST;
+      return CSR[seed].OPST; # TODO: Implement OPST as a builtin?
   ENTROPY:
     location: 15-0
     description: |
@@ -68,14 +69,12 @@ fields:
           raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
         }
       }
-      return CSR[seed].ENTROPY;
+      return CSR[seed].ENTROPY; # TODO: Implement ENTROPY as a builtin?
 sw_read(): |
-  Bits<3> csr_funct3 = $encoding[14:12];
-  Bits<5> csr_rs1_uimm = $encoding[19:15];
+  # CSRRS/CSRRC/CSRRSI/CSRRCI are the CSR instructions with funct3[1] set.
+  Boolean read_only_access = ($encoding[13] == 1'b1) && ($encoding[19:15] == 5'b00000);
 
-  if (((csr_funct3 == 3'b010) || (csr_funct3 == 3'b011) ||
-       (csr_funct3 == 3'b110) || (csr_funct3 == 3'b111)) &&
-      (csr_rs1_uimm == 5'b00000)) {
+  if (read_only_access) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/csr/mseccfg.yaml
+++ b/spec/std/isa/csr/mseccfg.yaml
@@ -22,4 +22,30 @@ definedBy:
           - name: Smmpm
           - name: Zicfilp
           - name: Smepmp
-fields: {}
+fields:
+  USEED:
+    location: 8
+    description: |
+      Controls access to the `seed` CSR from U-mode.
+    definedBy:
+      extension:
+        name: Zkr
+    type(): |
+      return (implemented?(ExtensionName::U)) ? CsrFieldType::RW : CsrFieldType::RO;
+    reset_value(): |
+      return (implemented?(ExtensionName::U)) ? UNDEFINED_LEGAL : 0;
+    sw_write(csr_value): |
+      return (implemented?(ExtensionName::U)) ? csr_value.USEED : 0;
+  SSEED:
+    location: 9
+    description: |
+      Controls access to the `seed` CSR from S-mode and VS-mode.
+    definedBy:
+      extension:
+        name: Zkr
+    type(): |
+      return (implemented?(ExtensionName::S)) ? CsrFieldType::RW : CsrFieldType::RO;
+    reset_value(): |
+      return (implemented?(ExtensionName::S)) ? UNDEFINED_LEGAL : 0;
+    sw_write(csr_value): |
+      return (implemented?(ExtensionName::S)) ? csr_value.SSEED : 0;

--- a/spec/std/isa/csr/mseccfg.yaml
+++ b/spec/std/isa/csr/mseccfg.yaml
@@ -29,23 +29,23 @@ fields:
       Controls access to the `seed` CSR from U-mode.
     definedBy:
       extension:
-        name: Zkr
+        allOf:
+          - name: Zkr
+          - name: U
     type(): |
-      return (implemented?(ExtensionName::U)) ? CsrFieldType::RW : CsrFieldType::RO;
+      return USEED_READ_ONLY_ZERO ? CsrFieldType::RO : CsrFieldType::RW;
     reset_value(): |
-      return (implemented?(ExtensionName::U)) ? UNDEFINED_LEGAL : 0;
-    sw_write(csr_value): |
-      return (implemented?(ExtensionName::U)) ? csr_value.USEED : 0;
+      return USEED_READ_ONLY_ZERO ? 0 : UNDEFINED_LEGAL;
   SSEED:
     location: 9
     description: |
       Controls access to the `seed` CSR from S-mode and VS-mode.
     definedBy:
       extension:
-        name: Zkr
+        allOf:
+          - name: Zkr
+          - name: S
     type(): |
-      return (implemented?(ExtensionName::S)) ? CsrFieldType::RW : CsrFieldType::RO;
+      return SSEED_READ_ONLY_ZERO ? CsrFieldType::RO : CsrFieldType::RW;
     reset_value(): |
-      return (implemented?(ExtensionName::S)) ? UNDEFINED_LEGAL : 0;
-    sw_write(csr_value): |
-      return (implemented?(ExtensionName::S)) ? csr_value.SSEED : 0;
+      return SSEED_READ_ONLY_ZERO ? 0 : UNDEFINED_LEGAL;

--- a/spec/std/isa/param/SSEED_READ_ONLY_ZERO.yaml
+++ b/spec/std/isa/param/SSEED_READ_ONLY_ZERO.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/param_schema.json
+
+$schema: param_schema.json#
+kind: parameter
+name: SSEED_READ_ONLY_ZERO
+long_name: Whether `mseccfg.SSEED` is read-only zero
+description: |
+  Indicates whether the `mseccfg.SSEED` field is hardwired read-only zero.
+
+  Options:
+
+    true::
+      `mseccfg.SSEED` is read-only zero.
+
+    false::
+      `mseccfg.SSEED` is writable.
+schema:
+  type: boolean
+definedBy:
+  extension:
+    allOf:
+      - name: Sm
+        version: ">= 1.12"
+      - name: Zkr
+      - name: S

--- a/spec/std/isa/param/USEED_READ_ONLY_ZERO.yaml
+++ b/spec/std/isa/param/USEED_READ_ONLY_ZERO.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/param_schema.json
+
+$schema: param_schema.json#
+kind: parameter
+name: USEED_READ_ONLY_ZERO
+long_name: Whether `mseccfg.USEED` is read-only zero
+description: |
+  Indicates whether the `mseccfg.USEED` field is hardwired read-only zero.
+
+  Options:
+
+    true::
+      `mseccfg.USEED` is read-only zero.
+
+    false::
+      `mseccfg.USEED` is writable.
+schema:
+  type: boolean
+definedBy:
+  extension:
+    allOf:
+      - name: Sm
+        version: ">= 1.12"
+      - name: Zkr
+      - name: U


### PR DESCRIPTION
Adds the missing seed CSR record for Zkr, including the mseccfg seed-access bits and seed access semantics.

AI-generated.
