### PR TITLE
feat(schema): allow string extension names in data_independent_timing 

### DIFF
--- a/doc/data-templates.adoc
+++ b/doc/data-templates.adoc
@@ -96,7 +96,7 @@ access:
   u: always    # U-mode access
   vs: always   # VS-mode access
   vu: always   # VU-mode access
-data_independent_timing: true  # For cryptographic extensions
+data_independent_timing: true  # true if always, false if never, or extension name ('Zkt', 'Zvkt')
 operation(): |
   # IDL code implementing the instruction
   X[xd] = X[xs1] + $signed(imm);

--- a/doc/docs/schemas/index.mdx
+++ b/doc/docs/schemas/index.mdx
@@ -54,6 +54,11 @@ Schemas are versioned independently of the UDB repository. Each schema file decl
 </div>
 
 <div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
+  <strong><a href="./v0.3/inst_schema">Inst Schema</a></strong><br />
+  <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.3</span>
+</div>
+
+<div style={{padding: '1rem', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}>
   <strong><a href="./v0.1/inst_subtype_schema">Inst Subtype Schema</a></strong><br />
   <span className="badge badge--secondary" style={{marginTop: '0.4rem', display: 'inline-block'}}>v0.1</span>
 </div>

--- a/doc/docs/schemas/v0.1/_category_.json
+++ b/doc/docs/schemas/v0.1/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "v0.1",
-  "position": 2,
+  "position": 3,
   "collapsible": true,
   "collapsed": false
 }

