### PR TITLE
fix(data): preserve correct upper mcycle bits on RV32 writes

### DIFF
--- a/spec/std/isa/csr/mcycle.yaml
+++ b/spec/std/isa/csr/mcycle.yaml
@@ -32,7 +32,7 @@ fields:
       # since writes to this register may not be hart-local, it must be handled
       # as a special case
       if (xlen() == 32) {
-        return sw_write_mcycle({read_mcycle()[63:31], csr_value.COUNT[31:0]});
+        return sw_write_mcycle({read_mcycle()[63:32], csr_value.COUNT[31:0]});
       } else {
         return sw_write_mcycle(csr_value.COUNT);
       }


### PR DESCRIPTION
RV32 writes to `mcycle.COUNT` should update the low 32 bits while preserving bits 63:32. The existing write path preserved bits 63:31, so this corrects the preserved slice.

Generated with AI assistance.