### PR TITLE
fix(udb): support scalar JSON schema combinators

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/z3.rb
+++ b/tools/ruby-gems/udb/lib/udb/z3.rb
@@ -398,17 +398,7 @@ module Udb
         assertions << any_of_constraint(branches)
       end
 
-      if schema_hsh.key?("oneOf")
-        raise "TODO: oneOf not yet implemented for integer constraints"
-      end
-
-      if schema_hsh.key?("noneOf")
-        raise "TODO: noneOf not yet implemented for integer constraints"
-      end
-
-      if schema_hsh.key?("if")
-        raise "TODO: if/then/else not yet implemented for integer constraints"
-      end
+      assertions.concat(combinator_constraints(solver, term, schema_hsh, method(:constrain_int)))
 
       if schema_hsh.key?("$ref")
         # Handle references to shorthand type definitions
@@ -475,17 +465,7 @@ module Udb
         assertions << any_of_constraint(branches)
       end
 
-      if schema_hsh.key?("oneOf")
-        raise "TODO: oneOf not yet implemented for boolean constraints"
-      end
-
-      if schema_hsh.key?("noneOf")
-        raise "TODO: noneOf not yet implemented for boolean constraints"
-      end
-
-      if schema_hsh.key?("if")
-        raise "TODO: if/then/else not yet implemented for boolean constraints"
-      end
+      assertions.concat(combinator_constraints(solver, term, schema_hsh, method(:constrain_bool)))
 
       if assert
         assertions.each { |a| solver.assert a }
@@ -542,21 +522,55 @@ module Udb
         assertions << any_of_constraint(branches)
       end
 
-      if schema_hsh.key?("oneOf")
-        raise "TODO: oneOf not yet implemented for string constraints"
-      end
-
-      if schema_hsh.key?("noneOf")
-        raise "TODO: noneOf not yet implemented for string constraints"
-      end
-
-      if schema_hsh.key?("if")
-        raise "TODO: if/then/else not yet implemented for string constraints"
-      end
+      assertions.concat(combinator_constraints(solver, term, schema_hsh, method(:constrain_string)))
 
       if assert
         assertions.each { |a| solver.assert a }
       end
+      assertions
+    end
+
+    # Convert a schema branch into one boolean expression without asserting it.
+    # Keeping branch expressions local is essential: asserting a branch directly
+    # would turn oneOf/if into an unconditional constraint.
+    sig {
+      params(
+        solver: Z3Solver,
+        term: T.any(Z3::BitvecExpr, Z3::BoolExpr, Z3::IntExpr),
+        schema_hsh: T::Hash[String, T.untyped],
+        constrainer: Method
+      ).returns(T::Array[Z3::BoolExpr])
+    }
+    def self.combinator_constraints(solver, term, schema_hsh, constrainer)
+      branch = lambda do |schema|
+        constrainer.call(solver, term, schema, assert: false).reduce(Z3.True) { |a, b| a & b }
+      end
+      assertions = []
+
+      if schema_hsh.key?("oneOf")
+        branches = schema_hsh.fetch("oneOf").map { |schema| branch.call(schema) }
+        # Exactly one branch must validate: at least one, and no pair may both.
+        assertions << T.unsafe(Z3).And(
+          T.unsafe(Z3).Or(*branches),
+          *branches.combination(2).map { |a, b| !(a & b) }
+        )
+      end
+
+      if schema_hsh.key?("noneOf")
+        branches = schema_hsh.fetch("noneOf").map { |schema| branch.call(schema) }
+        assertions << !T.unsafe(Z3).Or(*branches)
+      end
+
+      if schema_hsh.key?("if")
+        condition = branch.call(schema_hsh.fetch("if"))
+        if schema_hsh.key?("then")
+          assertions << condition.implies(branch.call(schema_hsh.fetch("then")))
+        end
+        if schema_hsh.key?("else")
+          assertions << (!condition).implies(branch.call(schema_hsh.fetch("else")))
+        end
+      end
+
       assertions
     end
 
@@ -741,6 +755,18 @@ module Udb
         else
           raise "unhandled subschema type"
         end
