### PR TITLE
docs(param): populate placeholder long_name fields

### DIFF
--- a/spec/std/isa/param/ASID_WIDTH.yaml
+++ b/spec/std/isa/param/ASID_WIDTH.yaml
@@ -9,7 +9,7 @@ name: ASID_WIDTH
 description:
   Number of implemented ASID bits. Maximum is 16 for XLEN==64, and 9 for
   XLEN==32
-long_name: TODO
+long_name: Width of satp.ASID
 schema:
   type: integer
   minimum: 0

--- a/spec/std/isa/param/MCID_WIDTH.yaml
+++ b/spec/std/isa/param/MCID_WIDTH.yaml
@@ -9,7 +9,7 @@ name: MCID_WIDTH
 description: |
   Number of bits used for the Monitoring Counter ID field (MCID).
   Default is 12.
-long_name: TODO
+long_name: Width of the Monitoring Counter ID (MCID) field
 schema:
   type: integer
   minimum: 1

--- a/spec/std/isa/param/NUM_PMP_ENTRIES.yaml
+++ b/spec/std/isa/param/NUM_PMP_ENTRIES.yaml
@@ -22,7 +22,7 @@ description: |
   An implemented entry may still be read-only zero (but will never cause an exception).
   The number of entries that are actually usable is given by
   NUM_USABLE_PMP_ENTRIES.
-long_name: TODO
+long_name: Number of implemented PMP entries
 schema:
   type: integer
   enum: [0, 16, 64]

--- a/spec/std/isa/param/NUM_USABLE_PMP_ENTRIES.yaml
+++ b/spec/std/isa/param/NUM_USABLE_PMP_ENTRIES.yaml
@@ -20,7 +20,7 @@ description: |
   zero.
 
   Must be between 0 and NUM_PMP_ENTRIES, inclusive.
-long_name: TODO
+long_name: Number of usable PMP entries
 schema:
   type: integer
   minimum: 0

--- a/spec/std/isa/param/PMP_GRANULARITY.yaml
+++ b/spec/std/isa/param/PMP_GRANULARITY.yaml
@@ -15,7 +15,7 @@ description: |
 
   Note that PMP_GRANULARITY is equal to G+2 (not G) as described in
   the privileged architecture.
-long_name: TODO
+long_name: PMP granularity
 schema:
   type: integer
   minimum: 2

--- a/spec/std/isa/param/RCID_WIDTH.yaml
+++ b/spec/std/isa/param/RCID_WIDTH.yaml
@@ -9,7 +9,7 @@ name: RCID_WIDTH
 description: |
   Number of bits used for the Resource Control ID field (RCID).
   Default is 12.
-long_name: TODO
+long_name: Width of the Resource Control ID (RCID) field
 schema:
   type: integer
   minimum: 1

--- a/spec/std/isa/param/SXLEN.yaml
+++ b/spec/std/isa/param/SXLEN.yaml
@@ -12,7 +12,7 @@ description: |
     * [32]:     SXLEN is always 32
     * [64]:     SXLEN is always 64
     * [32, 64]: SXLEN can be changed (via mstatus.SXL) between 32 and 64
-long_name: TODO
+long_name: XLEN in S-mode
 schema:
   type: array
   items:

--- a/spec/std/isa/param/UXLEN.yaml
+++ b/spec/std/isa/param/UXLEN.yaml
@@ -9,7 +9,7 @@ name: UXLEN
 description: |
   Set of XLENs supported in U-mode. When both 32 and 64 are supported, UXLEN can be changed,
   via mstatus.UXL, between 32 and 64.
-long_name: TODO
+long_name: XLEN in U-mode
 schema:
   type: array
   items:

--- a/spec/std/isa/param/VMID_WIDTH.yaml
+++ b/spec/std/isa/param/VMID_WIDTH.yaml
@@ -11,7 +11,7 @@ description:
   of a virtual machine ID).
 
   "
-long_name: TODO
+long_name: Width of hgatp.VMID
 schema:
   type: integer
   minimum: 0

--- a/spec/std/isa/param/VSXLEN.yaml
+++ b/spec/std/isa/param/VSXLEN.yaml
@@ -12,7 +12,7 @@ description: |
     * [32]:     VSXLEN is always 32
     * [64]:     VSXLEN is always 64
     * [32, 64]: VSXLEN can be changed (via `hstatus.VSXL`) between 32 and 64
-long_name: TODO
+long_name: XLEN in VS-mode
 schema:
   type: array
   items:

--- a/spec/std/isa/param/VUXLEN.yaml
+++ b/spec/std/isa/param/VUXLEN.yaml
@@ -9,7 +9,7 @@ name: VUXLEN
 description: |
   Set of XLENs supported in VU-mode. When both 32 and 64 are supported, VUXLEN can be changed
   via `vsstatus.UXL`.
-long_name: TODO
+long_name: XLEN in VU-mode
 schema:
   type: array
   items:


### PR DESCRIPTION
Addresses #2308.

Three of the ten `long_name: TODO` parameters listed there
(`PMP_NA4_SUPPORTED`, `PMP_NAPOT_SUPPORTED`, `PMP_TOR_SUPPORTED`) were
already fixed separately - this covers the remaining seven:
`UXLEN`, `SXLEN`, `VSXLEN`, `VUXLEN`, `VMID_WIDTH`,
`NUM_USABLE_PMP_ENTRIES`, `PMP_GRANULARITY`.

Also picked up four directly-related parameters in the exact same
`long_name: TODO` state that weren't in the original list:
`ASID_WIDTH`, `MCID_WIDTH`, `RCID_WIDTH` (the other implemented-ID-width
parameters alongside `VMID_WIDTH`) and `NUM_PMP_ENTRIES` (the direct
sibling of `NUM_USABLE_PMP_ENTRIES` - same directory, same `definedBy`
extension, same governing spec section).

`description:`/`schema:`/`definedBy:`/`requirements:` are untouched in
every file - `long_name` only. The XLEN-mode names follow the existing
`MXLEN.yaml` precedent (`XLEN in machine mode` -> `XLEN in U-mode`,
`XLEN in S-mode`, etc.).

There are ~150 more `long_name: TODO` parameters left in
`spec/std/isa/param/` beyond these 11 - scoped this PR to the ones I
could verify precisely against the spec rather than batch-filling all
of them.
