### PR TITLE
fix(csr): gate minstreth on Sm

### DIFF
--- a/spec/std/isa/csr/minstreth.yaml
+++ b/spec/std/isa/csr/minstreth.yaml
@@ -34,6 +34,6 @@ definedBy:
   allOf:
     - xlen: 32
     - extension:
-        name: Zicntr
+        name: Sm
 sw_read(): |
   return CSR[minstret].COUNT[63:32];


### PR DESCRIPTION
Change `minstreth` to be `definedBy: Sm`, aligning with `minstret`, `mcycle`, `mcycleh` of the M-mode Hardware Performance Monitory counter family.

Closes #2347