### PR TITLE
fix(data): write minstreth updates to minstret

### DIFF
--- a/spec/std/isa/csr/minstreth.yaml
+++ b/spec/std/isa/csr/minstreth.yaml
@@ -28,7 +28,7 @@ fields:
     reset_value: UNDEFINED_LEGAL
     affectedBy: [Zicntr, Smcntrpmf, Smcdeleg, Ssccfg]
     sw_write(csr_value): |
-      CSR[mcycle].COUNT = {csr_value.COUNT[31:0], CSR[minstret].COUNT[31:0]};
+      CSR[minstret].COUNT = {csr_value.COUNT[31:0], CSR[minstret].COUNT[31:0]};
       return csr_value.COUNT;
 definedBy:
   allOf:


### PR DESCRIPTION
`minstreth.COUNT` aliases the upper half of `minstret`, but its write operation updated `mcycle` instead. This corrects the write target to update `minstret`.

Generated with AI assistance.