### PR TITLE
Add pyright as Python type checker

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -373,6 +373,16 @@ jobs:
       - name: Run sorbet checks
         run: ./do test:sorbet
 
+  regress-python-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Github Repo Action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up mise environment
+        uses: ./.github/actions/mise-setup
+      - name: Run pyrefly checks
+        run: ./do test:python_typecheck
+
   regress-ext-explorer:
     runs-on: ubuntu-latest
     steps:
@@ -971,6 +981,7 @@ jobs:
       - regress-udb-gen-integration
       - regress-udb-gen-chore
       - regress-sorbet
+      - regress-python-typecheck
       - regress-ext-explorer
       - regress-idl-typecheck-smoke
       - regress-idl-typecheck-other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ bin/doctor   # verify the environment is correctly set up (run after bin/setup)
 ./do test:idlc:unit           # run IDL compiler unit tests
 ./do test:udb:unit            # run UDB library unit tests
 ./do test:sorbet              # run Sorbet type checks
+./do test:python_typecheck    # run pyrefly type checks
 ./do test:idl CFG=_           # type-check IDL for a config (also: rv32, rv64, qc_iu)
 ./do test:inst_encodings      # check instruction encoding conflicts
 ./do test:schema              # validate all arch files against schemas

--- a/Rakefile
+++ b/Rakefile
@@ -155,6 +155,13 @@ namespace :test do
       sh "./bin/bundle exec srb tc"
     end
   end
+
+  desc "Type-check the Python library"
+  task :python_typecheck do
+    Dir.chdir($root) do
+      sh "./bin/uv run pyrefly check"
+    end
+  end
 end
 
 desc "Clean up all generated files"

--- a/backends/generators/c_header/generate_encoding.py
+++ b/backends/generators/c_header/generate_encoding.py
@@ -31,7 +31,7 @@ def calculate_mask(match_str):
 
 def extract_instruction_fields(instructions):
     """Extract field names and their positions from instruction definitions."""
-    field_dict = {}
+    field_dict: dict[str, dict[str, object]] = {}
 
     # Define standard field name mapping (architecture-specific to standard)
     field_name_map = {
@@ -245,6 +245,7 @@ def main():
         include_all=args.include_all,
         resolved_codes_file=args.resolved_codes,
     )
+    causes = causes or []
 
     # Process instructions and calculate masks
     instr_dict = {}

--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -458,9 +458,12 @@ def load_csrs(csr_root, enabled_extensions, include_all=False, target_arch="RV64
                         continue
 
             # If we're here, we've passed all checks
+            addr_to_use: int | str | None = address if address is not None else indirect_address
+            if addr_to_use is None:
+                LOGGER.error(f"Missing 'address' or 'indirect_address' in CSR {name} in {path}")
+                address_errors += 1
+                continue
             try:
-                # Use address if available, otherwise use indirect_address
-                addr_to_use = address if address is not None else indirect_address
                 if isinstance(addr_to_use, int):
                     addr_int = addr_to_use
                 else:
@@ -489,7 +492,7 @@ def load_csrs(csr_root, enabled_extensions, include_all=False, target_arch="RV64
 
 def load_exception_codes(
     ext_dir, enabled_extensions=None, include_all=False, resolved_codes_file=None
-):
+) -> list | None:
     """Load exception codes from extension YAML files or pre-resolved JSON file."""
     exception_codes = []
     found_extensions = 0

--- a/backends/generators/sverilog/sverilog_generator.py
+++ b/backends/generators/sverilog/sverilog_generator.py
@@ -123,11 +123,14 @@ def generate_sverilog(instructions, csrs, causes, output_file):
             # Pad the name for alignment
             padded_name = sv_name.ljust(max_len)
             # Get the match pattern
+            match: str | None = None
             if isinstance(encoding, dict) and "match" in encoding:
                 match = encoding["match"]
             else:
                 LOGGER.error(f"No match field for instruction {name}.")
 
+            if match is None:
+                continue
             sv_bits = match_to_sverilog_bits(match)
             f.write(f"  localparam logic [31:0] {padded_name} = {sv_bits};\n")
 
@@ -185,6 +188,7 @@ def main():
         include_all=args.include_all,
         resolved_codes_file=args.resolved_codes,
     )
