### PR TITLE
fix(param): require VSXLEN and VUXLEN to support 32 when their parent can

### DIFF
--- a/spec/std/isa/param/VSXLEN.yaml
+++ b/spec/std/isa/param/VSXLEN.yaml
@@ -25,9 +25,14 @@ schema:
 requirements:
   idl(): |
     !$array_includes?(SXLEN, 64) -> !$array_includes?(VSXLEN, 64);
+
+    # When HSXLEN=32, hstatus.VSXL does not exist and VSXLEN=32, so a hart
+    # able to run HS-mode in RV32 must support VSXLEN=32.
+    $array_includes?(SXLEN, 32) -> $array_includes?(VSXLEN, 32);
   reason: |
     XLEN in VS-mode can never be larger than XLEN in S-mode
-    (and, transitively, cannot be larger than XLEN in M-mode).
+    (and, transitively, cannot be larger than XLEN in M-mode), and must be
+    able to equal it whenever HS-mode can run in RV32.
 definedBy:
   extension:
     name: H

--- a/spec/std/isa/param/VUXLEN.yaml
+++ b/spec/std/isa/param/VUXLEN.yaml
@@ -22,9 +22,14 @@ schema:
 requirements:
   idl(): |
     !$array_includes?(VSXLEN, 64) -> !$array_includes?(VUXLEN, 64);
+
+    # When VSXLEN=32, vsstatus.UXL does not exist and VU-mode XLEN=32, so a
+    # hart able to run VS-mode in RV32 must support VUXLEN=32.
+    $array_includes?(VSXLEN, 32) -> $array_includes?(VUXLEN, 32);
   reason: |
     XLEN in VU-mode can never be larger than XLEN in VS-mode
-    (and, transitively, cannot be larger than XLEN in S-mode or M-mode).
+    (and, transitively, cannot be larger than XLEN in S-mode or M-mode), and
+    must be able to equal it whenever VS-mode can run in RV32.
 definedBy:
   extension:
     name: H


### PR DESCRIPTION

`VSXLEN` and `VUXLEN` each constrained only their upper bound, so `VSXLEN: [32, 64]` with `VUXLEN: [64]` was accepted. In that hart `hstatus.VSXL` is read-write and can select RV32 for VS-mode, while `vsstatus.UXL` is hardwired to 64, leaving VU-mode wider than VS-mode. The same gap allowed `SXLEN: [32, 64]` with `VSXLEN: [64]`.

The privileged spec settles both: when HSXLEN=32 the VSXL field does not exist and VSXLEN=32, and when VSXLEN=32 the UXL field does not exist and VU-mode XLEN=32. So a hart whose parent mode can run in RV32 must support 32 in the child. `UXLEN` already carries this clause against `SXLEN`; this adds the two missing hypervisor analogues.

No config under `cfgs/` changes status. Of the five that set any of these parameters, none is newly rejected.

Closes #2254
