### PR TITLE
fix(inst): ctzw returns 32, not XLEN, when the low word is zero

### DIFF
--- a/spec/std/isa/inst/Zbb/ctzw.yaml
+++ b/spec/std/isa/inst/Zbb/ctzw.yaml
@@ -36,4 +36,9 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  X[xd] = lowest_set_bit(X[xs1][31:0]);
+  # lowest_set_bit() reports xlen() (64 here) for a zero input, but ctzw must report 32
+  if (X[xs1][31:0] == 0) {
+    X[xd] = 32;
+  } else {
+    X[xd] = lowest_set_bit(X[xs1][31:0]);
+  }


### PR DESCRIPTION
`ctzw` called `lowest_set_bit(X[xs1][31:0])`, but `lowest_set_bit` takes an `XReg` and returns `xlen()` when the value is zero. The 32-bit slice is zero-extended into the 64-bit parameter, so a zero low word produced 64 instead of 32 -contradicting the instruction's own description, and wrong in every mode where `ctzw` (xlen: 64 only) is legal.

Guard the zero case explicitly. `clzw` is unaffected because `highest_set_bit` returns -1 rather than a width for a zero input.
