### PR TITLE
docs(idl): document sext function

### DIFF
--- a/doc/docs/idl/standard-library.mdx
+++ b/doc/docs/idl/standard-library.mdx
@@ -149,3 +149,12 @@ write_memory(32, virtual_address, X[xs2][31:0], $encoding);
 :::note
 Both `read_memory` and `write_memory` may raise exceptions (access fault, page fault, misaligned) as a side effect of the access. No explicit error handling is needed in the calling code — the exception propagates automatically via `raise()`.
 :::
+
+### `sext(value, first_extended_bit)`
+
+Sign-extends `value` (an `XReg`) by replicating bit `first_extended_bit - 1` into bits `[MXLEN-1:first_extended_bit]` of the result.
+
+```idl
+# Load word (sign-extended via sext helper)
+X[xd] = sext(read_memory(32, virtual_address, $encoding), 32);
+```

--- a/doc/docs/idl/standard-library.mdx
+++ b/doc/docs/idl/standard-library.mdx
@@ -152,9 +152,12 @@ Both `read_memory` and `write_memory` may raise exceptions (access fault, page f
 
 ### `sext(value, first_extended_bit)`
 
-Sign-extends `value` (an `XReg`) by replicating bit `first_extended_bit - 1` into bits `[MXLEN-1:first_extended_bit]` of the result.
+Sign-extends `value` (an `XReg`) by replicating bit `first_extended_bit - 1` into bits `[MXLEN-1:first_extended_bit]` of the result. Returns an `XReg`.
 
 ```idl
+# Sign extend a 32-bit quantity to a full XReg width.
+XReg operand1 = sext(X[xs1], 32);
+
 # Load word (sign-extended via sext helper)
 X[xd] = sext(read_memory(32, virtual_address, $encoding), 32);
 ```


### PR DESCRIPTION
Documents the `sext` function in `standard-library.mdx`, per the discussion in #2252.

Description text uses MXLEN per @ThinkOpenly's confirmation that the doc/code should agree on MXLEN rather than XLEN.

Closes #2252.        

Wording suggested by @ThinkOpenly in #2252.