### PR TITLE
fix(config): PartialConfig#param_values defaults to Hash, not Array

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/config.rb
+++ b/tools/ruby-gems/udb/lib/udb/config.rb
@@ -238,7 +238,7 @@ module Udb
     def initialize(data, info)
       super(data, info)
 
-      @param_values = @data.key?("params") ? @data["params"] : [].freeze
+      @param_values = @data.key?("params") ? @data["params"] : {}.freeze
 
       @mxlen = @data.dig("params", "MXLEN")
 

--- a/tools/ruby-gems/udb/test/test_cfg.rb
+++ b/tools/ruby-gems/udb/test/test_cfg.rb
@@ -52,4 +52,26 @@ class TestCfg < Minitest::Test
       MSG
     end
   end
+
+  # a partially-configured config with no `params:` key at all must still
+  # expose a Hash from param_values, not the Array it used to default to
+  def test_partial_config_without_params_key_has_hash_param_values
+    cfg_path = Pathname.new(@gen_dir) / "no_params.yaml"
+    cfg_path.write(<<~YAML)
+      $schema: config_schema.json#
+      kind: architecture configuration
+      type: partially configured
+      name: no_params
+      description: Partial config with no params key, to check param_values defaults to a Hash
+      mandatory_extensions:
+        - name: I
+          version: ">= 2.1"
+    YAML
+
+    cfg_arch = @resolver.cfg_arch_for(cfg_path)
+
+    assert_kind_of Hash, cfg_arch.config.param_values
+    refute cfg_arch.config.param_values.key?("SXLEN")
+    assert_nil cfg_arch.config.param_values["SXLEN"]
+  end
 end


### PR DESCRIPTION
Fixes #2116.

`PartialConfig#initialize` defaulted `param_values` to `[].freeze` when
the config has no `params` key, but `param_values` is declared and
consumed as a `Hash` everywhere it's read (`condition.rb`,
`portfolio_design.rb` both call `.key?`/`[]` on it). `FullConfig`
already defaults to `{}.freeze` (line 202); `PartialConfig` was the
one class of the three that didn't match, so any partial config
omitting `params:` (which the schema explicitly allows) crashed the
first time anything touched `param_values`.

One-character fix: `[].freeze` → `{}.freeze`.

Added a regression test in `test_cfg.rb` that resolves a partial
config with no `params:` key and checks `param_values` comes back as
a `Hash` instead of raising.
