### PR TITLE
fix(data): correct counter filter alias descriptions

### DIFF
--- a/spec/std/isa/csr/mcycle.yaml
+++ b/spec/std/isa/csr/mcycle.yaml
@@ -49,14 +49,14 @@ fields:
         <%- if ext?(:Smcntrpmf) -%>
         * `mcyclecfg.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mcyclecfg.SINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mcyclecfg.SINH` <%- if ext?(:Ssccfg) -%>or its alias `cyclecfg.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mcyclecfg.UINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is U
+        * `mcyclecfg.UINH` <%- if ext?(:Ssccfg) -%>or its alias `cyclecfg.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mcyclecfg.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mcyclecfg.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mcyclecfg.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `cyclecfg.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mcyclecfg.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `cyclecfg.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
     reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/minstret.yaml
+++ b/spec/std/isa/csr/minstret.yaml
@@ -37,11 +37,11 @@ fields:
         * `minstretcfg.SINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `minstretcfg.UINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is U
+        * `minstretcfg.UINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `minstretcfg.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is VS
-        * `minstretcfg.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.SINH`<%- end -%> is set and the current privilege level is VU
+        * `minstretcfg.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `minstretcfg.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `instretcfg.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
 


### PR DESCRIPTION
The `mcycle.COUNT` and `minstret.COUNT` descriptions listed incorrect Ssccfg aliases for several privilege-mode filter bits. This updates the aliases to use the matching counter and field names.

Generated with AI assistance.