### PR TITLE
fix(csr): htimedeltah: read correct half of htimedelta

### DIFF
--- a/spec/std/isa/csr/H/htimedeltah.yaml
+++ b/spec/std/isa/csr/H/htimedeltah.yaml
@@ -29,4 +29,4 @@ fields:
       CSR[htimedelta].DELTA = {csr_value.DELTA, CSR[htimedelta].DELTA[31:0]};
       return csr_value.DELTA;
 sw_read(): |
-  return CSR[htimedelta].DELTA[31:0];
+  return CSR[htimedelta].DELTA[63:32];


### PR DESCRIPTION
`htimedeltah` represents the upper 32 bits of `htimedelta`, but `sw_read()` currently returns `CSR[htimedelta].DELTA[31:0]`. This is inconsistent with both the CSR description and the existing `sw_write()` implementation.

Update `htimedeltah.sw_read()` to return `CSR[htimedelta].DELTA[63:32]`.

Closes #2367.