### PR TITLE
docs(idl): state what read_memory returns, and that the width is MXLEN

### DIFF
--- a/doc/docs/idl/standard-library.mdx
+++ b/doc/docs/idl/standard-library.mdx
@@ -120,20 +120,22 @@ Memory access functions handle virtual-to-physical address translation, PMP/PMA 
 
 Reads `len` bits from virtual memory. `len` must be 8, 16, 32, or 64.
 
+Returns `XReg`, which is `Bits<MXLEN>` and not `Bits<len>`. The width of the returned value is the register width, whatever the access size, and the `len` bits that were read are zero-extended into it. A signed load therefore has to widen the result itself with `sext(value, len)`, which is why `lb` and `lw` call `sext` while `lbu` and `lwu` assign the result directly.
+
 ```idl
-# Load byte (zero-extended)
+# Load byte, zero-extended into the full XReg
 X[xd] = read_memory(8, virtual_address, $encoding);
 
-# Load word (sign-extended via sext helper)
+# Load word, sign-extended from bit 31 by the sext helper
 X[xd] = sext(read_memory(32, virtual_address, $encoding), 32);
 
-# Load doubleword
+# Load doubleword. MXLEN must be 64 here, since the return type is Bits<MXLEN>
 Bits<64> data = read_memory(64, virtual_address, $encoding);
 ```
 
 ### `write_memory(len, virtual_address, value, encoding)`
 
-Writes `len` bits to virtual memory.
+Writes `len` bits to virtual memory. Returns nothing.
 
 ```idl
 # Store byte

--- a/doc/docs/idl/standard-library.mdx
+++ b/doc/docs/idl/standard-library.mdx
@@ -120,10 +120,10 @@ Memory access functions handle virtual-to-physical address translation, PMP/PMA 
 
 Reads `len` bits from virtual memory. `len` must be 8, 16, 32, or 64.
 
-Returns `XReg`, which is `Bits<MXLEN>` and not `Bits<len>`. The width of the returned value is the register width, whatever the access size, and the `len` bits that were read are zero-extended into it. A signed load therefore has to widen the result itself with `sext(value, len)`, which is why `lb` and `lw` call `sext` while `lbu` and `lwu` assign the result directly.
+Returns `XReg` (`Bits<MXLEN>`). The `len` bits that were read are zero-extended to MXLEN. To read a signed quantity, the caller must sign-extend the result itself with `sext(result, len)`.
 
 ```idl
-# Load byte, zero-extended into the full XReg
+# Load byte, zero-extended to full XReg width
 X[xd] = read_memory(8, virtual_address, $encoding);
 
 # Load word, sign-extended from bit 31 by the sext helper
@@ -135,7 +135,7 @@ Bits<64> data = read_memory(64, virtual_address, $encoding);
 
 ### `write_memory(len, virtual_address, value, encoding)`
 
-Writes `len` bits to virtual memory. Returns nothing.
+Writes `len` bits to virtual memory. Returns nothing (`void`).
 
 ```idl
 # Store byte


### PR DESCRIPTION
The standard library page documented `read_memory`'s arguments and gave three examples but never said what it returns. The answer is not obvious from the examples: it returns `XReg`, which is `Bits<MXLEN>`, so the returned width is the register width and not the access width, and the `len` bits that were read are zero-extended into it.

That is the reason signed loads look the way they do. `lb` and `lw` wrap the call in `sext` because the value arrives zero-extended, while `lbu` and `lwu` assign it straight to `X[xd]`. Without the return type written down, the `sext` in those examples reads like a style choice rather than a requirement.

Also notes that the doubleword example needs MXLEN to be 64, since `Bits<64>` cannot hold a `Bits<MXLEN>` result on a 32-bit config, and that `write_memory` returns nothing.

Closes #2253
