### PR TITLE
fix(isa): assign VS reset value to vs_value in mstatus_sd_reset_value()

### DIFF
--- a/spec/std/isa/isa/globals.isa
+++ b/spec/std/isa/isa/globals.isa
@@ -3144,7 +3144,7 @@ function mstatus_sd_reset_value
       fs_value = (!implemented?(ExtensionName::F)) ? 0 : MSTATUS_FS_LEGAL_VALUES[0];
     }
     if ((!implemented?(ExtensionName::V)) || ($array_size(MSTATUS_VS_LEGAL_VALUES) == 1)) {
-      fs_value = (!implemented?(ExtensionName::V)) ? 0 : MSTATUS_VS_LEGAL_VALUES[0];
+      vs_value = (!implemented?(ExtensionName::V)) ? 0 : MSTATUS_VS_LEGAL_VALUES[0];
     }
 
     return ((fs_value == 3) || (vs_value == 3)) ? 1 : 0;


### PR DESCRIPTION
Fix a bug in `mstatus_sd_reset_value()` where the VS reset value is assigned to `fs_value` instead of `vs_value`.

Closes #2340