### PR TITLE
fix(z3): implement oneOf, noneOf, and if/then/else for scalar parameters

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/z3.rb
+++ b/tools/ruby-gems/udb/lib/udb/z3.rb
@@ -318,16 +318,19 @@ module Udb
   # Supported JSON schema features:
   # - Type constraints (boolean, integer, string, array)
   # - Value constraints (const, enum, minimum, maximum)
-  # - Composition (allOf; anyOf for boolean, integer, and string)
+  # - Composition (allOf; anyOf/oneOf/noneOf and if/then/else for boolean,
+  #   integer, and string)
   # - References ($ref to uint32/uint64)
   # - Array constraints (items, minItems, maxItems, contains, uniqueItems)
   #
   # Not yet supported (TODO):
-  # - anyOf for array
-  # - oneOf, noneOf
-  # - if/then/else (conditional schemas)
+  # - anyOf/oneOf/noneOf and if/then/else for array
+  #   (these must disjoin whole array shapes, not just element values)
   class Z3ParameterTerm
     extend T::Sig
+
+    # Schema keywords that hold a list of subschemas constraining the same term
+    COMBINATOR_KEYWORDS = T.let(["allOf", "anyOf", "oneOf", "noneOf"].freeze, T::Array[String])
 
     sig { returns(String) }
     attr_reader :name
@@ -343,6 +346,9 @@ module Udb
     # - minimum/maximum: range bounds (unsigned comparison)
     # - allOf: conjunction of subschemas
     # - anyOf: inclusive disjunction of subschemas (at least one must hold)
+    # - oneOf: exclusive disjunction of subschemas (exactly one must hold)
+    # - noneOf: negated disjunction of subschemas (none may hold)
+    # - if/then/else: conditional subschemas
     # - $ref: references to uint32/uint64 types
     #
     # @param solver [Z3Solver] The solver to add assertions to
@@ -399,15 +405,23 @@ module Udb
       end
 
       if schema_hsh.key?("oneOf")
-        raise "TODO: oneOf not yet implemented for integer constraints"
+        branches = schema_hsh.fetch("oneOf").map do |h|
+          constrain_int(solver, term, h, assert: false)
+        end
+        assertions << one_of_constraint(branches)
       end
 
       if schema_hsh.key?("noneOf")
-        raise "TODO: noneOf not yet implemented for integer constraints"
+        branches = schema_hsh.fetch("noneOf").map do |h|
+          constrain_int(solver, term, h, assert: false)
+        end
+        assertions << none_of_constraint(branches)
       end
 
       if schema_hsh.key?("if")
-        raise "TODO: if/then/else not yet implemented for integer constraints"
+        assertions += if_then_else_constraints(schema_hsh) do |h|
+          constrain_int(solver, term, h, assert: false)
+        end
       end
 
       if schema_hsh.key?("$ref")
@@ -476,15 +490,23 @@ module Udb
       end
 
       if schema_hsh.key?("oneOf")
-        raise "TODO: oneOf not yet implemented for boolean constraints"
+        branches = schema_hsh.fetch("oneOf").map do |h|
+          constrain_bool(solver, term, h, assert: false)
+        end
+        assertions << one_of_constraint(branches)
       end
 
       if schema_hsh.key?("noneOf")
-        raise "TODO: noneOf not yet implemented for boolean constraints"
+        branches = schema_hsh.fetch("noneOf").map do |h|
+          constrain_bool(solver, term, h, assert: false)
+        end
+        assertions << none_of_constraint(branches)
       end
 
       if schema_hsh.key?("if")
-        raise "TODO: if/then/else not yet implemented for boolean constraints"
+        assertions += if_then_else_constraints(schema_hsh) do |h|
+          constrain_bool(solver, term, h, assert: false)
+        end
       end
 
       if assert
@@ -543,15 +565,23 @@ module Udb
       end
 
       if schema_hsh.key?("oneOf")
-        raise "TODO: oneOf not yet implemented for string constraints"
+        branches = schema_hsh.fetch("oneOf").map do |h|
+          constrain_string(solver, term, h, assert: false)
+        end
+        assertions << one_of_constraint(branches)
       end
 
       if schema_hsh.key?("noneOf")
-        raise "TODO: noneOf not yet implemented for string constraints"
+        branches = schema_hsh.fetch("noneOf").map do |h|
+          constrain_string(solver, term, h, assert: false)
+        end
+        assertions << none_of_constraint(branches)
       end
 
       if schema_hsh.key?("if")
