### PR TITLE
fix(csr): forward menvcfgh accesses to menvcfg

### DIFF
--- a/spec/std/isa/csr/menvcfgh.yaml
+++ b/spec/std/isa/csr/menvcfgh.yaml
@@ -24,6 +24,9 @@ fields:
   STCE:
     location: 31
     alias: menvcfg.STCE
+    sw_write(csr_value): |
+      CSR[menvcfg].STCE = csr_value.STCE;
+      return csr_value.STCE;
     description: |
       *STimecmp Enable*
 
@@ -36,6 +39,9 @@ fields:
   PBMTE:
     location: 30
     alias: menvcfg.PBMTE
+    sw_write(csr_value): |
+      CSR[menvcfg].PBMTE = csr_value.PBMTE;
+      return csr_value.PBMTE;
     description: |
       *Page Based Memory Type Enable*
 
@@ -48,6 +54,9 @@ fields:
   ADUE:
     location: 29
     alias: menvcfg.ADUE
+    sw_write(csr_value): |
+      CSR[menvcfg].ADUE = csr_value.ADUE;
+      return csr_value.ADUE;
     description: |
       Alias of `menvcfg.ADUE`
     definedBy:
@@ -57,3 +66,5 @@ fields:
       return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
+sw_read(): |
+  return $bits(CSR[menvcfg])[63:32];


### PR DESCRIPTION
Fixes #2377 

## Summary

`menvcfgh` is the RV32 upper-half view of `menvcfg`, but it did not forward accesses to the parent CSR.

This change:

- adds a CSR-level `sw_read()` returning the upper 32 bits of `menvcfg`
- forwards writes for `STCE`, `PBMTE`, and `ADUE` to `menvcfg`

This matches the unified-storage implementation already used by `mstateen0h`.

Fixes #2377 