### PR TITLE
fix(csr): correct Sv48 canonical-address boundary in stvec/vstvec

### DIFF
--- a/spec/std/isa/csr/stvec.yaml
+++ b/spec/std/isa/csr/stvec.yaml
@@ -19,10 +19,10 @@ fields:
   BASE:
     location: 63-2
     description: |
-      <%- va_size = ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 49 :39) -%>
-      Bit 63:0 of the virtual address of the exception vector for any trap taken into S-mode.
+      <%- va_size = ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 48 : 39) -%>
+      Bits 63:2 of the virtual address of the exception vector for any trap taken into S-mode.
 
-      If the base address is written with a non-cannonical address (_i.e._, bits 63:<%= va_size %> do not match bit <%= va_size-1 %>),
+      If the base address is written with a non-canonical address (_i.e._, bits 63:<%= va_size %> do not match bit <%= va_size-1 %>),
       the write should be ignored.
 
     type: RW-R

--- a/spec/std/isa/csr/vstvec.yaml
+++ b/spec/std/isa/csr/vstvec.yaml
@@ -6,7 +6,7 @@
 $schema: "csr_schema.json#"
 kind: csr
 name: vstvec
-long_name: Supervisor Trap Vector
+long_name: Virtual Supervisor Trap Vector
 address: 0x205
 writable: true
 virtual_address: 0x105
@@ -20,10 +20,10 @@ fields:
   BASE:
     location: 63-2
     description: |
-      <%- va_size = ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 49 :39) -%>
-      Bit 63:0 of the virtual address of the exception vector for any trap taken into VS-mode.
+      <%- va_size = ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 48 : 39) -%>
+      Bits 63:2 of the virtual address of the exception vector for any trap taken into VS-mode.
 
-      If the base address is written with a non-cannonical address (_i.e._, bits 63:<%= va_size %> do not match bit <%= va_size-1 %>),
+      If the base address is written with a non-canonical address (_i.e._, bits 63:<%= va_size %> do not match bit <%= va_size-1 %>),
       the write should be ignored.
 
     type: RW-R


### PR DESCRIPTION
The `BASE` field description in `stvec` and `vstvec` computes the canonical-address boundary as `ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 49 : 39)`. The Sv48 arm yields 49, so the generated documentation states that a write should be ignored when bits 63:49 do not match bit 48. The correct check for Sv48 is bits 63:48 against bit 47 - `max_va_size()` in `spec/std/isa/isa/util.idl` already uses 48. Sv57 and Sv39 were both correct, which is likely why this went unnoticed.

The same sentence described the field as "Bit 63:0" where `location` is `63-2`, and misspelled "cannonical". Both are corrected here.

Separately, `vstvec`'s `long_name` was "Supervisor Trap Vector" - the only VS CSR missing the "Virtual" prefix.