### PR TITLE
fix(csr): length on some supervisor CSRs should be SXLEN/VSXLEN, not 64

### DIFF
--- a/spec/std/isa/csr/sepc.yaml
+++ b/spec/std/isa/csr/sepc.yaml
@@ -10,7 +10,7 @@ long_name: Supervisor Exception Program Counter
 address: 0x141
 writable: true
 priv_mode: S
-length: 64
+length: SXLEN
 description: |
   Written with the PC of an instruction on an exception or interrupt taken in (H)S-mode.
 
@@ -20,7 +20,8 @@ definedBy:
     name: S
 fields:
   PC:
-    location: 63-0
+    location_rv32: 31-0
+    location_rv64: 63-0
     description: |
       When a trap is taken into S-mode, `sepc.PC` is written with the virtual address of the
       instruction that was interrupted or that encountered the exception.
@@ -38,7 +39,7 @@ fields:
       When `misa.C` is clear, bit 1 is masked to zero. Writes to bit 1 are still captured, and
       may be visible on the next read with `misa.C` is set.
 
-      Holds bits 63:<%= ext?(:C) ? 2 : 1 %> of the virtual address associated with an exception.
+      Holds bits [SXLEN-1:<%= ext?(:C) ? 2 : 1 %>] of the virtual address associated with an exception.
     type: RW-RH
     sw_write(csr_value): |
       return csr_value.PC & ~64'b1;

--- a/spec/std/isa/csr/sip.yaml
+++ b/spec/std/isa/csr/sip.yaml
@@ -15,7 +15,7 @@ description: |
 
   Hypervisor-related interrupts (VS-mode interrupts and Supervisor Guest interrupts) are not reflected
   in `sip` even though those interrupts can be taken in HS-mode. Instead, they are reported through `hip`.
-length: 64
+length: SXLEN
 definedBy:
   extension:
     name: S

--- a/spec/std/isa/csr/sscratch.yaml
+++ b/spec/std/isa/csr/sscratch.yaml
@@ -10,14 +10,15 @@ long_name: Supervisor Scratch Register
 address: 0x140
 writable: true
 priv_mode: S
-length: 64
+length: SXLEN
 description: Scratch register for software use. Bits are not interpreted by hardware.
 definedBy: # actually, defined by RV64, but must implement U-mode for this CSR to exist
   extension:
     name: S
 fields:
   SCRATCH:
-    location: 63-0
+    location_rv32: 31-0
+    location_rv64: 63-0
     description: Scratch value
     type: RW
     reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/stval.yaml
+++ b/spec/std/isa/csr/stval.yaml
@@ -11,13 +11,14 @@ address: 0x143
 writable: true
 description: Holds trap-specific information
 priv_mode: S
-length: 64
+length: SXLEN
 definedBy:
   extension:
     name: S
 fields:
   VALUE:
-    location: 63-0
+    location_rv32: 31-0
+    location_rv64: 63-0
     description: |
       Written with trap-specific information when a trap is taken into S-mode.
 

--- a/spec/std/isa/csr/stvec.yaml
+++ b/spec/std/isa/csr/stvec.yaml
@@ -10,19 +10,20 @@ long_name: Supervisor Trap Vector
 address: 0x105
 writable: true
 priv_mode: S
-length: 64
+length: SXLEN
 description: Controls where traps jump.
 definedBy:
   extension:
     name: S
 fields:
   BASE:
-    location: 63-2
+    location_rv32: 31-2
+    location_rv64: 63-2
     description: |
       <%- va_size = ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 48 : 39) -%>
-      Bits 63:2 of the virtual address of the exception vector for any trap taken into S-mode.
+      Bits [SXLEN-1:2] of the virtual address of the exception vector for any trap taken into S-mode.
 
-      If the base address is written with a non-canonical address (_i.e._, bits 63:<%= va_size %> do not match bit <%= va_size-1 %>),
+      If the base address is written with a non-canonical address (_i.e._, bits [SXLEN-1:<%= va_size %>] do not match bit <%= va_size-1 %>),
       the write should be ignored.
 
     type: RW-R

--- a/spec/std/isa/csr/vsepc.yaml
+++ b/spec/std/isa/csr/vsepc.yaml
@@ -11,7 +11,7 @@ address: 0x241
 writable: true
 virtual_address: 0x141
 priv_mode: VS
-length: 64
+length: VSXLEN
 description: |
   Written with the PC of an instruction on an exception or interrupt taken in VS-mode.
 
@@ -21,7 +21,8 @@ definedBy:
     name: H
 fields:
   PC:
-    location: 63-0
+    location_rv32: 31-0
+    location_rv64: 63-0
     description: |
       When a trap is taken into VS-mode, `vsepc.PC` is written with the virtual address of the
       instruction that was interrupted or that encountered the exception.
@@ -39,7 +40,7 @@ fields:
       When `misa.C` is clear, bit 1 is masked to zero. Writes to bit 1 are still captured, and
       may be visible on the next read with `misa.C` is set.
 
-      Holds bits 63:<%= ext?(:C) ? 2 : 1 %> of the virtual address associated with an exception.
+      Holds bits [VSXLEN-1:<%= ext?(:C) ? 2 : 1 %>] of the virtual address associated with an exception.
     type: RW-RH
     sw_write(csr_value): |
       return csr_value.PC & ~64'b1;

--- a/spec/std/isa/csr/vstvec.yaml
+++ b/spec/std/isa/csr/vstvec.yaml
@@ -11,19 +11,20 @@ address: 0x205
 writable: true
 virtual_address: 0x105
 priv_mode: VS
-length: 64
+length: VSXLEN
 description: Controls where traps jump.
 definedBy:
   extension:
     name: H
 fields:
   BASE:
-    location: 63-2
+    location_rv32: 31-2
+    location_rv64: 63-2
     description: |
       <%- va_size = ext?(:Sv57) ? 57 : (ext?(:Sv48) ? 48 : 39) -%>
-      Bits 63:2 of the virtual address of the exception vector for any trap taken into VS-mode.
+      Bits [VSXLEN-1:2] of the virtual address of the exception vector for any trap taken into VS-mode.
 
-      If the base address is written with a non-canonical address (_i.e._, bits 63:<%= va_size %> do not match bit <%= va_size-1 %>),
+      If the base address is written with a non-canonical address (_i.e._, bits [VSXLEN-1:<%= va_size %>] do not match bit <%= va_size-1 %>),
       the write should be ignored.
 
     type: RW-R


### PR DESCRIPTION
`sepc`, `sip`, `sscratch`, `stval` and `stvec` carry `length: 64`, as do `vsepc` and `vstvec`, but the privileged spec defines each as an SXLEN-bit register, VSXLEN-bit for the VS-mode pair. In this schema `length: 64` means 64 bits wide whatever XLEN is, which is what `menvcfg` and the counters need but not these. It bites on the two configs that set `SXLEN: [32]`, `cfgs/rv32-riscv-tests.yaml` and `cfgs/rv32-vector.yaml`: there `sie` resolves to 32 bits while `sip` stays at 64, though the spec defines the two in one sentence as the same width.

This sets the length symbolically and splits the field locations into `location_rv32` and `location_rv64`, copying the encoding `mepc`, `mtval`, `mscratch` and `mtvec` already use. `sip` needs only the length change, since all of its fields already sit at or below bit 13. It also makes the S-mode trap path in `globals.isa` type-consistent with the M-mode one beside it, where `{CSR[stvec].BASE, 2'b00}` previously built a 64-bit value on RV32.

Closes #2361