### PR TITLE
feat(inst): add fscsr, fsrm, fsflags pseudoinstructions to csrrw

### DIFF
--- a/spec/std/isa/inst/Zicsr/csrrw.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrw.yaml
@@ -34,6 +34,18 @@ access:
   vs: always
   vu: always
 pseudoinstructions:
+  - when: xd == 0 && csr == 0x001
+    to: fsflags xs1
+  - when: xd == 0 && csr == 0x002
+    to: fsrm xs1
+  - when: xd == 0 && csr == 0x003
+    to: fscsr xs1
+  - when: csr == 0x001
+    to: fsflags xd, xs1
+  - when: csr == 0x002
+    to: fsrm xd, xs1
+  - when: csr == 0x003
+    to: fscsr xd, xs1
   - when: xd == 0
     to: csrw csr, xs1
 operation(): |


### PR DESCRIPTION
Add fscsr, fsrm, and fsflags pseudoinstructions.

Each of the three CSRs gets both the two-operand swap form (`fscsr xd, xs1`) and
the one-operand write-only form used when `xd == 0` (`fscsr xs1`). The `xd == 0`
entries come first, and all six precede the existing `csrw` fallback, matching
the specific-before-general ordering already used in csrrs.yaml.

The immediate variants fsrmi and fsflagsi are the remaining gap in this family;
they belong in csrrwi.yaml and are left for a follow-up.

Fixes #2218