### PR TITLE
test(udb): run every udb test file in CI and in test:udb:unit

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -524,6 +524,11 @@ jobs:
           - z3_extensions
           - z3_finite_array
           - z3_parameter_constraints
+          - csr
+          - gem_install
+          - register_file_obj
+          - schema_defs_pow2
+          - yaml_resolver
   regress-gen-go:
     runs-on: ubuntu-latest
     steps:

--- a/tools/ruby-gems/udb/test/run.rb
+++ b/tools/ruby-gems/udb/test/run.rb
@@ -6,17 +6,10 @@
 
 require_relative "test_helper"
 
-require_relative "test_cfg"
-require_relative "test_cfg_arch"
-require_relative "test_cli"
-require_relative "test_conditions"
-require_relative "test_csr"
-require_relative "test_gem_install"
-require_relative "test_instruction"
-require_relative "test_logic"
-require_relative "test_mmr"
-require_relative "test_mmr_schema"
-require_relative "test_schema_defs_pow2"
-require_relative "test_yaml_loader"
-require_relative "test_z3"
-require_relative "test_register_file_obj"
+# Load every test file in this directory. Enumerating them by hand meant a new
+# test file silently never ran here until someone remembered to add it.
+Dir.children(__dir__).grep(/\Atest_.+\.rb\z/).sort.each do |test_file|
+  next if test_file == "test_helper.rb"
+
+  require_relative test_file
+end

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -179,6 +179,11 @@ tests:
           - z3_extensions
           - z3_finite_array
           - z3_parameter_constraints
+          - csr
+          - gem_install
+          - register_file_obj
+          - schema_defs_pow2
+          - yaml_resolver
     test:
       - name: Run udb gem ${{ matrix.test }} unit tests
         run: ./bin/ruby tools/ruby-gems/udb/test/test_${{ matrix.test }}.rb


### PR DESCRIPTION
Two hand-maintained lists decide which udb test files run: the `regress-udb-unit-test` matrix in `tools/test/regress-tests.yaml` for CI, and the `require_relative` block in `tools/ruby-gems/udb/test/run.rb` for `./do test:udb:unit`. Neither covered all 19 test files, and `run.rb` is not invoked from CI at all, so `test_csr`, `test_gem_install`, `test_register_file_obj`, `test_schema_defs_pow2` and `test_yaml_resolver` (28 tests) never ran in CI, while `test:udb:unit` skipped 138 tests including the whole Z3 parameter constraint suite. `test_yaml_resolver` ran in neither.

`run.rb` now globs the directory, so the developer-facing list cannot drift again. The CI matrix stays an explicit list, since each entry becomes a job that uploads its own coverage artifact, so the five missing files are added by name and `.github/workflows/regress.yml` is regenerated with `./bin/chore gen -f regress`.

All five already pass when invoked directly, so this adds coverage rather than changing behavior. The slowest of them, `test_gem_install`, takes about 7 seconds.

Closes #2380
