### PR TITLE
fix(data): use Sm for Smcntrpmf MINH fields

### DIFF
--- a/spec/std/isa/csr/Smcntrpmf/mcyclecfg.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/mcyclecfg.yaml
@@ -48,7 +48,7 @@ fields:
       allOf:
         - xlen: 64
         - extension:
-            name: M
+            name: Sm
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
 

--- a/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
@@ -24,7 +24,7 @@ fields:
     type: RW
     definedBy:
       extension:
-        name: M
+        name: Sm
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
 

--- a/spec/std/isa/csr/Smcntrpmf/minstretcfg.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/minstretcfg.yaml
@@ -45,7 +45,7 @@ fields:
       allOf:
         - xlen: 64
         - extension:
-            name: M
+            name: Sm
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
 

--- a/spec/std/isa/csr/Smcntrpmf/minstretcfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/minstretcfgh.yaml
@@ -24,7 +24,7 @@ fields:
     type: RW
     definedBy:
       extension:
-        name: M
+        name: Sm
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
 


### PR DESCRIPTION
The Smcntrpmf `MINH` fields describe machine-mode counter filtering, so they should depend on the machine-mode privileged extension `Sm`, not the integer multiply/divide extension `M`.

Generated with AI assistance.