### PR TITLE
fix: update mailing list link in gemspec metadata

### DIFF
--- a/tools/ruby-gems/idl_highlighter/idl_highlighter.gemspec
+++ b/tools/ruby-gems/idl_highlighter/idl_highlighter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.license     = "BSD-3-Clause-Clear"
   s.metadata    = {
     "homepage_uri"      => "https://github.com/riscv/riscv-unified-db",
-    "mailing_list_uri"  => "https://lists.riscv.org/g/tech-unifieddb",
+    "mailing_list_uri"  => "https://lists.riscv.org/g/sig-unifieddb",
     "bug_tracker_uri"   => "https://github.com/riscv/riscv-unified-db/issues"
   }
   s.required_ruby_version = "~> 3.2"

--- a/tools/ruby-gems/idlc/idlc.gemspec
+++ b/tools/ruby-gems/idlc/idlc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.license     = "BSD-3-Clause-Clear"
   s.metadata    = {
     "homepage_uri" => "https://github.com/riscv/riscv-unified-db",
-    "mailing_list_uri" => "https://lists.riscv.org/g/tech-unifieddb",
+    "mailing_list_uri" => "https://lists.riscv.org/g/sig-unifieddb",
     "bug_tracker_uri" => "https://github.com/riscv/riscv-unified-db/issues"
   }
   s.required_ruby_version = "~> 3.2"

--- a/tools/ruby-gems/udb-gen/udb-gen.gemspec
+++ b/tools/ruby-gems/udb-gen/udb-gen.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.license     = "BSD-3-Clause-Clear"
   s.metadata    = {
     "homepage_uri" => "https://github.com/riscv/riscv-unified-db",
-    "mailing_list_uri" => "https://lists.riscv.org/g/tech-unifieddb",
+    "mailing_list_uri" => "https://lists.riscv.org/g/sig-unifieddb",
     "bug_tracker_uri" => "https://github.com/riscv/riscv-unified-db/issues"
   }
   s.required_ruby_version = "~> 3.2"

--- a/tools/ruby-gems/udb/udb.gemspec
+++ b/tools/ruby-gems/udb/udb.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.license     = "BSD-3-Clause-Clear"
   s.metadata    = {
     "homepage_uri" => "https://github.com/riscv/riscv-unified-db",
-    "mailing_list_uri" => "https://lists.riscv.org/g/tech-unifieddb",
+    "mailing_list_uri" => "https://lists.riscv.org/g/sig-unifieddb",
     "bug_tracker_uri" => "https://github.com/riscv/riscv-unified-db/issues"
   }
   s.required_ruby_version = "~> 3.2"

--- a/tools/ruby-gems/udb_helpers/udb_helpers.gemspec
+++ b/tools/ruby-gems/udb_helpers/udb_helpers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.license     = "BSD-3-Clause-Clear"
   s.metadata    = {
     "homepage_uri"      => "https://github.com/riscv/riscv-unified-db",
-    "mailing_list_uri"  => "https://lists.riscv.org/g/tech-unifieddb",
+    "mailing_list_uri"  => "https://lists.riscv.org/g/sig-unifieddb",
     "bug_tracker_uri"   => "https://github.com/riscv/riscv-unified-db/issues"
   }
   s.required_ruby_version = "~> 3.2"


### PR DESCRIPTION
The mailing_list_uri in all five gemspecs points to https://lists.riscv.org/g/tech-unifieddb, which no longer exists and redirects to a group not found page. Point it at the live UnifiedDB list instead: https://lists.riscv.org/g/sig-unifieddb.

Closes #2397