### PR TITLE
fix(data): correct floating-point precision in three instruction descriptions

### DIFF
--- a/spec/std/isa/inst/Q/fadd.q.yaml
+++ b/spec/std/isa/inst/Q/fadd.q.yaml
@@ -11,8 +11,8 @@ definedBy:
   extension:
     name: Q
 description: |
-  `fadd.q` is analogous to `fadd.d` and performs double-precision floating-point addition between
-  `qs1` and `qs2` and writes the final result to `qd`.
+  `fadd.q` is analogous to `fadd.d` and performs quad-precision floating-point addition between
+  `fs1` and `fs2` and writes the final result to `fd`.
 assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000011------------------1010011

--- a/spec/std/isa/inst/Q/fmvp.q.x.yaml
+++ b/spec/std/isa/inst/Q/fmvp.q.x.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: fmvp.q.x
 long_name: Floating-Point Move Pair from Integer Registers to Quad-Precision Register
 description: |
-  The `fmvp.q.x` instruction moves a double-precision number from a pair of integer registers into
+  The `fmvp.q.x` instruction moves a quad-precision number from a pair of integer registers into
   a floating-point register.
   Integer registers `xs1` and `xs2` supply bits 63:0 and 127:64, respectively; the result is written to
   floating-point register `fd`.

--- a/spec/std/isa/inst/Zfh/flh.yaml
+++ b/spec/std/isa/inst/Zfh/flh.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: flh
 long_name: Half-precision floating-point load
 description: |
-  The `flh` instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
+  The `flh` instruction loads a half-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
 
   `flh` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -17358,8 +17358,8 @@ Encoding::
 ....
 
 Description::
-xref:insts:fadd_q.adoc#udb:doc:inst:fadd_q[fadd.q] is analogous to xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] and performs double-precision floating-point addition between
-`qs1` and `qs2` and writes the final result to `qd`.
+xref:insts:fadd_q.adoc#udb:doc:inst:fadd_q[fadd.q] is analogous to xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] and performs quad-precision floating-point addition between
+`fs1` and `fs2` and writes the final result to `fd`.
 
 
 Decode Variables::
@@ -21410,7 +21410,7 @@ Encoding::
 ....
 
 Description::
-The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
+The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a half-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
 
 xref:insts:flh.adoc#udb:doc:inst:flh[flh] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -24215,7 +24215,7 @@ Encoding::
 ....
 
 Description::
-The xref:insts:fmvp_q_x.adoc#udb:doc:inst:fmvp_q_x[fmvp.q.x] instruction moves a double-precision number from a pair of integer registers into
+The xref:insts:fmvp_q_x.adoc#udb:doc:inst:fmvp_q_x[fmvp.q.x] instruction moves a quad-precision number from a pair of integer registers into
 a floating-point register.
 Integer registers `xs1` and `xs2` supply bits 63:0 and 127:64, respectively; the result is written to
 floating-point register `fd`.


### PR DESCRIPTION

fadd.q described itself as double-precision and named its operands qs1/qs2/qd, though the encoding declares fs1/fs2/fd. fmvp.q.x described a double-precision number while stating it transfers bits 127:64. flh described a single-precision load.

All three contradict their own long_name, and the sibling instructions confirm the intended wording: fsub.q, fmul.q and fdiv.q say quad-precision, and fsh says half-precision.

Closes #2244