### PR TITLE
Fix word operand handling in rorw and roriw

### DIFF
--- a/spec/std/isa/inst/B/roriw.yaml
+++ b/spec/std/isa/inst/B/roriw.yaml
@@ -41,5 +41,5 @@ operation(): |
 
   XReg xs1_word = X[xs1][31:0];
 
-  XReg unextended_result = (X[xs1] >> shamt) | (X[xs1] << (32 - shamt));
+  XReg unextended_result = (xs1_word >> shamt) | (xs1_word << (32 - shamt));
   X[xd] = {{32{unextended_result[31]}}, unextended_result};

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -42,5 +42,5 @@ operation(): |
   XReg xs1_word = X[xs1][31:0];
   XReg shamt = X[xs2][4:0];
 
-  XReg unextended_result = (X[xs1] >> shamt) | (X[xs1] << (32 - shamt));
+  XReg unextended_result = (xs1_word >> shamt) | (xs1_word << (32 - shamt));
   X[xd] = {{32{unextended_result[31]}}, unextended_result};


### PR DESCRIPTION
Fix the semantics of `rorw` and `roriw` to perform the rotation using the extracted 32-bit `xs1_word` operand rather than the full-width `X[xs1]` register value.

Both instructions continue to sign-extend the 32-bit result to XLEN as required.

Signed-off-by: Abhik Gude <abhigude@qti.qualcomm.com>