### PR TITLE
fix(data): correct htval privilege mode and length

### DIFF
--- a/spec/std/isa/csr/H/htinst.yaml
+++ b/spec/std/isa/csr/H/htinst.yaml
@@ -10,9 +10,9 @@ address: 0x64a
 writable: true
 long_name: Hypervisor Trap Instruction Register
 description: |
-  When a trap is taken into HS-mode, mtinst is written with a value that, if nonzero,
+  When a trap is taken into HS-mode, htinst is written with a value that, if nonzero,
   provides information about the instruction that trapped, to assist software in handling the trap.
-  The values that may be written to mtinst on a trap are documented in TODO.
+  The values that may be written to htinst on a trap are documented in TODO.
 
   htinst is a WARL register that need only be able to hold the values that the implementation may automatically write to it on a trap.
 priv_mode: S

--- a/spec/std/isa/csr/H/htval.yaml
+++ b/spec/std/isa/csr/H/htval.yaml
@@ -19,8 +19,8 @@ description: |
   Otherwise, for misaligned loads and stores that cause guest-page faults, a nonzero guest physical address in htval corresponds to the faulting portion of the access as indicated by the virtual address in stval. For instruction guest-page faults on systems with variable-length instructions, a nonzero htval corresponds to the faulting portion of the instruction as indicated by the virtual address in stval.
 
   htval is a WARL register that must be able to hold zero and may be capable of holding only an arbitrary subset of other 2-bit-shifted guest physical addresses, if any.
-priv_mode: M
-length: MXLEN
+priv_mode: S
+length: SXLEN
 definedBy:
   extension:
     name: H
@@ -38,5 +38,5 @@ fields:
         return CsrFieldType::RO;
       }
     description: |
-      Exception-specific information for a trap into M-mode.
+      Exception-specific information for a trap into HS-mode.
     reset_value: UNDEFINED_LEGAL


### PR DESCRIPTION
`htval` is an HS-level hypervisor trap value CSR, so its data should use supervisor privilege mode and `SXLEN`, matching the other HS-level hypervisor CSRs.

This also fixes copied `mtinst` references in the `htinst` description.

Generated with AI assistance.