### PR TITLE
fix(data): use encoding operand names in fclass.q and fli.q descriptions

### DIFF
--- a/spec/std/isa/inst/Q/fclass.q.yaml
+++ b/spec/std/isa/inst/Q/fclass.q.yaml
@@ -8,13 +8,13 @@ kind: instruction
 name: fclass.q
 long_name: Floating-Point Classify Quad-Precision
 description: |
-  The `fclass.q` instruction examines the value in floating-point register `rs1` and writes to integer
-  register `rd` a 10-bit mask that indicates the class of the floating-point number.
+  The `fclass.q` instruction examines the value in floating-point register `fs1` and writes to integer
+  register `xd` a 10-bit mask that indicates the class of the floating-point number.
 
-  The format of the mask is described in table given below. The corresponding bit in `rd`
-  will be set if the property is true and clear otherwise. All other bits in `rd` are cleared.
+  The format of the mask is described in table given below. The corresponding bit in `xd`
+  will be set if the property is true and clear otherwise. All other bits in `xd` are cleared.
 
-  Note that exactly one bit in `rd` will be set. `fclass.q` does not set the floating-point
+  Note that exactly one bit in `xd` will be set. `fclass.q` does not set the floating-point
   exception flags.
 
   .Format of result of `fclass` instruction.

--- a/spec/std/isa/inst/Q/fli.q.yaml
+++ b/spec/std/isa/inst/Q/fli.q.yaml
@@ -9,7 +9,7 @@ name: fli.q
 long_name: Floating-Point Load Immediate Quad-Precision
 description: |
   The `fli.q` instruction loads one of 32 quad-precision floating-point constants, encoded in the `xs1`
-  field, into floating-point register `rd`.
+  field, into floating-point register `fd`.
   `fli.q` is encoded like `fmv.w.x`, but with _fmt_ = Q.
 definedBy:
   extension:

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -17579,13 +17579,13 @@ Encoding::
 ....
 
 Description::
-The xref:insts:fclass_q.adoc#udb:doc:inst:fclass_q[fclass.q] instruction examines the value in floating-point register `rs1` and writes to integer
-register `rd` a 10-bit mask that indicates the class of the floating-point number.
+The xref:insts:fclass_q.adoc#udb:doc:inst:fclass_q[fclass.q] instruction examines the value in floating-point register `fs1` and writes to integer
+register `xd` a 10-bit mask that indicates the class of the floating-point number.
 
-The format of the mask is described in table given below. The corresponding bit in `rd`
-will be set if the property is true and clear otherwise. All other bits in `rd` are cleared.
+The format of the mask is described in table given below. The corresponding bit in `xd`
+will be set if the property is true and clear otherwise. All other bits in `xd` are cleared.
 
-Note that exactly one bit in `rd` will be set. xref:insts:fclass_q.adoc#udb:doc:inst:fclass_q[fclass.q] does not set the floating-point
+Note that exactly one bit in `xd` will be set. xref:insts:fclass_q.adoc#udb:doc:inst:fclass_q[fclass.q] does not set the floating-point
 exception flags.
 
 .Format of result of `fclass` instruction.
@@ -21574,7 +21574,7 @@ Encoding::
 
 Description::
 The xref:insts:fli_q.adoc#udb:doc:inst:fli_q[fli.q] instruction loads one of 32 quad-precision floating-point constants, encoded in the `xs1`
-field, into floating-point register `rd`.
+field, into floating-point register `fd`.
 xref:insts:fli_q.adoc#udb:doc:inst:fli_q[fli.q] is encoded like xref:insts:fmv_w_x.adoc#udb:doc:inst:fmv_w_x[fmv.w.x], but with _fmt_ = Q.
 
 


### PR DESCRIPTION
fclass.q referred to its operands as rs1 and rd, and fli.q to its destination as rd. Neither name appears in the instruction's assembly string or encoding.variables: fclass.q declares xd, fs1 and fli.q declares fd, xs1.

fclass.q's own result table already uses _xd_ and _fs1_, so the prose contradicted the table in the same file. fclass.s and fli.d describe the equivalent operands correctly.

Closes #2246