### PR TITLE
DCSR_MPRVEN_TYPE long_name is TODO

### DIFF
--- a/spec/std/isa/param/DCSR_MPRVEN_TYPE.yaml
+++ b/spec/std/isa/param/DCSR_MPRVEN_TYPE.yaml
@@ -14,7 +14,7 @@ description: |
     * 'read-only-0': tied to 0
     * 'read-only-1': tied to 1
     * 'rw': read-write
-long_name: TODO
+long_name: dcsr.MPRVEN implementation type
 schema:
   type: string
   enum: [read-only-0, read-only-1, rw]


### PR DESCRIPTION
`spec/std/isa/param/DCSR_MPRVEN_TYPE.yaml` sets `long_name: TODO`. This is one of the 160 parameters noted in #2241.

Opening this as a separate, single-file issue rather than commenting further on #2241, since that issue's author (@badnikhil) is still deciding on a batching approach given the possible UDB/ISA-manual migration — this scopes to just the one file so it doesn't presume that decision.