### PR TITLE
fix(data): correct field names in five CSR descriptions

### DIFF
--- a/spec/std/isa/csr/hstatus.yaml
+++ b/spec/std/isa/csr/hstatus.yaml
@@ -138,7 +138,7 @@ fields:
 
       Notably, `hstatus.VTVM` does *not* cause `hfence.vvma`, `sfence.w.inval`, or `sfence.inval.ir` to trap.
 
-      `mstatus.TVM` does not affect the VS-mode instructions controlled by `hstatus.TVTM`.
+      `mstatus.TVM` does not affect the VS-mode instructions controlled by `hstatus.VTVM`.
     type: RW
     reset_value: UNDEFINED_LEGAL
   VGEIN:

--- a/spec/std/isa/csr/mcycle.yaml
+++ b/spec/std/isa/csr/mcycle.yaml
@@ -40,7 +40,7 @@ fields:
       Cycle counter.
 
       <%- if ext?(:Zicntr) -%>
-      Aliased as `cycle.CYCLE`.
+      Aliased as `cycle.COUNT`.
       <%- end -%>
 
       Increments every cycle unless:

--- a/spec/std/isa/csr/mtvec.yaml
+++ b/spec/std/isa/csr/mtvec.yaml
@@ -49,7 +49,7 @@ fields:
 
       When Direct, all synchronous exceptions and asynchronous interrupts jump to (`mtvec.BASE` << 2).
 
-      When Vectored, asynchronous interrupts jump to (`mtvec.BASE` << 2 + `mcause.CAUSE`*4) while synchronous exceptions continue to jump to (`mtvec.BASE` << 2).
+      When Vectored, asynchronous interrupts jump to (`mtvec.BASE` << 2 + `mcause.CODE`*4) while synchronous exceptions continue to jump to (`mtvec.BASE` << 2).
     type(): |
       if (MTVEC_ACCESS == "ro") {
         return CsrFieldType::RO;

--- a/spec/std/isa/csr/stvec.yaml
+++ b/spec/std/isa/csr/stvec.yaml
@@ -41,7 +41,7 @@ fields:
 
       When Direct, all synchronous exceptions and asynchronous interrupts jump to (`stvec.BASE` << 2).
 
-      When Vectored, asynchronous interrupts jump to (`stvec.BASE` << 2 + `scause.CAUSE`*4) while synchronous exceptions continue to jump to (`stvec.BASE` << 2).
+      When Vectored, asynchronous interrupts jump to (`stvec.BASE` << 2 + `scause.CODE`*4) while synchronous exceptions continue to jump to (`stvec.BASE` << 2).
     type(): |
       return ($array_size(STVEC_MODES) == 1) ? CsrFieldType::RO : CsrFieldType::RWR;
     sw_write(csr_value): |

--- a/spec/std/isa/csr/vstvec.yaml
+++ b/spec/std/isa/csr/vstvec.yaml
@@ -42,7 +42,7 @@ fields:
 
       When Direct, all synchronous exceptions and asynchronous interrupts jump to (`vstvec.BASE` << 2).
 
-      When Vectored, asynchronous interrupts jump to (`vstvec.BASE` << 2 + `vscause.CAUSE`*4) while synchronous exceptions continue to jump to (`vstvec.BASE` << 2).
+      When Vectored, asynchronous interrupts jump to (`vstvec.BASE` << 2 + `vscause.CODE`*4) while synchronous exceptions continue to jump to (`vstvec.BASE` << 2).
     type(): |
       return ($array_size(VSTVEC_MODES) == 1) ? CsrFieldType::RO : CsrFieldType::RWR;
     sw_write(csr_value): |


### PR DESCRIPTION
Fix several instances where CSR field name descriptions used the wrong name.