### PR TITLE
fix(csr): return minstret high half from instreth

### DIFF
--- a/spec/std/isa/csr/instreth.yaml
+++ b/spec/std/isa/csr/instreth.yaml
@@ -76,6 +76,4 @@ sw_read(): |
     }
   }
 
-  # since the counter may be shared among harts, reads must be handled
-  # as a builtin function
-  return read_mcycle();
+  return CSR[minstret].COUNT[63:32];


### PR DESCRIPTION
Fix the `instreth` CSR `sw_read()` implementation to return the upper 32 bits of `minstret` instead of the return value of `read_mcycle()`.

Closes #2338