### PR TITLE
fix(csr): use mcounteren.TM for VU time/timeh permission check

### DIFF
--- a/spec/std/isa/csr/time.yaml
+++ b/spec/std/isa/csr/time.yaml
@@ -79,7 +79,7 @@ sw_read(): |
     }
   } else if (mode() == PrivilegeMode::VU) {
     # access in VU mode
-    if (((CSR[hcounteren].TM & CSR[scounteren].TM) == 1'b0) && (CSR[mcounteren].IR == 1'b1)) {
+    if (((CSR[hcounteren].TM & CSR[scounteren].TM) == 1'b0) && (CSR[mcounteren].TM == 1'b1)) {
       raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
     } else if (CSR[mcounteren].TM == 1'b0) {
       raise(ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/csr/timeh.yaml
+++ b/spec/std/isa/csr/timeh.yaml
@@ -80,7 +80,7 @@ sw_read(): |
     }
   } else if (mode() == PrivilegeMode::VU) {
     # access in VU mode
-    if (((CSR[hcounteren].TM & CSR[scounteren].TM) == 1'b0) && (CSR[mcounteren].IR == 1'b1)) {
+    if (((CSR[hcounteren].TM & CSR[scounteren].TM) == 1'b0) && (CSR[mcounteren].TM == 1'b1)) {
       raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
     } else if (CSR[mcounteren].TM == 1'b0) {
       raise(ExceptionCode::IllegalInstruction, mode(), $encoding);


### PR DESCRIPTION
Fix access checks for `time` CSR to use `mcounteren.TM` (time), not `mcounteren.IR` (instret).

Closes #2336