### PR TITLE
Add AIA top interrupt CSR data

### DIFF
--- a/spec/std/isa/csr/Smaia/mtopei.yaml
+++ b/spec/std/isa/csr/Smaia/mtopei.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mtopei
+long_name: Machine top external interrupt
+address: 0x35C
+writable: true
+priv_mode: M
+length: MXLEN
+description: |
+  Machine top external interrupt CSR.
+
+definedBy:
+  extension:
+    name: Smaia
+fields:
+  IID:
+    location: 26-16
+    description: |
+      Interrupt identity number for the highest-priority pending external
+      interrupt. Writes ignore this value and instead claim the interrupt that
+      the CSR currently reports.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      return CSR[mtopei].IID;
+  IPRIO:
+    location: 10-0
+    description: |
+      Interrupt priority for the highest-priority pending external interrupt.
+      Writes ignore this value and instead claim the interrupt that the CSR
+      currently reports.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      return CSR[mtopei].IPRIO;

--- a/spec/std/isa/csr/Smaia/mtopi.yaml
+++ b/spec/std/isa/csr/Smaia/mtopi.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mtopi
+long_name: Machine top interrupt
+address: 0xFB0
+writable: false
+priv_mode: M
+length: MXLEN
+description: |
+  Machine top interrupt CSR.
+definedBy:
+  extension:
+    name: Smaia
+fields:
+  IID:
+    location: 27-16
+    description: |
+      Interrupt identity number for the highest-priority pending interrupt.
+    type: RO
+    reset_value: UNDEFINED_LEGAL
+  IPRIO:
+    location: 7-0
+    description: |
+      Interrupt priority for the highest-priority pending interrupt.
+    type: RO
+    reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/Ssaia/stopei.yaml
+++ b/spec/std/isa/csr/Ssaia/stopei.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: stopei
+long_name: Supervisor top external interrupt
+address: 0x15C
+writable: true
+priv_mode: S
+length: SXLEN
+description: |
+  Supervisor top external interrupt CSR.
+definedBy:
+  extension:
+    name: Ssaia
+fields:
+  IID:
+    location: 26-16
+    description: |
+      Interrupt identity number for the highest-priority pending external
+      interrupt. Writes ignore this value and instead claim the interrupt that
+      the CSR currently reports.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      return CSR[stopei].IID;
+  IPRIO:
+    location: 10-0
+    description: |
+      Interrupt priority for the highest-priority pending external interrupt.
+      Writes ignore this value and instead claim the interrupt that the CSR
+      currently reports.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      return CSR[stopei].IPRIO;

--- a/spec/std/isa/csr/Ssaia/stopi.yaml
+++ b/spec/std/isa/csr/Ssaia/stopi.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: stopi
+long_name: Supervisor top interrupt
+address: 0xDB0
+writable: false
+priv_mode: S
+length: SXLEN
+description: |
+  Supervisor top interrupt CSR.
+definedBy:
+  extension:
+    name: Ssaia
+fields:
+  IID:
+    location: 27-16
+    description: |
+      Interrupt identity number for the highest-priority pending interrupt.
+    type: RO
+    reset_value: UNDEFINED_LEGAL
+  IPRIO:
+    location: 7-0
+    description: |
+      Interrupt priority for the highest-priority pending interrupt.
+    type: RO
+    reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/Ssaia/vstopei.yaml
+++ b/spec/std/isa/csr/Ssaia/vstopei.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: vstopei
+long_name: Virtual supervisor top external interrupt
+address: 0x25C
+virtual_address: 0x15C
+writable: true
+priv_mode: VS
+length: VSXLEN
+description: |
+  Virtual supervisor top external interrupt CSR.
+definedBy:
+  extension:
+    allOf:
+      - name: H
+      - name: Ssaia
+fields:
+  IID:
+    location: 26-16
+    description: |
+      Interrupt identity number for the highest-priority pending external
+      interrupt. Writes ignore this value and instead claim the interrupt that
+      the CSR currently reports.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      return CSR[vstopei].IID;
+  IPRIO:
+    location: 10-0
+    description: |
+      Interrupt priority for the highest-priority pending external interrupt.
+      Writes ignore this value and instead claim the interrupt that the CSR
+      currently reports.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      return CSR[vstopei].IPRIO;

--- a/spec/std/isa/csr/Ssaia/vstopi.yaml
+++ b/spec/std/isa/csr/Ssaia/vstopi.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: vstopi
+long_name: Virtual supervisor top interrupt
+address: 0xEB0
+virtual_address: 0xDB0
+writable: false
+priv_mode: VS
+length: VSXLEN
+description: |
+  Virtual supervisor top interrupt CSR.
+definedBy:
+  extension:
+    allOf:
+      - name: H
+      - name: Ssaia
+fields:
+  IID:
+    location: 27-16
+    description: |
+      Interrupt identity number for the highest-priority pending interrupt.
+    type: RO
+    reset_value: UNDEFINED_LEGAL
+  IPRIO:
+    location: 7-0
+    description: |
+      Interrupt priority for the highest-priority pending interrupt.
+    type: RO
+    reset_value: UNDEFINED_LEGAL


### PR DESCRIPTION
Adds missing AIA top-interrupt CSR records for Smaia and Ssaia, including top-interrupt field layouts and top-external-interrupt write semantics.

AI-generated.
