### PR TITLE
fix(param): cross-reference HPM unimplemented/misconfigured behavior

### DIFF
--- a/spec/std/isa/param/HPM_COUNTER_EN.yaml
+++ b/spec/std/isa/param/HPM_COUNTER_EN.yaml
@@ -23,6 +23,11 @@ description: |
   indexes 3-31.
   Index 3 in HPM_COUNTER_EN corresponds to mhpmcounter3.
   Index 31 in HPM_COUNTER_EN corresponds to mhpmcounter31.
+
+  Whether accessing an index where `HPM_COUNTER_EN[n]` is `false` causes an
+  `IllegalInstruction` exception or instead returns a constant (read-only zero)
+  value is *not* controlled by this parameter; that is governed by
+  `TRAP_ON_UNIMPLEMENTED_CSR`, which applies uniformly to every unimplemented CSR.
 long_name: TODO
 schema:
   type: array

--- a/spec/std/isa/param/HPM_EVENTS.yaml
+++ b/spec/std/isa/param/HPM_EVENTS.yaml
@@ -6,7 +6,13 @@
 $schema: param_schema.json#
 kind: parameter
 name: HPM_EVENTS
-description: List of defined event numbers that can be written into mhpmeventN
+description: |
+  List of defined event numbers that can be written into mhpmeventN.
+
+  Writing an event number that is not in this list is not an error: the
+  `EVENT` field's `sw_write()` behavior legalizes it to
+  `UNDEFINED_LEGAL_DETERMINISTIC`, i.e., the counter is left free to return a
+  constant value for as long as it is misconfigured, without trapping.
 long_name: TODO
 schema:
   type: array


### PR DESCRIPTION
Addresses #69.

`Zihpm.adoc` says accessing an unimplemented HPM counter "may cause an
illegal-instruction exception or may return a constant value," and that
a counter with a misconfigured event selector "may return a constant
value." Issue #69 read this as several missing parameters.

Tracing it through, both behaviors are already fully modeled here, just
not documented as such:

- Unimplemented-counter access is already governed generically by
  `TRAP_ON_UNIMPLEMENTED_CSR` (applies to every CSR, not Zihpm-specific).
- A misconfigured event selector is already handled by
  `mhpmeventN`'s `EVENT.sw_write()` (see `mhpmeventN.layout`), which
  legalizes an out-of-`HPM_EVENTS` write to `UNDEFINED_LEGAL_DETERMINISTIC`.
- "Implemented number" and "set of events" are `HPM_COUNTER_EN` and
  `HPM_EVENTS` respectively, both already present.
- "Width" is fixed at 64 bits by the unpriv spec itself ("29 additional
  unprivileged 64-bit hardware performance counters"), so there's nothing
  implementation-variable to parameterize there.

`HPM_COUNTER_EN`'s vague description (the other half of #69) was already
fixed separately in #1991.

So no new parameters are needed for the behaviors #69 cites — this PR
just adds the missing cross-references to `HPM_COUNTER_EN` and
`HPM_EVENTS` so that connection is documented instead of looking like an
open gap.

No functional/schema changes — `description` text only.
