### PR TITLE
fix(param): enforce the counter-enable rules the descriptions already state

### DIFF
--- a/spec/std/isa/param/HCOUNTENABLE_EN.yaml
+++ b/spec/std/isa/param/HCOUNTENABLE_EN.yaml
@@ -25,3 +25,16 @@ schema:
 definedBy:
   extension:
     name: H
+requirements:
+  idl(): |
+    for (U32 i = 0; i < 3; i++) {
+      !implemented?(ExtensionName::Zicntr) -> !HCOUNTENABLE_EN[i];
+    }
+    for (U32 i = 3; i < 32; i++) {
+      !implemented?(ExtensionName::Zihpm) -> !HCOUNTENABLE_EN[i];
+      (!HPM_COUNTER_EN[i]) -> !HCOUNTENABLE_EN[i];
+    }
+  reason: |
+    Counters 0-2 are defined by Zicntr
+    Counters 3..31 are defined by Zihpm
+    When mhpmcounter[i] does not exist, it cannot be enabled.

--- a/spec/std/isa/param/HCOUNTENABLE_EN.yaml
+++ b/spec/std/isa/param/HCOUNTENABLE_EN.yaml
@@ -37,4 +37,4 @@ requirements:
   reason: |
     Counters 0-2 are defined by Zicntr
     Counters 3..31 are defined by Zihpm
-    When mhpmcounter[i] does not exist, it cannot be enabled.
+    When mhpmcounter[i] is not implemented, it cannot be enabled.

--- a/spec/std/isa/param/MCOUNTENABLE_EN.yaml
+++ b/spec/std/isa/param/MCOUNTENABLE_EN.yaml
@@ -27,6 +27,14 @@ definedBy:
     name: Sm
 requirements:
   idl(): |
+    for (U32 i = 0; i < 3; i++) {
+      !implemented?(ExtensionName::Zicntr) -> !MCOUNTENABLE_EN[i];
+    }
     for (U32 i=3; i < 32; i++) {
+      !implemented?(ExtensionName::Zihpm) -> !MCOUNTENABLE_EN[i];
       MCOUNTENABLE_EN[i] -> HPM_COUNTER_EN[i];
     }
+  reason: |
+    Counters 0-2 are defined by Zicntr
+    Counters 3..31 are defined by Zihpm
+    When mhpmcounter[i] does not exist, it cannot be enabled.

--- a/spec/std/isa/param/MCOUNTENABLE_EN.yaml
+++ b/spec/std/isa/param/MCOUNTENABLE_EN.yaml
@@ -37,4 +37,4 @@ requirements:
   reason: |
     Counters 0-2 are defined by Zicntr
     Counters 3..31 are defined by Zihpm
-    When mhpmcounter[i] does not exist, it cannot be enabled.
+    When mhpmcounter[i] is not implemented, it cannot be enabled.


### PR DESCRIPTION

`MCOUNTENABLE_EN`, `SCOUNTENABLE_EN` and `HCOUNTENABLE_EN` carry the same three sentences in their descriptions: an unimplemented counter cannot be enabled, bits 0 to 2 must be false without `Zicntr`, and bits 3 to 31 must be false without `Zihpm`. Only `SCOUNTENABLE_EN` encodes all three in `requirements`. `MCOUNTENABLE_EN` encodes one and `HCOUNTENABLE_EN` has no `requirements` block, so both accept configurations their own descriptions forbid.

This adds the missing clauses, copying the encoding `SCOUNTENABLE_EN` already uses. `MCOUNTENABLE_EN` keeps its existing counter-existence clause, which is the same rule written as a contrapositive. No cross-level clause is added, since the privileged spec states that a bit in `mcounteren` does not affect whether the corresponding bit in `scounteren` is writable.

No configuration changes status. Of the seven under `cfgs/` that set any of these parameters, none is newly rejected.

Closes #2265
