### PR TITLE
fix(csr): read vsctrctl should not return mctrctl

### DIFF
--- a/spec/std/isa/csr/Smctr/vsctrctl.yaml
+++ b/spec/std/isa/csr/Smctr/vsctrctl.yaml
@@ -225,4 +225,4 @@ sw_read(): |
   if (MCTRCTL_CUSTOM_IMPLEMENTED) {
     mask = mask | (4'b1111 `<< 60);
   }
-  return ($bits(CSR[mctrctl]) & mask);
+  return ($bits(CSR[vsctrctl]) & mask);


### PR DESCRIPTION
`vsctrctl.sw_read()` currently returns the masked value of `CSR[mctrctl]` instead of `CSR[vsctrctl]`, causing reads to observe the machine CSR rather than the value stored in `vsctrctl`.

Update `sw_read()` to read from `CSR[vsctrctl]` while preserving the existing mask logic.

Closes #2371.