### PR TITLE
fix: BCDDevice READ case silently dropping HTIF console input

### DIFF
--- a/backends/cpp_hart_gen/cpp/include/udb/htif.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/htif.hpp
@@ -26,12 +26,12 @@ union HTIFCOMMAND
 class HTIFDevice
 {
 public:
-  HTIFDevice(udb::IssSocModel* pSoC);
+  HTIFDevice(udb::IssSocModel* pSoC, uint64_t fromHost);
   ~HTIFDevice();
-
   virtual int HandleCommand(HTIFCOMMAND cmd) = 0;
 protected:
   udb::IssSocModel* m_pSoC;
+  uint64_t m_fromHost;
 };
 
 //SysCall Device
@@ -43,7 +43,7 @@ typedef int (SysCallDevice::*SYSCALLHANDLER)(uint64_t a0, uint64_t a1, uint64_t 
 class SysCallDevice : public HTIFDevice
 {
 public:
-  SysCallDevice(udb::IssSocModel* pSoC);
+  SysCallDevice(udb::IssSocModel* pSoC, uint64_t fromHost);
   ~SysCallDevice();
 
   class Pass : public udb::ExitEvent
@@ -78,7 +78,7 @@ protected:
 class BCDDevice : public HTIFDevice
 {
 public:
-  BCDDevice(udb::IssSocModel* pSoC);
+  BCDDevice(udb::IssSocModel* pSoC, uint64_t fromHost);
   ~BCDDevice();
 
   enum BCDCMD

--- a/backends/cpp_hart_gen/cpp/src/htif.cpp
+++ b/backends/cpp_hart_gen/cpp/src/htif.cpp
@@ -4,7 +4,7 @@
 
 HostTargetInterface::HostTargetInterface(udb::IssSocModel* pSoC, uint64_t toHostAddress,
                                          uint64_t fromHostAddress, uint64_t sigAddress,
-                                         uint64_t sigLength) : m_sysCall(pSoC), m_bcd(pSoC)
+                                         uint64_t sigLength) : m_sysCall(pSoC, fromHostAddress), m_bcd(pSoC, fromHostAddress)
 {
   m_toHost = toHostAddress;
   m_fromHost = fromHostAddress;
@@ -75,9 +75,10 @@ int HostTargetInterface::HandleCommand(HTIFCOMMAND cmd)
   return 0;
 }
 
-HTIFDevice::HTIFDevice(udb::IssSocModel* pSoC)
+HTIFDevice::HTIFDevice(udb::IssSocModel* pSoC, uint64_t fromHost)
 {
   m_pSoC = pSoC;
+  m_fromHost = fromHost;
 }
 
 HTIFDevice::~HTIFDevice()
@@ -85,8 +86,8 @@ HTIFDevice::~HTIFDevice()
 
 }
 
-SysCallDevice::SysCallDevice(udb::IssSocModel* pSoC)
-  : HTIFDevice(pSoC), m_cmdHandlers(94)
+SysCallDevice::SysCallDevice(udb::IssSocModel* pSoC, uint64_t fromHost)
+  : HTIFDevice(pSoC, fromHost), m_cmdHandlers(94)
 {
   m_cmdHandlers[93] = &SysCallDevice::exit;
 }
@@ -135,8 +136,8 @@ int SysCallDevice::exit(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
   return a0;
 }
 
-BCDDevice::BCDDevice(udb::IssSocModel* pSoC)
-  : HTIFDevice(pSoC)
+BCDDevice::BCDDevice(udb::IssSocModel* pSoC, uint64_t fromHost)
+  : HTIFDevice(pSoC, fromHost)
 {
 
 }
@@ -151,7 +152,11 @@ int BCDDevice::HandleCommand(HTIFCOMMAND cmd)
   switch(cmd.command)
   {
   case READ:
-    //TODO:
+    {
+      //TODO: use dedicated console, stdin for now
+      uint8_t ch = static_cast<uint8_t>(std::getchar());
+      m_pSoC->memcpy_from_host(m_fromHost, &ch, sizeof(ch));
+    }
     break;
   case WRITE:
     //TODO: use deicated console, stdout for now


### PR DESCRIPTION
fixes #2310

## Summary
`BCDDevice::HandleCommand()`'s READ case was empty, so any guest program  issuing an HTIF console READ got no response — the command was silently dropped with no data and no error. Additionally, `m_fromHost` was never passed down to `HTIFDevice`/`BCDDevice`, so there was no host→target write 
path wired up for HTIF devices at all.

## Changes
- `HTIFDevice` base class now stores `m_fromHost`, passed in via its constructor
- `SysCallDevice` and `BCDDevice` constructors forward `fromHost` from `HostTargetInterface`
- `BCDDevice::HandleCommand`'s READ case now reads a character via `std::getchar()` and writes it to the guest at `m_fromHost` using `IssSocModel::memcpy_from_host`,  mirroring how WRITE already uses `std::putchar` for the reverse direction