### PR TITLE
Fix CTR supervisor CSR defining extensions

### DIFF
--- a/spec/std/isa/csr/Smctr/sctrctl.yaml
+++ b/spec/std/isa/csr/Smctr/sctrctl.yaml
@@ -13,7 +13,7 @@ priv_mode: S
 length: 64
 definedBy:
   extension:
-    name: Smctr
+    name: Ssctr
 description: The `sctrctl` register enables and configures the Control Transfer Records capability in S mode.
 fields:
   U:

--- a/spec/std/isa/csr/Smctr/vsctrctl.yaml
+++ b/spec/std/isa/csr/Smctr/vsctrctl.yaml
@@ -14,7 +14,9 @@ priv_mode: VS
 length: 64
 definedBy:
   extension:
-    name: Smctr
+    allOf:
+      - name: Ssctr
+      - name: H
 description: |
   The `vsctrctl` register is a VS-mode's version of supervisor register `sctrctl` that
   configures the Control Transfer Records capability. When `V=1`, vsctrctl substitutes

--- a/spec/std/isa/ext/Smctr.yaml
+++ b/spec/std/isa/ext/Smctr.yaml
@@ -51,7 +51,7 @@ requirements:
   extension:
     allOf:
       - name: S
-        version: ~> 1.13 # The latest ratified version of S when Sscntr was ratified
+        version: ~> 1.13 # The latest ratified version of S when Ssctr was ratified
       - name: Smcsrind
         version: ~> 1.0
       - name: Ssctr

--- a/spec/std/isa/ext/Ssctr.yaml
+++ b/spec/std/isa/ext/Ssctr.yaml
@@ -18,6 +18,6 @@ requirements:
   extension:
     allOf:
       - name: S
-        version: ~> 1.13 # The latest ratified version of S when Sscntr was ratified
+        version: ~> 1.13 # The latest ratified version of S when Ssctr was ratified
       - name: Sscsrind
         version: ~> 1.0


### PR DESCRIPTION
Mark `sctrctl` as defined by `Ssctr` instead of `Smctr`, matching its supervisor-level role.

Mark `vsctrctl` as depending on both `Ssctr` and `H`, since it is the virtual supervisor view of `sctrctl`.

Generated with AI assistance.