### PR TITLE
fix(data): correct TINST store/AMO access fault check

### DIFF
--- a/spec/std/isa/csr/H/htinst.yaml
+++ b/spec/std/isa/csr/H/htinst.yaml
@@ -34,7 +34,7 @@ fields:
           || (TINST_VALUE_ON_LOAD_ADDRESS_MISALIGNED != "always zero")
           || (TINST_VALUE_ON_LOAD_ACCESS_FAULT != "always zero")
           || (TINST_VALUE_ON_STORE_AMO_ADDRESS_MISALIGNED != "always zero")
-          || (TINST_VALUE_ON_STORE_AMO_ACCESS_FAULT != "always_zero")
+          || (TINST_VALUE_ON_STORE_AMO_ACCESS_FAULT != "always zero")
           || (TINST_VALUE_ON_UCALL != "always zero")
           || (TINST_VALUE_ON_SCALL != "always zero")
           || (TINST_VALUE_ON_MCALL != "always zero")

--- a/spec/std/isa/csr/H/mtinst.yaml
+++ b/spec/std/isa/csr/H/mtinst.yaml
@@ -34,7 +34,7 @@ fields:
           || (TINST_VALUE_ON_LOAD_ADDRESS_MISALIGNED != "always zero")
           || (TINST_VALUE_ON_LOAD_ACCESS_FAULT != "always zero")
           || (TINST_VALUE_ON_STORE_AMO_ADDRESS_MISALIGNED != "always zero")
-          || (TINST_VALUE_ON_STORE_AMO_ACCESS_FAULT != "always_zero")
+          || (TINST_VALUE_ON_STORE_AMO_ACCESS_FAULT != "always zero")
           || (TINST_VALUE_ON_UCALL != "always zero")
           || (TINST_VALUE_ON_SCALL != "always zero")
           || (TINST_VALUE_ON_MCALL != "always zero")


### PR DESCRIPTION
The `TINST_VALUE_ON_STORE_AMO_ACCESS_FAULT` parameter uses the enum value `"always zero"`, but the `htinst` and `mtinst` CSR type checks compared it against `"always_zero"`. Generated with AI assistance.