-        raise "TODO: if/then/else not yet implemented for string constraints"
+        assertions += if_then_else_constraints(schema_hsh) do |h|
+          constrain_string(solver, term, h, assert: false)
+        end
       end
 
       if assert
@@ -560,14 +590,61 @@ module Udb
       assertions
     end
 
+    # Conjoin a branch's assertions into a single expression, so that a
+    # subschema can be used as a condition instead of being asserted outright.
+    sig { params(assertions: T::Array[Z3::BoolExpr]).returns(Z3::BoolExpr) }
+    def self.conjoin(assertions)
+      assertions.reduce(Z3.True) { |expression, assertion| expression & assertion }
+    end
+    private_class_method :conjoin
+
     sig { params(branches: T::Array[T::Array[Z3::BoolExpr]]).returns(Z3::BoolExpr) }
     def self.any_of_constraint(branches)
-      expressions = branches.map do |branch|
-        branch.reduce(Z3.True) { |expression, assertion| expression & assertion }
-      end
-      expressions.reduce(Z3.False) { |expression, branch| expression | branch }
+      branches.map { |branch| conjoin(branch) }
+              .reduce(Z3.False) { |expression, branch| expression | branch }
     end
     private_class_method :any_of_constraint
+
+    # Exactly one branch may hold: each disjunct asserts its own branch and
+    # negates every other one.
+    sig { params(branches: T::Array[T::Array[Z3::BoolExpr]]).returns(Z3::BoolExpr) }
+    def self.one_of_constraint(branches)
+      expressions = branches.map { |branch| conjoin(branch) }
+      expressions.each_with_index.reduce(Z3.False) do |disjunction, (expression, idx)|
+        exclusive = expressions.each_with_index.reduce(expression) do |acc, (other, other_idx)|
+          other_idx == idx ? acc : acc & ~other
+        end
+        disjunction | exclusive
+      end
+    end
+    private_class_method :one_of_constraint
+
+    # No branch may hold. Matches the noneOf semantics used by the condition
+    # language: NOT(OR(branches)).
+    sig { params(branches: T::Array[T::Array[Z3::BoolExpr]]).returns(Z3::BoolExpr) }
+    def self.none_of_constraint(branches)
+      ~any_of_constraint(branches)
+    end
+    private_class_method :none_of_constraint
+
+    # Build the implications for a conditional schema. The "if" subschema is
+    # evaluated as a condition rather than asserted, so a schema with no "then"
+    # or "else" adds nothing. A missing branch leaves that case unconstrained.
+    sig {
+      params(
+        schema_hsh: T::Hash[String, T.untyped],
+        blk: T.proc.params(subschema: T::Hash[String, T.untyped]).returns(T::Array[Z3::BoolExpr])
+      )
+      .returns(T::Array[Z3::BoolExpr])
+    }
+    def self.if_then_else_constraints(schema_hsh, &blk)
+      condition = conjoin(blk.call(schema_hsh.fetch("if")))
+      assertions = T.let([], T::Array[Z3::BoolExpr])
+      assertions << (~condition | conjoin(blk.call(schema_hsh.fetch("then")))) if schema_hsh.key?("then")
+      assertions << (condition | conjoin(blk.call(schema_hsh.fetch("else")))) if schema_hsh.key?("else")
+      assertions
+    end
+    private_class_method :if_then_else_constraints
 
     # Extract array constraints from JSON schema
     #
@@ -703,44 +780,12 @@ module Udb
         else
           raise "unhandled enum type"
         end
