### PR TITLE
fix(param): prohibit unimplemented HPM counters from being marked disabled

### DIFF
--- a/spec/std/isa/param/COUNTINHIBIT_EN.yaml
+++ b/spec/std/isa/param/COUNTINHIBIT_EN.yaml
@@ -25,6 +25,15 @@ schema:
     type: boolean
   maxItems: 32
   minItems: 32
+
+requirements:
+  idl(): |
+    for (U32 i = 3; i < 32; i++) {
+      (!HPM_COUNTER_EN[i]) -> !COUNTINHIBIT_EN[i];
+    }
+  reason: |
+    When mhpmcounter[i] is not implemented, it cannot be inhibited.
+
 definedBy:
   allOf:
     - extension:


### PR DESCRIPTION
Add restrictions to match those in the parameter description:
> An unimplemented counter cannot be specified, i.e., if HPM_COUNTER_EN[3] is false,
> it would be illegal to set COUNTINHIBIT_EN[3] to true.

Closes #2323