+      elsif schema_hsh.key?("oneOf") || schema_hsh.key?("noneOf")
+        schemas = schema_hsh.fetch(schema_hsh.key?("oneOf") ? "oneOf" : "noneOf")
+        types = schemas.map { |subschema| detect_type(subschema) }.uniq
+        raise "Subschema types do not agree" unless types.size == 1
+
+        types.fetch(0)
+      elsif schema_hsh.key?("if")
+        schemas = [schema_hsh.fetch("if"), schema_hsh["then"], schema_hsh["else"]].compact
+        types = schemas.map { |subschema| detect_type(subschema) }.uniq
+        raise "Subschema types do not agree" unless types.size == 1
+
+        types.fetch(0)
       elsif schema_hsh.key?("$ref")
         case schema_hsh.fetch("$ref").split("/").last
         when "uint32", "uint64", "32bit_unsigned_pow2", "64bit_unsigned_pow2"

--- a/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
+++ b/tools/ruby-gems/udb/test/test_z3_parameter_constraints.rb
@@ -344,6 +344,108 @@ class TestZ3ParameterConstraints < Minitest::Test
     @solver.pop
   end
 
+  def test_constrain_int_with_oneof
+    schema = {
+      "oneOf" => [
+        { "const" => 1 },
+        { "const" => 2 }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("oneof_int", @solver, schema)
+
+    [1, 2].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 3)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_int_with_noneof
+    schema = {
+      "type" => "integer",
+      "noneOf" => [{ "const" => 0 }, { "const" => 1 }]
+    }
+    param = Udb::Z3ParameterTerm.new("noneof_int", @solver, schema)
+
+    @solver.push
+    @solver.assert(param == 0)
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == 2)
+    assert @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_int_with_if_then_else
+    schema = {
+      "type" => "integer",
+      "if" => { "minimum" => 10 },
+      "then" => { "maximum" => 20 },
+      "else" => { "minimum" => 0, "maximum" => 5 }
+    }
+    param = Udb::Z3ParameterTerm.new("conditional_int", @solver, schema)
+
+    [15, 3].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == 25)
+    refute @solver.satisfiable?
+    @solver.pop
+
+    @solver.push
+    @solver.assert(param == 7)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_bool_with_oneof_and_noneof
+    oneof = { "oneOf" => [{ "const" => true }, { "const" => false }] }
+    param = Udb::Z3ParameterTerm.new("oneof_bool", @solver, oneof)
+    assert @solver.satisfiable?
+
+    noneof = { "type" => "boolean", "noneOf" => [{ "const" => true }] }
+    param = Udb::Z3ParameterTerm.new("noneof_bool", @solver, noneof)
+    @solver.push
+    @solver.assert(param == true)
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
+  def test_constrain_string_with_oneof_and_noneof
+    schema = {
+      "oneOf" => [
+        { "const" => "alpha" },
+        { "const" => "beta" }
+      ]
+    }
+    param = Udb::Z3ParameterTerm.new("oneof_string", @solver, schema)
+
+    ["alpha", "beta"].each do |value|
+      @solver.push
+      @solver.assert(param == value)
+      assert @solver.satisfiable?
+      @solver.pop
+    end
+
+    @solver.push
+    @solver.assert(param == "gamma")
+    refute @solver.satisfiable?
+    @solver.pop
+  end
+
   # Type detection tests
   def test_detect_type_from_allof_integer
     schema = {


### PR DESCRIPTION
**Summary**

- Adds support for scalar JSON Schema combinators in the UDB Z3 parameter constraint system.
- Implements `oneOf`, `noneOf`, and conditional `if`/`then`/`else` constraints for integer, boolean, and string parameters.
- Keeps branch constraints local so constraints from individual branches are not asserted unconditionally.
- Extends parameter type detection for schemas whose type is inferred from `oneOf`, `noneOf`, or conditional branches.
- Adds unit test coverage for valid and invalid values, including satisfiable and unsatisfiable solver states.
- Leaves array combinator support for a follow-up change because `Z3FiniteArray` requires separate branch-local constraint handling.

Refs [#2402](https://github.com/riscv/riscv-unified-db/issues/2402) and [#1890](https://github.com/riscv/riscv-unified-db/issues/1890)