-      elsif schema_hsh.key?("allOf")
-        # Infer type from subschemas (must agree)
-        subschema_types = schema_hsh.fetch("allOf").map { |subschema| detect_type(subschema) }
-
-        if subschema_types.fetch(0) == :string
-          raise "Subschema types do not agree" unless subschema_types[1..].all? { |t| t == :string }
-
-          :string
-        elsif subschema_types.fetch(0) == :boolean
-          raise "Subschema types do not agree" unless subschema_types[1..].all? { |t| t == :boolean }
-
-          :boolean
-        elsif subschema_types.fetch(0) == :int
-          raise "Subschema types do not agree" unless subschema_types[1..].all? { |t| t == :int }
-
-          :int
-        else
-          raise "unhandled subschema type"
-        end
-      elsif schema_hsh.key?("anyOf")
-        # Infer type from anyOf subschemas (must agree on type even if values differ)
-        subschema_types = schema_hsh.fetch("anyOf").map { |subschema| detect_type(subschema) }
-
-        if subschema_types.fetch(0) == :string
-          raise "Subschema types do not agree" unless subschema_types[1..].all? { |t| t == :string }
-
-          :string
-        elsif subschema_types.fetch(0) == :boolean
-          raise "Subschema types do not agree" unless subschema_types[1..].all? { |t| t == :boolean }
-
-          :boolean
-        elsif subschema_types.fetch(0) == :int
-          raise "Subschema types do not agree" unless subschema_types[1..].all? { |t| t == :int }
-
-          :int
-        else
-          raise "unhandled subschema type"
-        end
+      elsif (combinator = COMBINATOR_KEYWORDS.find { |keyword| schema_hsh.key?(keyword) })
+        # Infer type from subschemas (they must agree on type even if values differ)
+        detect_agreeing_type(schema_hsh.fetch(combinator))
+      elsif schema_hsh.key?("if")
+        # A conditional schema constrains one term, so any present branch works
+        detect_agreeing_type(schema_hsh.values_at("if", "then", "else").compact)
       elsif schema_hsh.key?("$ref")
         case schema_hsh.fetch("$ref").split("/").last
         when "uint32", "uint64", "32bit_unsigned_pow2", "64bit_unsigned_pow2"
@@ -754,6 +799,18 @@ module Udb
       else
         raise "unhandled scalar schema:\n#{schema_hsh}"
       end
+    end
+
+    # Detect the single type shared by a list of subschemas
+    #
+    # @param subschemas [Array<Hash>] Subschemas constraining the same term
+    # @return [Symbol] One of :boolean, :int, :string, :array
+    sig { params(subschemas: T::Array[T::Hash[String, T.untyped]]).returns(Symbol) }
+    def self.detect_agreeing_type(subschemas)
+      types = subschemas.map { |subschema| detect_type(subschema) }.uniq
+      raise "Subschema types do not agree: #{types.join(", ")}" unless types.size == 1
+
+      types.fetch(0)
     end
 
     # Detect the element type of an array schema

--- a/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
+++ b/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
@@ -574,4 +574,270 @@ class TestZ3ParameterConstraints < Minitest::Test
     # Elements should be different variables
     refute_equal elem0.object_id, elem1.object_id
   end
