### PR TITLE
fix(generators): support nested UDB definedBy format in parse_extension_requirements (#2344)

### DIFF
--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -17,9 +17,36 @@ LOGGER = logging.getLogger(__name__)
 def check_requirement(req, exts):
     if isinstance(req, str):
         return req in exts
-    elif isinstance(req, dict) and "name" in req:
-        # If it has a name field, just match the extension name and ignore version
-        return req["name"] in exts
+    elif isinstance(req, dict):
+        if "extension" in req:
+            return check_requirement(req["extension"], exts)
+        elif "xlen" in req:
+            # XLEN filtering is handled separately by target_arch / --arch
+            return True
+        elif "allOf" in req:
+            reqs = req["allOf"]
+            if isinstance(reqs, str):
+                reqs = [reqs]
+            return all(check_requirement(r, exts) for r in reqs)
+        elif "anyOf" in req:
+            reqs = req["anyOf"]
+            if isinstance(reqs, str):
+                reqs = [reqs]
+            return any(check_requirement(r, exts) for r in reqs)
+        elif "oneOf" in req:
+            reqs = req["oneOf"]
+            if isinstance(reqs, str):
+                reqs = [reqs]
+            return any(check_requirement(r, exts) for r in reqs)
+        elif "name" in req:
+            ext_name = req["name"]
+            if isinstance(ext_name, str) and ext_name.startswith("RV"):
+                if ext_name.startswith(("RV32", "RV64")):
+                    ext_parts = ext_name[4:]
+                else:
+                    ext_parts = ext_name[2:]
+                return any(ext_part in exts for ext_part in ext_parts)
+            return ext_name in exts
     return False
 
 
@@ -567,5 +594,21 @@ def signed(value: int, width: int) -> int:
 
 
 if __name__ == "__main__":
-    print("This module is not meant to be run directly.")
-    print("Please use go_generator.py instead.")
+    # Run self-tests for parse_extension_requirements
+    req1 = {"extension": {"name": "Zbb"}}
+    f1 = parse_extension_requirements(req1)
+    assert f1(["Zbb", "I"])
+    assert not f1(["I", "M"])
+
+    req2 = {"allOf": [{"xlen": 64}, {"extension": {"name": "Zbb"}}]}
+    f2 = parse_extension_requirements(req2)
+    assert f2(["Zbb"])
+    assert not f2(["I"])
+
+    req3 = {"extension": {"anyOf": [{"name": "Zbb"}, {"name": "Zba"}]}}
+    f3 = parse_extension_requirements(req3)
+    assert f3(["Zba"])
+    assert f3(["Zbb"])
+    assert not f3(["M"])
+
+    print("parse_extension_requirements self-test passed!")

--- a/backends/generators/test_extension_requirements.py
+++ b/backends/generators/test_extension_requirements.py
@@ -1,0 +1,29 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+import unittest
+
+from backends.generators.generator import parse_extension_requirements
+
+
+class TestExtensionRequirements(unittest.TestCase):
+    def test_parse_extension_requirements(self) -> None:
+        req1 = {"extension": {"name": "Zbb"}}
+        f1 = parse_extension_requirements(req1)
+        self.assertTrue(f1(["Zbb", "I"]))
+        self.assertFalse(f1(["I", "M"]))
+
+        req2 = {"allOf": [{"xlen": 64}, {"extension": {"name": "Zbb"}}]}
+        f2 = parse_extension_requirements(req2)
+        self.assertTrue(f2(["Zbb"]))
+        self.assertFalse(f2(["I"]))
+
+        req3 = {"extension": {"anyOf": [{"name": "Zbb"}, {"name": "Zba"}]}}
+        f3 = parse_extension_requirements(req3)
+        self.assertTrue(f3(["Zba"]))
+        self.assertTrue(f3(["Zbb"]))
+        self.assertFalse(f3(["M"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2344
Refs #2344

### Summary
- Replaces the flat extension matching in `backends/generators/generator.py` (`check_requirement`) with a recursive evaluator that understands UDB's nested `definedBy` structures (`{extension: {name: ...}}`, `{allOf: [{xlen: N}, {extension: ...}]}`, `anyOf`, `oneOf`).
- Fixes `--extensions` filtering in Go, C-header, and SystemVerilog generators so instructions are accurately included or excluded.
- Adds self-test assertions for `parse_extension_requirements()` under `__main__`.