### PR TITLE
fix(isa): use Hypervisor XLEN field encoding

### DIFF
--- a/spec/std/isa/csr/vsstatus.yaml
+++ b/spec/std/isa/csr/vsstatus.yaml
@@ -59,7 +59,13 @@ fields:
     type(): |
       return ($array_size(VUXLEN) > 1) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
-      return ($array_size(VUXLEN) > 1) ? UNDEFINED_LEGAL : VUXLEN[0];
+      if ($array_size(VUXLEN) == 1 && VUXLEN[0] == 32) {
+        return 0;
+      } else if ($array_size(VUXLEN) == 1 && VUXLEN[0] == 64) {
+        return 1;
+      } else {
+        return UNDEFINED_LEGAL;
+      }
   SPELP:
     location: 23
     long_name: VS-mode Previous Expected Landing Pad state

--- a/spec/std/isa/isa/globals.isa
+++ b/spec/std/isa/isa/globals.isa
@@ -923,17 +923,17 @@ function xlen {
           unreachable();
         }
       } else if (implemented?(ExtensionName::H) && mode() == PrivilegeMode::VS) {
-        if (CSR[hstatus].VSXL == $bits(XRegWidth::XLEN32)) {
+        if (CSR[hstatus].VSXL == 0) {
           return 32;
-        } else if (CSR[hstatus].VSXL == $bits(XRegWidth::XLEN64)) {
+        } else if (CSR[hstatus].VSXL == 1) {
           return 64;
         } else {
           unreachable();
         }
       } else if (implemented?(ExtensionName::H) && mode() == PrivilegeMode::VU) {
-        if (CSR[vsstatus].UXL == $bits(XRegWidth::XLEN32)) {
+        if (CSR[vsstatus].UXL == 0) {
           return 32;
-        } else if (CSR[vsstatus].UXL == $bits(XRegWidth::XLEN64)) {
+        } else if (CSR[vsstatus].UXL == 1) {
           return 64;
         } else {
           unreachable();
@@ -1311,10 +1311,10 @@ function base32? {
       } else if (implemented?(ExtensionName::U) && mode() == PrivilegeMode::U) {
         return CSR[mstatus].UXL == $bits(xlen32);
       } else if (implemented?(ExtensionName::H) && mode() == PrivilegeMode::VS) {
-        return CSR[hstatus].VSXL == $bits(xlen32);
+        return CSR[hstatus].VSXL == 0;
       } else {
         assert(implemented?(ExtensionName::H) && mode() == PrivilegeMode::VU, "Unexpected mode");
-        return CSR[vsstatus].UXL == $bits(xlen32);
+        return CSR[vsstatus].UXL == 0;
       }
     }
   }
@@ -1355,11 +1355,11 @@ function current_translation_mode {
         } else if (mode_val == $bits(SatpMode::Sv32)) {
           # Sv32 is only defined when XLEN == 32
           if (MXLEN == 64) {
-            if ((effective_mode == PrivilegeMode::VS) && (CSR[hstatus].VSXL != $bits(XRegWidth::XLEN32))) {
+            if ((effective_mode == PrivilegeMode::VS) && (CSR[hstatus].VSXL != 0)) {
               # not supported in this XLEN
               return SatpMode::Reserved;
             }
-            if ((effective_mode == PrivilegeMode::VU) && (CSR[vsstatus].UXL != $bits(XRegWidth::XLEN32))) {
+            if ((effective_mode == PrivilegeMode::VU) && (CSR[vsstatus].UXL != 0)) {
               # not supported in this XLEN
               return SatpMode::Reserved;
             }
@@ -1373,11 +1373,11 @@ function current_translation_mode {
           return SatpMode::Sv32;
         } else if ((MXLEN == 64) && (mode_val == $bits(SatpMode::Sv39))) {
           # Sv39 is only defined when XLEN == 64
-          if (effective_mode == PrivilegeMode::VS && CSR[hstatus].VSXL != $bits(XRegWidth::XLEN64)) {
+          if (effective_mode == PrivilegeMode::VS && CSR[hstatus].VSXL != 1) {
             # not supported in this XLEN
             return SatpMode::Reserved;
           }
-          if (effective_mode == PrivilegeMode::VU && CSR[vsstatus].UXL != $bits(XRegWidth::XLEN64)) {
+          if (effective_mode == PrivilegeMode::VU && CSR[vsstatus].UXL != 1) {
             # not supported in this XLEN
             return SatpMode::Reserved;
           }
@@ -1390,11 +1390,11 @@ function current_translation_mode {
           return SatpMode::Sv39;
         } else if ((MXLEN == 64) && (mode_val == $bits(SatpMode::Sv48))) {
           # Sv48 is only defined when XLEN == 64
-          if (effective_mode == PrivilegeMode::VS && CSR[hstatus].VSXL != $bits(XRegWidth::XLEN64)) {
+          if (effective_mode == PrivilegeMode::VS && CSR[hstatus].VSXL != 1) {
             # not supported in this XLEN
             return SatpMode::Reserved;
           }
-          if (effective_mode == PrivilegeMode::VU && CSR[vsstatus].UXL != $bits(XRegWidth::XLEN64)) {
+          if (effective_mode == PrivilegeMode::VU && CSR[vsstatus].UXL != 1) {
             # not supported in this XLEN
             return SatpMode::Reserved;
           }
@@ -1407,11 +1407,11 @@ function current_translation_mode {
           return SatpMode::Sv48;
         } else if ((MXLEN == 64) && (mode_val == $bits(SatpMode::Sv57))) {
           # Sv57 is only defined when XLEN == 64
-          if (effective_mode == PrivilegeMode::VS && CSR[hstatus].VSXL != $bits(XRegWidth::XLEN64)) {
+          if (effective_mode == PrivilegeMode::VS && CSR[hstatus].VSXL != 1) {
             # not supported in this XLEN
             return SatpMode::Reserved;
           }
-          if (effective_mode == PrivilegeMode::VU && CSR[vsstatus].UXL != $bits(XRegWidth::XLEN64)) {
+          if (effective_mode == PrivilegeMode::VU && CSR[vsstatus].UXL != 1) {
             # not supported in this XLEN
             return SatpMode::Reserved;
           }
@@ -1598,7 +1598,7 @@ function tinst_value_for_guest_page_fault {
         if (TINST_VALUE_ON_FINAL_LOAD_GUEST_PAGE_FAULT == "always zero") {
           return 0;
         } else if (TINST_VALUE_ON_FINAL_LOAD_GUEST_PAGE_FAULT == "always pseudoinstruction") {
-          if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 32) || ((MXLEN == 64) && (CSR[hstatus].VSXL == $bits(XRegWidth::XLEN32)))) {
+          if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 32) || ((MXLEN == 64) && (CSR[hstatus].VSXL == 0))) {
             return 0x00002000;
           } else {
             return 0x00003000;
@@ -1613,7 +1613,7 @@ function tinst_value_for_guest_page_fault {
         if (TINST_VALUE_ON_FINAL_STORE_AMO_GUEST_PAGE_FAULT == "always zero") {
           return 0;
         } else if (TINST_VALUE_ON_FINAL_STORE_AMO_GUEST_PAGE_FAULT == "always pseudoinstruction") {
-          if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 32) || ((MXLEN == 64) && (CSR[hstatus].VSXL == $bits(XRegWidth::XLEN32)))) {
+          if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 32) || ((MXLEN == 64) && (CSR[hstatus].VSXL == 0))) {
             return 0x00002020;
           } else {
             return 0x00003020;
@@ -1628,9 +1628,9 @@ function tinst_value_for_guest_page_fault {
     } else {
       if (REPORT_GPA_IN_TVAL_ON_INTERMEDIATE_GUEST_PAGE_FAULT) {
         # spec states hardware must write the pseduo-instruction values to *tinst
-        if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 32) || ((MXLEN == 64) && (CSR[hstatus].VSXL == $bits(XRegWidth::XLEN32)))) {
+        if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 32) || ((MXLEN == 64) && (CSR[hstatus].VSXL == 0))) {
           return 0x00002000;
-        } else if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 64) || ((MXLEN == 64) && (CSR[hstatus].VSXL == $bits(XRegWidth::XLEN64)))) {
+        } else if (($array_size(VSXLEN) == 1 && VSXLEN[0] == 64) || ((MXLEN == 64) && (CSR[hstatus].VSXL == 1))) {
           return 0x00003000;
         }
       }


### PR DESCRIPTION
Closes #2352.

## Problem

The Hypervisor XLEN fields (`hstatus.VSXL` and `vsstatus.UXL`) use their own field encoding (`0 = RV32`, `1 = RV64`), but several VS/VU runtime paths compare them against the `XRegWidth` encoding instead. Additionally, `vsstatus.UXL.reset_value()` initializes the field using the raw `VUXLEN` parameter rather than the encoded CSR value.

## Solution

Update the VS/VU runtime helpers in `globals.isa` to use the Hypervisor field encoding and change `vsstatus.UXL.reset_value()` to initialize the encoded CSR value for fixed `VUXLEN` configurations.