### PR TITLE
fix(csr): retain henvcfg CBIE on illegal writes

### DIFF
--- a/spec/std/isa/csr/H/henvcfg.yaml
+++ b/spec/std/isa/csr/H/henvcfg.yaml
@@ -258,7 +258,7 @@ fields:
       if (csr_value.CBIE == 0 || csr_value.CBIE == 1 || csr_value.CBIE == 3) {
         return csr_value.CBIE;
       } else {
-        return CSR[menvcfg].CBIE;
+        return CSR[henvcfg].CBIE;
       }
     reset_value: UNDEFINED_LEGAL
   SSE:


### PR DESCRIPTION
`sw_write` for `henvcfg.CBIE` return `menvcfg.CBIE` (note `*m*envcfg`) when writing reserved value. 

Fix to return `henvcfg.CBIE` (preserve current value) when writing reserved value. 

Closes #2369.