### PR TITLE
fix(isa): check Zilsd for RV32 sd

### DIFF
--- a/spec/std/isa/inst/I/sd.yaml
+++ b/spec/std/isa/inst/I/sd.yaml
@@ -51,7 +51,7 @@ operation(): |
   XReg virtual_address = X[xs1] + $signed(imm);
 
   if (xlen() == 32) {
-    if (implemented?(ExtensionName::Zclsd)) {
+    if (implemented?(ExtensionName::Zilsd)) {
       data = {X[xs2 + 1], X[xs2]};
     } else {
       raise(ExceptionCode::IllegalInstruction, mode(), $encoding);


### PR DESCRIPTION
`sd` is `definedBy: anyOf: [I, Zilsd]`, but its RV32 branch gates on `implemented?(ExtensionName::Zclsd)`.

Fix the RV32 `sd` operation to check `Zilsd`, matching the instruction's `definedBy` declaration and the paired-register store extension.

Fixes #2283