### PR TITLE
Add Sstc timer compare CSR data

### DIFF
--- a/spec/std/isa/csr/Sstc/stimecmp.yaml
+++ b/spec/std/isa/csr/Sstc/stimecmp.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: stimecmp
+long_name: Supervisor timer compare
+address: 0x14D
+writable: true
+priv_mode: S
+length: 64
+description: |
+  Supervisor timer compare register.
+
+  When `menvcfg.STCE` is set, `stimecmp` is operational and provides
+  supervisor mode with a CSR-based timer interrupt facility.
+definedBy:
+  extension:
+    name: Sstc
+fields:
+  TIME:
+    location: 63-0
+    description: |
+      Time compare value for supervisor timer interrupts.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (mode() != PrivilegeMode::M) {
+        if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+          raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+        }
+      }
+      return csr_value.TIME;
+sw_read(): |
+  if (mode() != PrivilegeMode::M) {
+    if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+      raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    }
+  }
+  return CSR[stimecmp].TIME;

--- a/spec/std/isa/csr/Sstc/stimecmph.yaml
+++ b/spec/std/isa/csr/Sstc/stimecmph.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: stimecmph
+long_name: Supervisor timer compare high
+address: 0x15D
+writable: true
+priv_mode: S
+length: 32
+description: |
+  Upper 32 bits of the `stimecmp` CSR.
+definedBy:
+  allOf:
+    - xlen: 32
+    - extension:
+        name: Sstc
+fields:
+  TIME:
+    location: 31-0
+    alias: stimecmp.TIME[63:32]
+    description: |
+      Upper 32 bits of the supervisor timer compare value.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (mode() != PrivilegeMode::M) {
+        if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+          raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+        }
+      }
+      CSR[stimecmp].TIME = {csr_value.TIME, CSR[stimecmp].TIME[31:0]};
+      return csr_value.TIME;
+sw_read(): |
+  if (mode() != PrivilegeMode::M) {
+    if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+      raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    }
+  }
+  return CSR[stimecmp].TIME[63:32];

--- a/spec/std/isa/csr/Sstc/vstimecmp.yaml
+++ b/spec/std/isa/csr/Sstc/vstimecmp.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: vstimecmp
+long_name: Virtual supervisor timer compare
+address: 0x24D
+writable: true
+virtual_address: 0x14D
+priv_mode: VS
+length: 64
+description: |
+  Virtual supervisor timer compare register.
+
+  When `menvcfg.STCE` and `henvcfg.STCE` are set, `vstimecmp` is operational
+  and provides VS-mode with a CSR-based timer interrupt facility.
+definedBy:
+  extension:
+    allOf:
+      - name: H
+      - name: Sstc
+fields:
+  TIME:
+    location: 63-0
+    description: |
+      Time compare value for virtual supervisor timer interrupts.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      } else if (CSR[henvcfg].STCE == 1'b0 || CSR[hcounteren].TM == 1'b0) {
+        raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+      }
+      return csr_value.TIME;
+sw_read(): |
+  if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (CSR[henvcfg].STCE == 1'b0 || CSR[hcounteren].TM == 1'b0) {
+    raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+  }
+  return CSR[vstimecmp].TIME;

--- a/spec/std/isa/csr/Sstc/vstimecmph.yaml
+++ b/spec/std/isa/csr/Sstc/vstimecmph.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: vstimecmph
+long_name: Virtual supervisor timer compare high
+address: 0x25D
+writable: true
+virtual_address: 0x15D
+priv_mode: VS
+length: 32
+description: |
+  Upper 32 bits of the `vstimecmp` CSR.
+definedBy:
+  allOf:
+    - xlen: 32
+    - extension:
+        allOf:
+          - name: H
+          - name: Sstc
+fields:
+  TIME:
+    location: 31-0
+    alias: vstimecmp.TIME[63:32]
+    description: |
+      Upper 32 bits of the virtual supervisor timer compare value.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+        raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+      } else if (CSR[henvcfg].STCE == 1'b0 || CSR[hcounteren].TM == 1'b0) {
+        raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+      }
+      CSR[vstimecmp].TIME = {csr_value.TIME, CSR[vstimecmp].TIME[31:0]};
+      return csr_value.TIME;
+sw_read(): |
+  if (CSR[menvcfg].STCE == 1'b0 || CSR[mcounteren].TM == 1'b0) {
+    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (CSR[henvcfg].STCE == 1'b0 || CSR[hcounteren].TM == 1'b0) {
+    raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+  }
+  return CSR[vstimecmp].TIME[63:32];


### PR DESCRIPTION
Adds the missing Sstc timer-compare CSR records for supervisor and virtual-supervisor modes, including STCE and counter-enable access gating.

AI-generated.
