### PR TITLE
fix(idl): highest_set_bit never terminates on a zero input

### DIFF
--- a/spec/std/isa/isa/util.idl
+++ b/spec/std/isa/isa/util.idl
@@ -73,9 +73,9 @@ function highest_set_bit {
     or -1 if value is zero.
   }
   body {
-    for (Bits<8> i=xlen()-1; i >= 0; i--) {
-      if (value[i] == 1) {
-        return i;
+    for (Bits<8> i=xlen(); i > 0; i--) {
+      if (value[i-1] == 1) {
+        return i-1;
       }
     }
 

--- a/tests/data/golden/Xqci@0.13.0.adoc
+++ b/tests/data/golden/Xqci@0.13.0.adoc
@@ -39618,9 +39618,9 @@ h! `XReg`
 
 [source,idl,subs="specialchars,macros"]
 ----
-for pass:[(]Bits<8> i = xref:#udb-function-xlen[xlen]pass:[(]) - 1; i >= 0; i--) {
-  if pass:[(]value[i] == 1) {
-    return i;
+for pass:[(]Bits<8> i = xref:#udb-function-xlen[xlen]pass:[(]); i > 0; i--) {
+  if pass:[(]value[i - 1] == 1) {
+    return i - 1;
   }
 }
 return -'sd1;


### PR DESCRIPTION
`highest_set_bit` looped with `for (Bits<8> i=xlen()-1; i >= 0; i--)`. `Bits<8>` is unsigned, so `i >= 0` never goes false and `i--` wraps 0 to 255 - the `return -'sd1` fall-through is unreachable. The generated C++ model loops forever, so `clz`/`clzw` on a zero operand hang. The Ruby evaluator terminates by accident of its integer representation, which is why it went unnoticed.

Count down from `xlen()` and index `value[i-1]` instead: same indices, same results, but termination no longer depends on signedness. `lowest_set_bit` counts up against `i < xlen()` and is unaffected.