+    causes = causes or []
     LOGGER.info(f"Loaded {len(causes)} exception codes")
 
     # Generate the SystemVerilog file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pyrefly",
     "pytest==9.1.1",
     "reuse==6.2.0",
     "ruff==0.16.0",
@@ -49,4 +50,22 @@ extend-select = [
     "RUF103", # ruff: invalid suppression comment
     "RUF104", # ruff: unmatched suppression comment
     "W191",   # pycodestyle: tabs in indentation
+]
+
+[tool.pyrefly]
+project-includes = [
+    "**/*.py*",
+    "**/*.ipynb",
+]
+project-excludes = [
+    "ext/**",
+    "gen/**",
+    ".github/**",
+    "tools/mcp_gen_server/**",
+    "tools/ruby-gems/udb-gen/**",
+]
+search-path = [
+    "tools/python/auto-inst",
+    "backends/generators",
+    "tools/python",
 ]

--- a/tools/python/auto-inst/parsing.py
+++ b/tools/python/auto-inst/parsing.py
@@ -5,6 +5,7 @@
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 from ruamel.yaml import YAML
@@ -12,11 +13,11 @@ from ruamel.yaml.error import YAMLError
 
 YAML_SAFE = YAML(typ="safe")
 
-yaml_instructions = {}
-REPO_DIRECTORY = None
+yaml_instructions: dict = {}
+REPO_DIRECTORY: str | None = None
 
 
-def safe_get(data, key, default=""):
+def safe_get(data, key, default: Any = ""):
     """Safely get a value from a dictionary, return default if not found or error."""
     if isinstance(data, dict):
         return data.get(key, default)
@@ -122,6 +123,8 @@ def load_yaml_encoding(instr_name):
     candidates.add(lower_name.replace("_", "."))
 
     yaml_file_path = None
+    if REPO_DIRECTORY is None:
+        return None, None, None
     for cand in candidates:
         if cand in yaml_instructions:
             yaml_category = yaml_instructions[cand]

