### PR TITLE
Implement BCDDevice READ handler (HTIF console input)

### DIFF
--- a/backends/cpp_hart_gen/cpp/include/udb/htif.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/htif.hpp
@@ -26,12 +26,13 @@ union HTIFCOMMAND
 class HTIFDevice
 {
 public:
-  HTIFDevice(udb::IssSocModel* pSoC);
+  HTIFDevice(udb::IssSocModel* pSoC, uint64_t fromHostAddress);
   ~HTIFDevice();
 
   virtual int HandleCommand(HTIFCOMMAND cmd) = 0;
 protected:
   udb::IssSocModel* m_pSoC;
+  uint64_t m_fromHost;
 };
 
 //SysCall Device
@@ -43,7 +44,7 @@ typedef int (SysCallDevice::*SYSCALLHANDLER)(uint64_t a0, uint64_t a1, uint64_t 
 class SysCallDevice : public HTIFDevice
 {
 public:
-  SysCallDevice(udb::IssSocModel* pSoC);
+  SysCallDevice(udb::IssSocModel* pSoC, uint64_t fromHostAddress);
   ~SysCallDevice();
 
   class Pass : public udb::ExitEvent
@@ -78,7 +79,7 @@ protected:
 class BCDDevice : public HTIFDevice
 {
 public:
-  BCDDevice(udb::IssSocModel* pSoC);
+  BCDDevice(udb::IssSocModel* pSoC, uint64_t fromHostAddress);
   ~BCDDevice();
 
   enum BCDCMD

--- a/backends/cpp_hart_gen/cpp/src/htif.cpp
+++ b/backends/cpp_hart_gen/cpp/src/htif.cpp
@@ -4,7 +4,7 @@
 
 HostTargetInterface::HostTargetInterface(udb::IssSocModel* pSoC, uint64_t toHostAddress,
                                          uint64_t fromHostAddress, uint64_t sigAddress,
-                                         uint64_t sigLength) : m_sysCall(pSoC), m_bcd(pSoC)
+                                         uint64_t sigLength) : m_sysCall(pSoC, fromHostAddress), m_bcd(pSoC, fromHostAddress)
 {
   m_toHost = toHostAddress;
   m_fromHost = fromHostAddress;
@@ -75,9 +75,10 @@ int HostTargetInterface::HandleCommand(HTIFCOMMAND cmd)
   return 0;
 }
 
-HTIFDevice::HTIFDevice(udb::IssSocModel* pSoC)
+HTIFDevice::HTIFDevice(udb::IssSocModel* pSoC, uint64_t fromHostAddress)
 {
   m_pSoC = pSoC;
+  m_fromHost = fromHostAddress;
 }
 
 HTIFDevice::~HTIFDevice()
@@ -85,8 +86,8 @@ HTIFDevice::~HTIFDevice()
 
 }
 
-SysCallDevice::SysCallDevice(udb::IssSocModel* pSoC)
-  : HTIFDevice(pSoC), m_cmdHandlers(94)
+SysCallDevice::SysCallDevice(udb::IssSocModel* pSoC, uint64_t fromHostAddress)
+  : HTIFDevice(pSoC, fromHostAddress), m_cmdHandlers(94)
 {
   m_cmdHandlers[93] = &SysCallDevice::exit;
 }
@@ -135,8 +136,8 @@ int SysCallDevice::exit(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
   return a0;
 }
 
-BCDDevice::BCDDevice(udb::IssSocModel* pSoC)
-  : HTIFDevice(pSoC)
+BCDDevice::BCDDevice(udb::IssSocModel* pSoC, uint64_t fromHostAddress)
+  : HTIFDevice(pSoC, fromHostAddress)
 {
 
 }
@@ -151,7 +152,11 @@ int BCDDevice::HandleCommand(HTIFCOMMAND cmd)
   switch(cmd.command)
   {
   case READ:
-    //TODO:
+    {
+      //Read a character from stdin, use stdin for now
+      uint8_t ch = static_cast<uint8_t>(std::getchar());
+      m_pSoC->memcpy_from_host(m_fromHost, &ch, sizeof(ch));
+    }
     break;
   case WRITE:
     //TODO: use deicated console, stdout for now


### PR DESCRIPTION
## Description
`BCDDevice::HandleCommand`'s READ case was empty (just a TODO), so any guest program reading console input via HTIF got no response.

This PR implements READ by reading a character from stdin and writing it back to the guest via the existing `memcpy_from_host` mechanism, symmetric to how WRITE already uses `stdout` via `std::putchar`.

To make this possible, `HTIFDevice` (and its subclasses `SysCallDevice`, `BCDDevice`) now also receive `fromHostAddress` in their constructors, since devices previously had no access to the `fromHost` address needed to write responses back to the target.

## Changes
- `HTIFDevice` base class stores `m_fromHost`, passed in via constructor
- `SysCallDevice` / `BCDDevice` constructors updated to forward `fromHostAddress`
- `BCDDevice::HandleCommand` READ case now reads via `std::getchar()` and writes the result back to the guest via `memcpy_from_host`
