### PR TITLE
fix(idlc): evaluate $array_size for variable-length arrays

### DIFF
--- a/tools/ruby-gems/idlc/lib/idlc/ast.rb
+++ b/tools/ruby-gems/idlc/lib/idlc/ast.rb
@@ -1604,8 +1604,14 @@ module Idl
     sig { override.params(symtab: SymbolTable).returns(Integer) }
     def value(symtab)
       w = expression.type(symtab).width
-      value_error "Width of the array is unknown" if w == :unknown
-      T.cast(w, Integer)
+      if w == :unknown
+        # a configured array may have a value even when its static width is unknown
+        v = expression.value(symtab)
+        value_error "Width of the array is unknown" unless v.is_a?(Array)
+        v.size
+      else
+        T.cast(w, Integer)
+      end
     end
 
     sig { override.returns(String) }

--- a/tools/ruby-gems/idlc/test/idl/constraints.yaml
+++ b/tools/ruby-gems/idlc/test/idl/constraints.yaml
@@ -42,3 +42,17 @@ tests:
     p:
       TRUE_ARRAY: [true, true, true, true, true, true, true, true]
     r: true
+  - c: |
+      for (U32 i = 0; i < $array_size(VALS); i++) {
+        true -> (VALS[i] < 100);
+      }
+    p:
+      VALS: [99, 50, 1]
+    r: true
+  - c: |
+      for (U32 i = 0; i < $array_size(VALS); i++) {
+        true -> (VALS[i] < 100);
+      }
+    p:
+      VALS: [99, 50, 100]
+    r: false

--- a/tools/ruby-gems/idlc/test/test_constraints.rb
+++ b/tools/ruby-gems/idlc/test/test_constraints.rb
@@ -23,7 +23,8 @@ def to_idl_type(value)
   when TrueClass, FalseClass
     Idl::Type.new(:boolean)
   when Array
-    Idl::Type.new(:array, sub_type: to_idl_type(value[0]))
+    # match variable-length parameter types created from JSON Schema
+    Idl::Type.new(:array, width: :unknown, sub_type: to_idl_type(value[0]))
   else
     raise "Unexepected type"
   end
@@ -51,7 +52,7 @@ class ConstraintTestFactory
             if test.key?("p")
               @symtab.push(nil)
               test["p"].each do |name, value|
-                @symtab.add!(name, Idl::Var.new(name, to_idl_type(value), value))
+                @symtab.add!(name, Idl::Var.new(name, to_idl_type(value).make_const, value))
               end
             end
             constraint_ast = nil


### PR DESCRIPTION
In a configured architecture, a variable-length array parameter can have a concrete value while its static width remains `:unknown`, since `Type.from_json_schema_array_type` only sets a width when `minItems == maxItems`. As a result, requirements constraints using `$array_size(PARAM)` as a loop bound could not be evaluated.

When the static width is unknown, derive the size from the configured array value. If the value is also unknown, evaluation remains unknown, which condition evaluation already handles. Two constraint tests cover the satisfied and violated cases.

Closes #2306