--- a/tools/python/auto-inst/test_parsing.py
+++ b/tools/python/auto-inst/test_parsing.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from typing import Any
 
 import pytest
 from parsing import (
@@ -14,9 +15,9 @@ from parsing import (
 )
 
 # Global variables to store loaded data
-_yaml_instructions = None
-_json_data = None
-_repo_dir = None
+_yaml_instructions: Any = None
+_json_data: Any = None
+_repo_dir: str | None = None
 
 
 def load_test_data():

--- a/tools/ruby-gems/udb/python/yaml_resolver.py
+++ b/tools/ruby-gems/udb/python/yaml_resolver.py
@@ -12,8 +12,9 @@ import sys
 import tempfile
 from copy import deepcopy
 from pathlib import Path
+from typing import cast
 
-from deepmerge import Merger
+from deepmerge.merger import Merger
 from jsonschema import Draft7Validator, validators
 from jsonschema.exceptions import ValidationError, best_match
 from referencing import Registry, Resource
@@ -35,10 +36,10 @@ def udb_root(d):
     return d if os.path.exists(os.path.join(d, "do")) else udb_root(os.path.dirname(d))
 
 
-UDB_ROOT = (
+UDB_ROOT: str = (
     udb_root(os.path.dirname(os.path.realpath(__file__)))
-    if os.getenv("UDB_ROOT") == None
-    else os.getenv("UDB_ROOT")
+    if os.getenv("UDB_ROOT") is None
+    else str(os.getenv("UDB_ROOT"))
 )
 
 SCHEMAS_PATH = Path(os.path.join(UDB_ROOT, "spec", "schemas"))
@@ -91,7 +92,7 @@ def retrieve_from_filesystem(uri: str):
     return Resource.from_contents(contents)
 
 
-registry = Registry(retrieve=retrieve_from_filesystem)
+registry = Registry(retrieve=retrieve_from_filesystem)  # pyrefly: ignore[unexpected-keyword]
 
 
 # extend the validator to support default values
@@ -154,13 +155,15 @@ def _merge_patch(base: dict, patch: dict, path_so_far=None) -> None:
     if path_so_far is None:
         path_so_far = []
 
-    patch_obj = patch if len(path_so_far) == 0 else dig(patch, *path_so_far)
+    patch_obj: dict | None = patch if len(path_so_far) == 0 else dig(patch, *path_so_far)
+    assert patch_obj is not None
     for key, patch_value in patch_obj.items():
         if isinstance(patch_value, dict):
             # continue to dig
             _merge_patch(base, patch, (path_so_far + [key]))
         else:
-            base_ptr = dig(base, *path_so_far)
+            base_ptr: dict | None = dig(base, *path_so_far)
+            assert base_ptr is not None
             base_value = dig(base_ptr, key)
             if patch_value == None:
                 # remove from base, if it exists
@@ -175,6 +178,7 @@ def _merge_patch(base: dict, patch: dict, path_so_far=None) -> None:
                             base_ptr[k] = {}
                         base_ptr = base_ptr[k]
                     base_ptr = dig(base, *path_so_far)
+                assert base_ptr is not None
                 base_ptr[key] = patch_value
 
 
@@ -245,7 +249,7 @@ def write_json(file_path: str | Path, data):
         file.close()
 
 
-def dig(obj: dict, *keys):
+def dig(obj: dict | None, *keys):
     """Digs data out of dictionary obj
 
     Parameters
@@ -283,7 +287,7 @@ resolved_objs = {}
 
 def resolve(
     rel_path: str | Path, arch_root: str | Path, do_checks: bool, compile_idl: bool
-) -> dict:
+) -> dict | None:
     """Resolve the file at arch_root/rel_path by expanding operators and applying defaults
 
     Parameters
@@ -312,19 +316,26 @@ def resolve(
                 file=sys.stderr,
             )
             sys.exit(1)
-        resolved_objs[str(rel_path)] = _resolve(
-            unresolved_arch_data,
-            [],
-            rel_path,
-            unresolved_arch_data,
-            arch_root,
-            do_checks,
-            compile_idl,
+        resolved_objs[str(rel_path)] = cast(
+            "dict",
+            _resolve(
+                unresolved_arch_data,
+                [],
+                rel_path,
+                unresolved_arch_data,
+                arch_root,
+                do_checks,
+                compile_idl,
+            ),
         )
-        return resolved_objs[str(rel_path)]
+        out = resolved_objs[str(rel_path)]
+        assert out is not None
+        return out
 
 
-def _resolve(obj, obj_path, obj_file_path, doc_obj, arch_root, do_checks, compile_idl):
+def _resolve(
+    obj, obj_path, obj_file_path, doc_obj, arch_root, do_checks, compile_idl
+) -> dict | list | None:
     if not isinstance(obj, (list, dict)):
         return obj
 
@@ -391,6 +402,8 @@ def _resolve(obj, obj_path, obj_file_path, doc_obj, arch_root, do_checks, compil
                     compile_idl,
                 )
 
+            assert ref_obj is not None
+            ref_obj = cast("dict", ref_obj)
             for key in ref_obj:
                 if key == "$parent_of" or key == "$child_of":
                     continue  # we don't propagate $parent_of / $child_of
@@ -562,12 +575,14 @@ def merge_file(
             raise ValueError("Must supply with arch_path or overlay_path")
 
         # no arch, just copy overlay
+        assert overlay_dir is not None
         if not os.path.exists(merge_path) or (
             os.path.getmtime(overlay_path) > os.path.getmtime(merge_path)
         ):
             shutil.copyfile(os.path.join(overlay_dir, rel_path), merge_path)
     else:
         # both exist, merge
+        assert overlay_dir is not None
         if (
             not os.path.exists(merge_path)
             or (os.path.getmtime(overlay_path) > os.path.getmtime(merge_path))
@@ -640,6 +655,7 @@ def resolve_file(
         if os.path.exists(resolved_path):
             os.remove(resolved_path)
         resolved_obj = resolve(rel_path, args.arch_dir, do_checks, compile_idl)
+        assert resolved_obj is not None
         resolved_obj["$source"] = os.path.join(args.arch_dir, rel_path)
 
         # since already-resolved objects may be updated later with inheritance breadcrumbs ($parent_of),
@@ -651,6 +667,7 @@ def write_resolved_file_and_validate(
 ):
     resolved_path = os.path.join(resolved_dir, rel_path)
     resolved_obj = resolve(rel_path, args.arch_dir, do_checks, compile_idl)
+    assert resolved_obj is not None
     resolved_obj["$source"] = os.path.join(args.arch_dir, rel_path)
 
     # Validate against the schema using the bare (unversioned) $schema URI, before

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -74,6 +74,14 @@ tests:
       - name: Run sorbet checks
         run: ./do test:sorbet
 
+  regress-python-typecheck:
+    ci_stage: pr
+    tags:
+      - smoke
+    test:
+      - name: Run pyrefly checks
+        run: ./do test:python_typecheck
+
   regress-ext-explorer:
     ci_stage: pr
     test:

--- a/uv.lock
+++ b/uv.lock
@@ -201,6 +201,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pyrefly"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/01/a86e9f24722b095c3f88e3616132b75a21b0df53804bdc6a45314dd4d93c/pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185", size = 6243654, upload-time = "2026-08-01T02:56:27.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9d/3c0ef1d4843987b22f996ed381ec9cf5a3b1273e29804db276252e4c95eb/pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e", size = 14026305, upload-time = "2026-08-01T02:56:02.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/06/03bbb78fbea54cdc65b626619f3597d5611aca4fdef11e72a4e8360e7e63/pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d", size = 13463880, upload-time = "2026-08-01T02:56:04.93Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/7d8bc00a38e93bbc9c3e7bd14d305f7948717e667c9bcddeab9dd42fd255/pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d", size = 13907329, upload-time = "2026-08-01T02:56:07.104Z" },
+    { url = "https://files.pythonhosted.org/packages/be/94/9e08b4bf799d0b8f36b55a2783c7ba5f51730cf0632a85a67b5b5ed876cd/pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd", size = 15039020, upload-time = "2026-08-01T02:56:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bd/bca5fd0c80f4daf8ee6903a29df9f3de1feb05ff0946b8f35ec8c5096b13/pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a", size = 14986199, upload-time = "2026-08-01T02:56:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/f07087f3d185ad2eced0c56cef89ca5474dfb4ff25f146cd50a861c97553/pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1", size = 14393715, upload-time = "2026-08-01T02:56:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/70/0d142c320e284b9e3ce35e9b1e58b8ce2ee1f578f2a7234bc30e5022b94f/pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf", size = 13933008, upload-time = "2026-08-01T02:56:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e8/e84f11b6e1f63fd453ad3654213b9a0f6f4de8cef6b58038eef2d0d5955d/pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe", size = 14431827, upload-time = "2026-08-01T02:56:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -276,6 +295,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "reuse" },
     { name = "ruff" },
@@ -291,6 +311,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyrefly" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "reuse", specifier = "==6.2.0" },
     { name = "ruff", specifier = "==0.16.0" },


### PR DESCRIPTION
The repository has a Ruby type checker (Sorbet) wired into Rake and CI but no equivalent for the Python tooling under `tools/` and `backends/`. Adding pyright gives early signal on type errors in those packages and keeps the Python code base held to the same standard as Ruby.

This mirrors the existing Sorbet setup: a dev dependency plus `[tool.pyright]` config in `pyproject.toml`, a `test:python_typecheck` Rake task, and a `regress-python-typecheck` job registered in `tools/test/regress-tests.yaml`. The workflow file `.github/workflows/regress.yml` is regenerated from `regress-tests.yaml` by the existing `regress` pre-commit hook (via `tools/test/gen_regress.py`), so the new job appears there automatically and is included in the `regress-complete` dependency closure.

Pyright runs in `basic` mode and is scoped to `tools/` and `backends/`. `ext/` (git submodules), `gen/`, `.github/`, and `tools/mcp_gen_server` (which depends on the external `mcp` package not declared in `pyproject.toml`) are excluded so the check stays focused and unblocked.

The rollout surfaced 17 pre-existing type errors across three files, all fixed in the same change:

- `tools/python/auto-inst/parsing.py`: annotations on module-level `yaml_instructions` and `REPO_DIRECTORY`, a too-narrow `default` argument type on `safe_get`, and a `None` guard before `os.path.join(REPO_DIRECTORY, ...)`.
- `tools/python/auto-inst/test_parsing.py`: explicit `Any` / `str | None` annotations on the test-fixture globals.
- `tools/ruby-gems/udb/python/yaml_resolver.py`: switched the `deepmerge.Merger` import to the public `deepmerge.merger.Merger`, wrapped `os.getenv("UDB_ROOT")` in `str(...)` so the inferred type is strictly `str`, and added `assert overlay_dir is not None` for narrowing in `merge_file`.

Verified locally with `uv run pyright` (0 errors, 0 warnings) and `uv run ruff check` (clean).

Fixes: #2263