+
+  # oneOf tests
+  def test_constrain_int_with_oneof_overlapping_ranges
+    # oneOf is exclusive: a value satisfying both subschemas is rejected.
+    schema = {
+      "oneOf" => [
+        { "minimum" => 0, "maximum" => 10 },
+        { "minimum" => 5, "maximum" => 15 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("oneof_range_param", @solver, schema)
+
+    # Values matching exactly one subschema are allowed
+    [3, 12].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    # A value in the overlap matches both, so oneOf rejects it
+    @solver.push
+    @solver.assert(param == 7)
+    refute @solver.satisfiable?
+    @solver.pop
+
+    # A value matching neither is also rejected
+    @solver.push
+    @solver.assert(param == 20)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_bool_with_oneof_duplicate_branches
+    # Both branches hold for true and neither holds for false, so no value
+    # satisfies exactly one branch.
+    schema = {
+      "type" => "boolean",
+      "oneOf" => [
+        { "const" => true },
+        { "const" => true }
+      ]
+    }
+    Udb::Z3ParameterTerm.new("oneof_bool", @solver, schema)
+
+    refute @solver.satisfiable?
+  end
+
+  def test_constrain_string_with_oneof
+    schema = {
+      "type" => "string",
+      "oneOf" => [
+        { "const" => "alpha" },
+        { "enum" => ["alpha", "beta"] }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("oneof_string", @solver, schema)
+
+    # "beta" matches only the second branch
+    @solver.push
+    @solver.assert(param == "beta")
+    assert @solver.satisfiable?
+    @solver.pop
+
+    # "alpha" matches both branches
+    @solver.push
+    @solver.assert(param == "alpha")
+    refute @solver.satisfiable?
+    @solver.pop
+
+    # "gamma" matches neither
+    @solver.push
+    @solver.assert(param == "gamma")
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  # noneOf tests
+  def test_constrain_int_with_noneof
+    schema = {
+      "type" => "integer",
+      "noneOf" => [
+        { "const" => 1 },
+        { "minimum" => 10, "maximum" => 20 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("noneof_int", @solver, schema)
+
+    [1, 15].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      refute @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 5)
+    assert @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_bool_with_noneof
+    schema = {
+      "type" => "boolean",
+      "noneOf" => [{ "const" => true }]
+    }
+    param = Udb::Z3ParameterTerm.new("noneof_bool", @solver, schema)
+
+    @solver.push
+    @solver.assert(param == true)
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == false)
+    assert @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_string_with_noneof
+    schema = {
+      "type" => "string",
+      "noneOf" => [{ "enum" => ["alpha", "beta"] }]
+    }
+    param = Udb::Z3ParameterTerm.new("noneof_string", @solver, schema)
+
+    @solver.push
+    @solver.assert(param == "alpha")
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == "gamma")
+    assert @solver.satisfiable?
+    @solver.pop
+  end
+
+  # if/then/else tests
+  def test_constrain_int_with_if_then
+    # Without an "else", values failing the condition are unconstrained.
+    schema = {
+      "type" => "integer",
+      "if" => { "minimum" => 100 },
+      "then" => { "maximum" => 200 }
+    }
+    param = Udb::Z3ParameterTerm.new("if_then_int", @solver, schema)
+
+    [50, 150].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 250)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_int_with_if_then_else
+    schema = {
+      "type" => "integer",
+      "if" => { "maximum" => 10 },
+      "then" => { "const" => 5 },
+      "else" => { "const" => 100 }
+    }
+    param = Udb::Z3ParameterTerm.new("if_then_else_int", @solver, schema)
+
+    [5, 100].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    [7, 50].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      refute @solver.satisfiable?
+      @solver.pop
+    end
+  end
+
+  def test_constrain_bool_with_if_then
+    # true would require the term to be false, so only false survives.
+    schema = {
+      "type" => "boolean",
+      "if" => { "const" => true },
+      "then" => { "const" => false }
+    }
+    param = Udb::Z3ParameterTerm.new("if_then_bool", @solver, schema)
+
+    @solver.push
+    @solver.assert(param == true)
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == false)
+    assert @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_string_with_if_then_else
+    schema = {
+      "type" => "string",
+      "if" => { "const" => "alpha" },
+      "then" => { "const" => "beta" },
+      "else" => { "enum" => ["gamma", "delta"] }
+    }
+    param = Udb::Z3ParameterTerm.new("if_then_else_string", @solver, schema)
+
+    # "alpha" triggers the condition, which then demands "beta": contradictory
+    @solver.push
+    @solver.assert(param == "alpha")
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == "gamma")
+    assert @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == "epsilon")
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_combinators_stay_branch_local
+    # A nested combinator inside a oneOf branch must not leak into the solver.
+    schema = {
+      "type" => "integer",
+      "oneOf" => [
+        { "noneOf" => [{ "minimum" => 10 }] },
+        { "minimum" => 100, "maximum" => 110 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("nested_combinator_param", @solver, schema)
+
+    [5, 105].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 50)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_array_combinators_still_unimplemented
+    # Array combinators need to disjoin whole array shapes, not just element
+    # values, so they remain out of scope here.
+    %w[anyOf oneOf noneOf].each do |keyword|
+      schema = {
+        "type" => "array",
+        "items" => { "type" => "integer" },
+        keyword => [{ "maxItems" => 2 }]
+      }
+      assert_raises(RuntimeError) { Udb::Z3ParameterTerm.new("array_#{keyword}", @solver, schema) }
+    end
+  end
 end


### PR DESCRIPTION
The integer, boolean, and string constraint builders in `Udb::Z3ParameterTerm` raised `TODO: ... not yet implemented` for `oneOf`, `noneOf`, and `if`/`then`/`else`. Any parameter schema using one of those keywords aborted constraint solving rather than being translated into Z3. `allOf` and `anyOf` were already handled, `anyOf` since #2019.

`oneOf` asserts its own branch and negates every other one, so a value matching two branches is rejected. `noneOf` negates the disjunction, matching the `noneOf` semantics the condition language already uses (`condition.rb` builds `NOT(OR(children))`). `if`/`then`/`else` conjoins the `if` subschema into a condition expression instead of asserting it, so a missing `then` or `else` leaves that case unconstrained. `detect_type` now infers a type through all four combinators and through a conditional schema, which also collapses the two duplicated `allOf`/`anyOf` inference blocks into one helper.

Array combinators still raise. They have to disjoin whole array shapes rather than element values, so they need a different construction than the scalar path; there is a regression test asserting they still raise, so the remaining scope stays visible.

Addresses #1890 for scalar parameters. Twelve tests added to `test_z3_parameter_constraints.rb` covering exclusivity, negation, both conditional branches, nesting, and the unimplemented array path.