### PR TITLE
fix(data): correct TINST parameter descriptions

### DIFF
--- a/spec/std/isa/param/TINST_VALUE_ON_FINAL_INSTRUCTION_GUEST_PAGE_FAULT.yaml
+++ b/spec/std/isa/param/TINST_VALUE_ON_FINAL_INSTRUCTION_GUEST_PAGE_FAULT.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: TINST_VALUE_ON_FINAL_INSTRUCTION_GUEST_PAGE_FAULT
 description: |
-  Value to write into htval/mtval2 when there is a guest page fault on a final translation.
+  Value written into htinst/mtinst when there is an instruction guest-page fault on a final translation.
 
   Possible values:
     * "always zero": Always write the value zero

--- a/spec/std/isa/param/TINST_VALUE_ON_FINAL_LOAD_GUEST_PAGE_FAULT.yaml
+++ b/spec/std/isa/param/TINST_VALUE_ON_FINAL_LOAD_GUEST_PAGE_FAULT.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: TINST_VALUE_ON_FINAL_LOAD_GUEST_PAGE_FAULT
 description: |
-  Value to write into htval/mtval2 when there is a guest page fault on a final translation.
+  Value written into htinst/mtinst when there is a load guest-page fault on a final translation.
 
   Possible values:
     * "always zero": Always write the value zero

--- a/spec/std/isa/param/TINST_VALUE_ON_FINAL_STORE_AMO_GUEST_PAGE_FAULT.yaml
+++ b/spec/std/isa/param/TINST_VALUE_ON_FINAL_STORE_AMO_GUEST_PAGE_FAULT.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: TINST_VALUE_ON_FINAL_STORE_AMO_GUEST_PAGE_FAULT
 description: |
-  Value to write into htval/mtval2 when there is a guest page fault on a final translation.
+  Value written into htinst/mtinst when there is a store/AMO guest-page fault on a final translation.
 
   Possible values:
     * "always zero": Always write the value zero

--- a/spec/std/isa/param/TINST_VALUE_ON_LOAD_ADDRESS_MISALIGNED.yaml
+++ b/spec/std/isa/param/TINST_VALUE_ON_LOAD_ADDRESS_MISALIGNED.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: TINST_VALUE_ON_LOAD_ADDRESS_MISALIGNED
 description: |
-  Value written into htinst/mtinst on a VirtualInstruction exception from VU/VS-mode.
+  Value written into htinst/mtinst on a LoadAddressMisaligned exception from VU/VS-mode.
 
   Possible values:
     * "always zero": Always write the value zero

--- a/spec/std/isa/param/TINST_VALUE_ON_STORE_AMO_ADDRESS_MISALIGNED.yaml
+++ b/spec/std/isa/param/TINST_VALUE_ON_STORE_AMO_ADDRESS_MISALIGNED.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: TINST_VALUE_ON_STORE_AMO_ADDRESS_MISALIGNED
 description: |
-  Value written into htinst/mtinst on a VirtualInstruction exception from VU/VS-mode.
+  Value written into htinst/mtinst on a StoreAmoAddressMisaligned exception from VU/VS-mode.
 
   Possible values:
     * "always zero": Always write the value zero


### PR DESCRIPTION
Several `TINST_VALUE_*` parameter descriptions referred to the wrong CSR or exception type. This updates final guest-page-fault descriptions to refer to `htinst`/`mtinst`, and updates address-misaligned descriptions to name the matching exception.

Generated with AI assistance.