### PR TITLE
fix(data): set long_name for NUM_PMP_ENTRIES

### DIFF
--- a/spec/std/isa/param/NUM_PMP_ENTRIES.yaml
+++ b/spec/std/isa/param/NUM_PMP_ENTRIES.yaml
@@ -22,7 +22,7 @@ description: |
   An implemented entry may still be read-only zero (but will never cause an exception).
   The number of entries that are actually usable is given by
   NUM_USABLE_PMP_ENTRIES.
-long_name: TODO
+long_name: number of implemented PMP entries
 schema:
   type: integer
   enum: [0, 16, 64]


### PR DESCRIPTION
Sets `long_name` for NUM_PMP_ENTRIES, matching the established convention used elsewhere (e.g. ELEN: "maximum vector element bit width"). The value is taken directly from the parameter's own description.

Related to #2241.