### PR TITLE
fix(csr): senvcfg length should be SXLEN, not 64

### DIFF
--- a/spec/std/isa/csr/senvcfg.yaml
+++ b/spec/std/isa/csr/senvcfg.yaml
@@ -12,7 +12,7 @@ long_name: Supervisor Environment Configuration
 description: |
   Contains fields that control certain characteristics of the U-mode execution environment.
 priv_mode: S
-length: 64
+length: SXLEN
 definedBy:
   extension:
     allOf:


### PR DESCRIPTION
`spec/std/isa/csr/senvcfg.yaml` carries `length: 64`, but supervisor.adoc defines `senvcfg` as an SXLEN-bit read/write register. Change `senvcfg` length to `SXLEN`.

Closes #2364