### PR TITLE
Avoid absolute wavedrom path in instruction appendix

### DIFF
--- a/backends/instructions_appendix/tasks.rake
+++ b/backends/instructions_appendix/tasks.rake
@@ -92,28 +92,10 @@ end
 namespace :test do
   desc "Check the instruction appendix output vs. stored golden output"
   task instruction_appendix: "gen:instruction_appendix_adoc" do
-    files = {
-      golden: {
-        file: Tempfile.new("golden"),
-        path: "#{$root}/tests/golden/all_instructions.golden.adoc"
-      },
-      output: {
-        file: Tempfile.new("output"),
-        path: "gen/instructions_appendix/all_instructions.adoc"
-      }
-    }
+    golden = "#{$root}/tests/golden/all_instructions.golden.adoc"
+    output = "gen/instructions_appendix/all_instructions.adoc"
 
-    # filter out lines that have file paths
-    [:golden, :output].each do |which|
-      file = files[which][:file]
-      path = files[which][:path]
-      orig = File.read(path)
-      filtered = orig.lines.reject { |l| l =~ /^:wavedrom:/ }.join("\n")
-      file.write(filtered)
-      file.flush
-    end
-
-    sh "diff -u #{files[:golden][:file].path} #{files[:output][:file].path}"
+    sh "diff -u #{golden} #{output}"
     if $? == 0
       puts "PASSED"
     else

--- a/backends/instructions_appendix/templates/instructions.adoc.erb
+++ b/backends/instructions_appendix/templates/instructions.adoc.erb
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: <%= $root %>/bin/wavedrom
+:wavedrom: {docdir}/../../bin/wavedrom
 // Now the document header is complete and the wavedrom attribute is active.
 
 <%- pb = Udb.create_progressbar(

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: /home/jcarlin/riscv-projects/riscv-unified-db/bin/wavedrom
+:wavedrom: {docdir}/../../bin/wavedrom
 // Now the document header is complete and the wavedrom attribute is active.
 
 


### PR DESCRIPTION
Use a docdir-relative wavedrom path in the generated instruction appendix so the golden file does not depend on a checkout-specific absolute path.