--- a/doc/docs/schemas/v0.1/inst_schema.mdx
+++ b/doc/docs/schemas/v0.1/inst_schema.mdx
@@ -106,7 +106,7 @@ Decode field
 | `encoding` | One of: [`old_encoding`](#old-encoding) \| `object` |  | Instruction encoding and decode variables |
 | `format` | `object` |  |  |
 | `pseudoinstructions` | Array&lt;\{`when`, `to`\}&gt; [↓&nbsp;schema](#pseudoinstructions-schema) |  | Variations of this instruction that form a pseudoinstruction |
-| `data_independent_timing` | One of: `boolean` \| `string` |  | Whether the instruction always has data-independent timing (true), never does (false), or does when a specific extension is implemented (e.g., 'Zkt' or 'Zvkt') |
+| `data_independent_timing` | `boolean` |  | Whether or not the instruction must execute with data-independent timing when the Zkt extension is supported |
 | `cert_normative_rules` | Architecturally visible behaviors requiring validation by certification tests |  |  |
 | `sail()` | `string` |  | Functional description of the instruction using Sail |
 | `operation_ast` | `object` |  |  |

--- a/doc/docs/schemas/v0.2/inst_schema.mdx
+++ b/doc/docs/schemas/v0.2/inst_schema.mdx
@@ -106,7 +106,7 @@ Decode field
 | `encoding` | One of: [`old_encoding`](#old-encoding) \| `object` |  | Instruction encoding and decode variables |
 | `format` | `object` |  |  |
 | `pseudoinstructions` | Array&lt;\{`when`, `to`\}&gt; [↓&nbsp;schema](#pseudoinstructions-schema) |  | Variations of this instruction that form a pseudoinstruction |
-| `data_independent_timing` | `boolean` |  | Whether or not the instruction must execute with data-independent timing when the Zkt extension is supported |
+| `data_independent_timing` | One of: `boolean` \| `string` |  | Whether the instruction always has data-independent timing (true), never does (false), or does when a specific extension is implemented (e.g., 'Zkt' or 'Zvkt') |
 | `operation_ast` | `object` |  |  |
 | `operation()` | `string` |  | Functional description of the instruction using IDL language |
 | `access_detail` | `string` |  | Extra detail about access when at least one mode is 'sometimes' |

--- a/doc/docs/schemas/v0.2/inst_schema.mdx
+++ b/doc/docs/schemas/v0.2/inst_schema.mdx
@@ -106,7 +106,7 @@ Decode field
 | `encoding` | One of: [`old_encoding`](#old-encoding) \| `object` |  | Instruction encoding and decode variables |
 | `format` | `object` |  |  |
 | `pseudoinstructions` | Array&lt;\{`when`, `to`\}&gt; [↓&nbsp;schema](#pseudoinstructions-schema) |  | Variations of this instruction that form a pseudoinstruction |
-| `data_independent_timing` | One of: `boolean` \| `string` |  | Whether the instruction always has data-independent timing (true), never does (false), or does when a specific extension is implemented (e.g., 'Zkt' or 'Zvkt') |
+| `data_independent_timing` | `boolean` |  | Whether or not the instruction must execute with data-independent timing when the Zkt extension is supported |
 | `operation_ast` | `object` |  |  |
 | `operation()` | `string` |  | Functional description of the instruction using IDL language |
 | `access_detail` | `string` |  | Extra detail about access when at least one mode is 'sometimes' |

--- a/doc/docs/schemas/v0.3/_category_.json
+++ b/doc/docs/schemas/v0.3/_category_.json
@@ -1,6 +1,6 @@
 {
-  "label": "v0.2",
-  "position": 2,
+  "label": "v0.3",
+  "position": 1,
   "collapsible": true,
   "collapsed": false
 }

--- a/doc/docs/schemas/v0.3/inst_schema.mdx
+++ b/doc/docs/schemas/v0.3/inst_schema.mdx
@@ -1,5 +1,5 @@
 ---
-title: Inst Schema (v0.1)
+title: Inst Schema (v0.3)
 sidebar_label: Inst Schema
 custom_edit_url: null
 # This file is auto-generated from inst_schema.json
@@ -13,7 +13,7 @@ import AnchorOpenDetails from '@site/src/components/AnchorOpenDetails';
 
 # Inst Schema
 
-<span class="badge badge--secondary">v0.1</span>
+<span class="badge badge--secondary">v0.3</span>
 
 <br />
 
@@ -107,8 +107,6 @@ Decode field
 | `format` | `object` |  |  |
 | `pseudoinstructions` | Array&lt;\{`when`, `to`\}&gt; [↓&nbsp;schema](#pseudoinstructions-schema) |  | Variations of this instruction that form a pseudoinstruction |
 | `data_independent_timing` | One of: `boolean` \| `string` |  | Whether the instruction always has data-independent timing (true), never does (false), or does when a specific extension is implemented (e.g., 'Zkt' or 'Zvkt') |
-| `cert_normative_rules` | Architecturally visible behaviors requiring validation by certification tests |  |  |
-| `sail()` | `string` |  | Functional description of the instruction using Sail |
 | `operation_ast` | `object` |  |  |
 | `operation()` | `string` |  | Functional description of the instruction using IDL language |
 | `access_detail` | `string` |  | Extra detail about access when at least one mode is 'sometimes' |
@@ -143,5 +141,5 @@ Decode field
 
 | Property | Value |
 |----------|-------|
-| Version | `v0.1` |
+| Version | `v0.3` |
 | JSON Schema Version | [Draft 07](https://json-schema.org/draft-07) |

--- a/spec/schemas/inst_schema.json
+++ b/spec/schemas/inst_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.2",
+  "$id": "v0.3",
   "$defs": {
     "fully_resolved_opcodes": {
       "type": "object",
@@ -391,8 +391,15 @@
       "description": "Assembly format of the instruction. Can use decode variables"
     },
     "data_independent_timing": {
-      "type": "boolean",
-      "description": "Whether or not the instruction must execute with data-independent timing when the Zkt extension is supported",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Whether the instruction always has data-independent timing (true), never does (false), or does when a specific extension is implemented (e.g., 'Zkt' or 'Zvkt')",
       "default": false
     },
     "pseudoinstructions": {

--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/clmul.yaml
+++ b/spec/std/isa/inst/B/clmul.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/orn.yaml
+++ b/spec/std/isa/inst/B/orn.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/rev8.yaml
+++ b/spec/std/isa/inst/B/rev8.yaml
@@ -43,7 +43,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/rol.yaml
+++ b/spec/std/isa/inst/B/rol.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/rolw.yaml
+++ b/spec/std/isa/inst/B/rolw.yaml
@@ -32,7 +32,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/ror.yaml
+++ b/spec/std/isa/inst/B/ror.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/rori.yaml
+++ b/spec/std/isa/inst/B/rori.yaml
@@ -40,7 +40,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/roriw.yaml
+++ b/spec/std/isa/inst/B/roriw.yaml
@@ -33,7 +33,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -33,7 +33,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/B/xnor.yaml
+++ b/spec/std/isa/inst/B/xnor.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.add.yaml
+++ b/spec/std/isa/inst/C/c.add.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 hints:
   - { $ref: inst/Zihintntl/c.ntl.p1.yaml# }
   - { $ref: inst/Zihintntl/c.ntl.pall.yaml# }

--- a/spec/std/isa/inst/C/c.addi.yaml
+++ b/spec/std/isa/inst/C/c.addi.yaml
@@ -31,7 +31,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.addiw.yaml
+++ b/spec/std/isa/inst/C/c.addiw.yaml
@@ -32,7 +32,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.addw.yaml
+++ b/spec/std/isa/inst/C/c.addw.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   Bits<32> t0 = X[creg2reg(xd)][31:0];
   Bits<32> t1 = X[creg2reg(xs2)][31:0];

--- a/spec/std/isa/inst/C/c.and.yaml
+++ b/spec/std/isa/inst/C/c.and.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/C/c.andi.yaml
+++ b/spec/std/isa/inst/C/c.andi.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-63
   X[creg2reg(xd)] = X[creg2reg(xd)] & $signed(imm);

--- a/spec/std/isa/inst/C/c.lui.yaml
+++ b/spec/std/isa/inst/C/c.lui.yaml
@@ -31,7 +31,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.mv.yaml
+++ b/spec/std/isa/inst/C/c.mv.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.nop.yaml
+++ b/spec/std/isa/inst/C/c.nop.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/C/c.or.yaml
+++ b/spec/std/isa/inst/C/c.or.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/C/c.slli.yaml
+++ b/spec/std/isa/inst/C/c.slli.yaml
@@ -36,7 +36,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-63
   X[xd] = X[xd] << shamt;

--- a/spec/std/isa/inst/C/c.srai.yaml
+++ b/spec/std/isa/inst/C/c.srai.yaml
@@ -37,7 +37,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-63
   X[creg2reg(xd)] = X[creg2reg(xd)] >>> shamt;

--- a/spec/std/isa/inst/C/c.srli.yaml
+++ b/spec/std/isa/inst/C/c.srli.yaml
@@ -37,7 +37,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-63
   X[creg2reg(xd)] = X[creg2reg(xd)] >> shamt;

--- a/spec/std/isa/inst/C/c.sub.yaml
+++ b/spec/std/isa/inst/C/c.sub.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/C/c.subw.yaml
+++ b/spec/std/isa/inst/C/c.subw.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   Bits<32> t0 = X[creg2reg(xd)][31:0];
   Bits<32> t1 = X[creg2reg(xs2)][31:0];

--- a/spec/std/isa/inst/C/c.xor.yaml
+++ b/spec/std/isa/inst/C/c.xor.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg t0 = X[creg2reg(xd)];
   XReg t1 = X[creg2reg(xs2)];

--- a/spec/std/isa/inst/I/add.yaml
+++ b/spec/std/isa/inst/I/add.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 hints:
   - { $ref: inst/Zihintntl/ntl.p1.yaml# }
   - { $ref: inst/Zihintntl/ntl.pall.yaml# }

--- a/spec/std/isa/inst/I/addi.yaml
+++ b/spec/std/isa/inst/I/addi.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: (xd == 0 && xs1 == 0 && imm == 0)
     to: nop

--- a/spec/std/isa/inst/I/addiw.yaml
+++ b/spec/std/isa/inst/I/addiw.yaml
@@ -31,7 +31,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: imm == 0
     to: sext.w xd, xs1

--- a/spec/std/isa/inst/I/addw.yaml
+++ b/spec/std/isa/inst/I/addw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg operand1 = sext(X[xs1], 32);
   XReg operand2 = sext(X[xs2], 32);

--- a/spec/std/isa/inst/I/and.yaml
+++ b/spec/std/isa/inst/I/and.yaml
@@ -26,5 +26,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = X[xs1] & X[xs2];

--- a/spec/std/isa/inst/I/andi.yaml
+++ b/spec/std/isa/inst/I/andi.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: imm == 255
     to: zext.b xd, xs1

--- a/spec/std/isa/inst/I/auipc.yaml
+++ b/spec/std/isa/inst/I/auipc.yaml
@@ -28,5 +28,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = $pc + $signed(imm);

--- a/spec/std/isa/inst/I/lui.yaml
+++ b/spec/std/isa/inst/I/lui.yaml
@@ -26,5 +26,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = $signed(imm);

--- a/spec/std/isa/inst/I/or.yaml
+++ b/spec/std/isa/inst/I/or.yaml
@@ -26,5 +26,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = X[xs1] | X[xs2];

--- a/spec/std/isa/inst/I/ori.yaml
+++ b/spec/std/isa/inst/I/ori.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 hints:
   - { $ref: inst/Zicbop/prefetch.r.yaml# }
   - { $ref: inst/Zicbop/prefetch.w.yaml# }

--- a/spec/std/isa/inst/I/sll.yaml
+++ b/spec/std/isa/inst/I/sll.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (xlen() == 64) {
     X[xd] = X[xs1] << X[xs2][5:0];

--- a/spec/std/isa/inst/I/slli.yaml
+++ b/spec/std/isa/inst/I/slli.yaml
@@ -36,7 +36,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-(XLEN-1)
   X[xd] = X[xs1] << shamt;

--- a/spec/std/isa/inst/I/slliw.yaml
+++ b/spec/std/isa/inst/I/slliw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-32
   X[xd] = sext(X[xs1] << shamt, 32);

--- a/spec/std/isa/inst/I/sllw.yaml
+++ b/spec/std/isa/inst/I/sllw.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = sext(X[xs1] << X[xs2][4:0], 32);

--- a/spec/std/isa/inst/I/slt.yaml
+++ b/spec/std/isa/inst/I/slt.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: xs2 == 0
     to: sltz xd, xs1

--- a/spec/std/isa/inst/I/slti.yaml
+++ b/spec/std/isa/inst/I/slti.yaml
@@ -29,6 +29,6 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   X[xd] = ($signed(X[xs1]) < $signed(imm)) ? '1 : '0;

--- a/spec/std/isa/inst/I/sltiu.yaml
+++ b/spec/std/isa/inst/I/sltiu.yaml
@@ -33,7 +33,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: imm == 1
     to: seqz xd, xs1

--- a/spec/std/isa/inst/I/sltu.yaml
+++ b/spec/std/isa/inst/I/sltu.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: xs1 == 0
     to: snez xd, xs2

--- a/spec/std/isa/inst/I/sra.yaml
+++ b/spec/std/isa/inst/I/sra.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (xlen() == 64) {
     X[xd] = X[xs1] >>> X[xs2][5:0];

--- a/spec/std/isa/inst/I/srai.yaml
+++ b/spec/std/isa/inst/I/srai.yaml
@@ -38,7 +38,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-63
   X[xd] = X[xs1] >>> shamt;

--- a/spec/std/isa/inst/I/sraiw.yaml
+++ b/spec/std/isa/inst/I/sraiw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-32
   XReg operand = sext(X[xs1], 32);

--- a/spec/std/isa/inst/I/sraw.yaml
+++ b/spec/std/isa/inst/I/sraw.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg operand1 = sext(X[xs1], 32);
 

--- a/spec/std/isa/inst/I/srl.yaml
+++ b/spec/std/isa/inst/I/srl.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (xlen() == 64) {
     X[xd] = X[xs1] >> X[xs2][5:0];

--- a/spec/std/isa/inst/I/srli.yaml
+++ b/spec/std/isa/inst/I/srli.yaml
@@ -35,7 +35,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-63
   X[xd] = X[xs1] >> shamt;

--- a/spec/std/isa/inst/I/srliw.yaml
+++ b/spec/std/isa/inst/I/srliw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   # shamt is between 0-31
   XReg operand = X[xs1][31:0];

--- a/spec/std/isa/inst/I/srlw.yaml
+++ b/spec/std/isa/inst/I/srlw.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = sext(X[xs1][31:0] >> X[xs2][4:0], 32);

--- a/spec/std/isa/inst/I/sub.yaml
+++ b/spec/std/isa/inst/I/sub.yaml
@@ -26,7 +26,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: xs1 == 0
     to: neg xd, xs2

--- a/spec/std/isa/inst/I/subw.yaml
+++ b/spec/std/isa/inst/I/subw.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: xs1 == 0
     to: negw xd, xs2

--- a/spec/std/isa/inst/I/xor.yaml
+++ b/spec/std/isa/inst/I/xor.yaml
@@ -26,5 +26,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): X[xd] = X[xs1] ^ X[xs2];

--- a/spec/std/isa/inst/I/xori.yaml
+++ b/spec/std/isa/inst/I/xori.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: $signed(imm) == -1
     to: not xd, xs1

--- a/spec/std/isa/inst/M/mul.yaml
+++ b/spec/std/isa/inst/M/mul.yaml
@@ -40,7 +40,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/M/mulh.yaml
+++ b/spec/std/isa/inst/M/mulh.yaml
@@ -39,7 +39,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/M/mulhsu.yaml
+++ b/spec/std/isa/inst/M/mulhsu.yaml
@@ -39,7 +39,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/M/mulhu.yaml
+++ b/spec/std/isa/inst/M/mulhu.yaml
@@ -39,7 +39,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/M/mulw.yaml
+++ b/spec/std/isa/inst/M/mulw.yaml
@@ -40,7 +40,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/README.md
+++ b/spec/std/isa/inst/README.md
@@ -62,7 +62,7 @@ operation(): |
   - **`name`**: Name of the field (e.g., `xs1`, `xs2`).
   - **`location`**: Bit positions of the field in the instruction encoding.
 - **`access`**: Specifies the privilege mode access for the instruction (`always`, `sometimes`, or `never`).
-- **`data_independent_timing`**: Indicates whether the execution timing is data-independent.
+- **`data_independent_timing`**: Indicates whether the execution timing is data-independent. A boolean (`true`/`false`) indicates if the instruction always or never has data-independent timing. A string indicates the extension (e.g., `Zkt` or `Zvkt`) that requires the instruction to have data-independent timing. A boolean (`true`/`false`) indicates if the instruction always or never has data-independent timing. A string indicates the extension (e.g., `Zkt` or `Zvkt`) that requires the instruction to have data-independent timing. A boolean (`true`/`false`) indicates if the instruction always or never has data-independent timing. A string indicates the extension (e.g., `Zkt` or `Zvkt`) that requires the instruction to have data-independent timing.
 - **`operation()`**: Optional field for IDL description. Leave empty if unused.
 
 ## JSON Schema

--- a/spec/std/isa/inst/V/vadd.vi.yaml
+++ b/spec/std/isa/inst/V/vadd.vi.yaml
@@ -30,5 +30,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vadd.vv.yaml
+++ b/spec/std/isa/inst/V/vadd.vv.yaml
@@ -30,7 +30,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |
   VectorState state = vector_state();
   VectorLmulType lmul_type = state.lmul_type;

--- a/spec/std/isa/inst/V/vadd.vx.yaml
+++ b/spec/std/isa/inst/V/vadd.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vrsub.vi.yaml
+++ b/spec/std/isa/inst/V/vrsub.vi.yaml
@@ -30,5 +30,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vrsub.vx.yaml
+++ b/spec/std/isa/inst/V/vrsub.vx.yaml
@@ -32,5 +32,5 @@ access:
 pseudoinstructions:
   - when: xs1 == 0
     to: vneg.v vd, vs2, vm
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vsub.vv.yaml
+++ b/spec/std/isa/inst/V/vsub.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vsub.vx.yaml
+++ b/spec/std/isa/inst/V/vsub.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwadd.vv.yaml
+++ b/spec/std/isa/inst/V/vwadd.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwadd.vx.yaml
+++ b/spec/std/isa/inst/V/vwadd.vx.yaml
@@ -32,5 +32,5 @@ access:
 pseudoinstructions:
   - when: xs1 == 0
     to: vwcvt.x.x.v vd, vs2, vm
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwadd.wv.yaml
+++ b/spec/std/isa/inst/V/vwadd.wv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwadd.wx.yaml
+++ b/spec/std/isa/inst/V/vwadd.wx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwaddu.vv.yaml
+++ b/spec/std/isa/inst/V/vwaddu.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwaddu.vx.yaml
+++ b/spec/std/isa/inst/V/vwaddu.vx.yaml
@@ -32,5 +32,5 @@ access:
 pseudoinstructions:
   - when: xs1 == 0
     to: vwcvtu.x.x.v vd, vs2, vm
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwaddu.wv.yaml
+++ b/spec/std/isa/inst/V/vwaddu.wv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwaddu.wx.yaml
+++ b/spec/std/isa/inst/V/vwaddu.wx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsub.vv.yaml
+++ b/spec/std/isa/inst/V/vwsub.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsub.vx.yaml
+++ b/spec/std/isa/inst/V/vwsub.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsub.wv.yaml
+++ b/spec/std/isa/inst/V/vwsub.wv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsub.wx.yaml
+++ b/spec/std/isa/inst/V/vwsub.wx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsubu.vv.yaml
+++ b/spec/std/isa/inst/V/vwsubu.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsubu.vx.yaml
+++ b/spec/std/isa/inst/V/vwsubu.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsubu.wv.yaml
+++ b/spec/std/isa/inst/V/vwsubu.wv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/V/vwsubu.wx.yaml
+++ b/spec/std/isa/inst/V/vwsubu.wx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zbkb/brev8.yaml
+++ b/spec/std/isa/inst/Zbkb/brev8.yaml
@@ -25,7 +25,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg input = X[xs1];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbkb/pack.yaml
+++ b/spec/std/isa/inst/Zbkb/pack.yaml
@@ -27,7 +27,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: (xs2 == 0) && (xlen() == 32)
     to: zext.h xd, xs1

--- a/spec/std/isa/inst/Zbkb/packh.yaml
+++ b/spec/std/isa/inst/Zbkb/packh.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |

--- a/spec/std/isa/inst/Zbkb/packw.yaml
+++ b/spec/std/isa/inst/Zbkb/packw.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 pseudoinstructions:
   - when: (xs2 == 0x0)
     to: zext.h xd, xs1

--- a/spec/std/isa/inst/Zbkb/unzip.yaml
+++ b/spec/std/isa/inst/Zbkb/unzip.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg input = X[xs1];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbkb/zip.yaml
+++ b/spec/std/isa/inst/Zbkb/zip.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg input = X[xs1];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbkx/xperm4.yaml
+++ b/spec/std/isa/inst/Zbkx/xperm4.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg input1 = X[xs1];
   XReg input2 = X[xs2];

--- a/spec/std/isa/inst/Zbkx/xperm8.yaml
+++ b/spec/std/isa/inst/Zbkx/xperm8.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   XReg input1 = X[xs1];
   XReg input2 = X[xs2];

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -28,7 +28,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
 
   if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {

--- a/spec/std/isa/inst/Zcb/c.not.yaml
+++ b/spec/std/isa/inst/Zcb/c.not.yaml
@@ -25,7 +25,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
 
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {

--- a/spec/std/isa/inst/Zcb/c.zext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.b.yaml
@@ -26,7 +26,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |2
 
   if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {

--- a/spec/std/isa/inst/Zicond/czero.eqz.yaml
+++ b/spec/std/isa/inst/Zicond/czero.eqz.yaml
@@ -30,6 +30,6 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   X[xd] = (X[xs2] == 0) ? 0 : X[xs1];

--- a/spec/std/isa/inst/Zicond/czero.nez.yaml
+++ b/spec/std/isa/inst/Zicond/czero.nez.yaml
@@ -30,6 +30,6 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zkt
 operation(): |
   X[xd] = (X[xs2] != 0) ? 0 : X[xs1];

--- a/spec/std/isa/inst/Zvbb/vandn.vv.yaml
+++ b/spec/std/isa/inst/Zvbb/vandn.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vandn.vx.yaml
+++ b/spec/std/isa/inst/Zvbb/vandn.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vbrev.v.yaml
+++ b/spec/std/isa/inst/Zvbb/vbrev.v.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vbrev8.v.yaml
+++ b/spec/std/isa/inst/Zvbb/vbrev8.v.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vclz.v.yaml
+++ b/spec/std/isa/inst/Zvbb/vclz.v.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vcpop.v.yaml
+++ b/spec/std/isa/inst/Zvbb/vcpop.v.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vctz.v.yaml
+++ b/spec/std/isa/inst/Zvbb/vctz.v.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vrev8.v.yaml
+++ b/spec/std/isa/inst/Zvbb/vrev8.v.yaml
@@ -27,5 +27,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vrol.vv.yaml
+++ b/spec/std/isa/inst/Zvbb/vrol.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vrol.vx.yaml
+++ b/spec/std/isa/inst/Zvbb/vrol.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vror.vi.yaml
+++ b/spec/std/isa/inst/Zvbb/vror.vi.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vror.vv.yaml
+++ b/spec/std/isa/inst/Zvbb/vror.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vror.vx.yaml
+++ b/spec/std/isa/inst/Zvbb/vror.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vwsll.vi.yaml
+++ b/spec/std/isa/inst/Zvbb/vwsll.vi.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vwsll.vv.yaml
+++ b/spec/std/isa/inst/Zvbb/vwsll.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbb/vwsll.vx.yaml
+++ b/spec/std/isa/inst/Zvbb/vwsll.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbc/vclmul.vv.yaml
+++ b/spec/std/isa/inst/Zvbc/vclmul.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbc/vclmul.vx.yaml
+++ b/spec/std/isa/inst/Zvbc/vclmul.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbc/vclmulh.vv.yaml
+++ b/spec/std/isa/inst/Zvbc/vclmulh.vv.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/spec/std/isa/inst/Zvbc/vclmulh.vx.yaml
+++ b/spec/std/isa/inst/Zvbc/vclmulh.vx.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: true
+data_independent_timing: Zvkt
 operation(): |

--- a/tools/ruby-gems/udb-gen/templates/manual/instruction.adoc.erb
+++ b/tools/ruby-gems/udb-gen/templates/manual/instruction.adoc.erb
@@ -12,7 +12,11 @@
 
 <%- if inst.data_independent_timing? -%>
 [IMPORTANT]
-This instruction must have data-independent timing when extension `Zkt` is enabled.
+<%- if inst.data_independent_timing.is_a?(String) -%>
+This instruction must have data-independent timing when extension `<%= inst.data_independent_timing %>` is enabled.
+<%- else -%>
+This instruction must always have data-independent timing.
+<%- end -%>
 <%- end -%>
 
 == Assembly format

--- a/tools/ruby-gems/udb/lib/udb/obj/instruction.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/instruction.rb
@@ -398,8 +398,13 @@ module Udb
         end
     end
 
-    # @return [Boolean] Whether or not the instruction must have data-independent timing when Zkt is enabled.
-    def data_independent_timing? = @data["data_independent_timing"]
+    # @return [Boolean, String, nil] Whether the instruction always has data-independent timing (true), never does (false/nil), or does when a specific extension is implemented (String).
+    sig { returns(T.nilable(T.any(T::Boolean, String))) }
+    def data_independent_timing = @data["data_independent_timing"]
+
+    # @return [Boolean] Whether the instruction has data-independent timing (always or under an extension).
+    sig { returns(T::Boolean) }
+    def data_independent_timing? = !!@data["data_independent_timing"]
 
     # @param xlen [Integer] 32 or 64, the target xlen
     # @return [Boolean] whethen or not instruction is defined in base +xlen+

--- a/tools/ruby-gems/udb/test/test_instruction.rb
+++ b/tools/ruby-gems/udb/test/test_instruction.rb
@@ -61,4 +61,28 @@ class TestInstruction < Minitest::Test
     extracted = rs1_var.extract
     refute_match(/sext/, extracted, "non-signed decode variable should not use sext")
   end
+
+  def test_data_independent_timing
+    db = @cfg_arch
+
+    add_inst = db.instructions.find { |i| i.name == "add" }
+    refute_nil add_inst, "ADD instruction should be found"
+    assert_equal "Zkt", add_inst.data_independent_timing
+    assert_equal true, add_inst.data_independent_timing?
+
+    sha_inst = db.instructions.find { |i| i.name == "sha256sig0" }
+    refute_nil sha_inst, "SHA256SIG0 instruction should be found"
+    assert_equal true, sha_inst.data_independent_timing
+    assert_equal true, sha_inst.data_independent_timing?
+
+    vadd_inst = db.instructions.find { |i| i.name == "vadd.vv" }
+    refute_nil vadd_inst, "VADD.VV instruction should be found"
+    assert_equal "Zvkt", vadd_inst.data_independent_timing
+    assert_equal true, vadd_inst.data_independent_timing?
+
+    fld_inst = db.instructions.find { |i| i.name == "fld" }
+    refute_nil fld_inst, "FLD instruction should be found"
+    assert_equal false, fld_inst.data_independent_timing
+    assert_equal false, fld_inst.data_independent_timing?
+  end
 end


### PR DESCRIPTION
### Summary
- Extends the `data_independent_timing` schema property to accept either a boolean (`true` if always, `false` if never) or a string extension name (`Zkt`, `Zvkt`, etc.).
- Resolves inconsistent definitions across schema descriptions, manual templates, and documentation.
- Updates `Udb::Instruction#data_independent_timing` and `#data_independent_timing?` along with unit test coverage.
- Updates AsciiDoc manual generation template (`instruction.adoc.erb`) to render `This instruction must have data-independent timing when extension <ext> is enabled.` for extension strings, or `This instruction must always have data-independent timing.` for `true`.
- Aligns instruction YAML metadata across `Zkt` scalar instructions, `Zvkt` vector instructions, dedicated crypto instructions (`true`), and floating-point instructions (`false`).

Refs #2261