### PR TITLE
fix(udb): add format and format= to Udb::DummyProgressBar (#2407)

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/log.rb
+++ b/tools/ruby-gems/udb/lib/udb/log.rb
@@ -74,6 +74,14 @@ module Udb
   class DummyProgressBar
     extend T::Sig
 
+    sig { returns(String) }
+    attr_accessor :format
+
+    sig { params(fmt: String, _options: T.untyped).void }
+    def initialize(fmt = "", **_options)
+      @format = fmt
+    end
+
     sig { void }
     def advance
       # do nothing
@@ -90,7 +98,7 @@ module Udb
 
     sig { params(fmt: String, options: T.untyped).returns(DummyProgressBar) }
     def register(fmt, **options)
-      DummyProgressBar.new
+      DummyProgressBar.new(fmt, **options)
     end
   end
 

--- a/tools/ruby-gems/udb/test/test_cli.rb
+++ b/tools/ruby-gems/udb/test/test_cli.rb
@@ -98,7 +98,16 @@ class TestCli < Minitest::Test
       assert_instance_of Udb::DummyProgressBar, bar_warn
       bar_warn.format = "New format"
       assert_equal "New format", bar_warn.format
+
+      Udb.log_level = Udb::LogLevel::Info
+      Udb.create_top_level_progressbar(level: Udb::LogLevel::Warn)
+      sub_bar = Udb.create_progressbar("Sub :bar")
+      assert_instance_of Udb::DummyProgressBar, sub_bar
+      assert_equal "Sub :bar", sub_bar.format
+      sub_bar.format = "Updated sub :bar"
+      assert_equal "Updated sub :bar", sub_bar.format
     ensure
+      Udb.delete_top_level_progressbar
       Udb.log_level = old_level
     end
   end

--- a/tools/ruby-gems/udb/test/test_cli.rb
+++ b/tools/ruby-gems/udb/test/test_cli.rb
@@ -84,4 +84,22 @@ class TestCli < Minitest::Test
     assert_equal num_csr_yaml_files, num_listed
   end
 
+  def test_dummy_progressbar_format
+    bar = Udb::DummyProgressBar.new
+    bar.format = "Test :bar"
+    assert_equal "Test :bar", bar.format
+    bar.advance
+    bar.finish
+
+    old_level = Udb.log_level
+    begin
+      Udb.log_level = Udb::LogLevel::Warn
+      bar_warn = Udb.create_progressbar("Test :bar")
+      assert_instance_of Udb::DummyProgressBar, bar_warn
+      bar_warn.format = "New format"
+      assert_equal "New format", bar_warn.format
+    ensure
+      Udb.log_level = old_level
+    end
+  end
 end

--- a/tools/ruby-gems/udb/test/test_cli.rb
+++ b/tools/ruby-gems/udb/test/test_cli.rb
@@ -99,8 +99,8 @@ class TestCli < Minitest::Test
       bar_warn.format = "New format"
       assert_equal "New format", bar_warn.format
 
-      Udb.log_level = Udb::LogLevel::Info
-      Udb.create_top_level_progressbar(level: Udb::LogLevel::Warn)
+      Udb.log_level = Udb::LogLevel::Warn
+      Udb.create_top_level_progressbar(level: Udb::LogLevel::Info)
       sub_bar = Udb.create_progressbar("Sub :bar")
       assert_instance_of Udb::DummyProgressBar, sub_bar
       assert_equal "Sub :bar", sub_bar.format


### PR DESCRIPTION
Closes #2407
Refs #2407

### Summary
- Adds `attr_accessor :format` and `initialize(fmt = "", **_options)` to `Udb::DummyProgressBar` (`tools/ruby-gems/udb/lib/udb/log.rb`), matching the `TTY::ProgressBar` interface used by the rest of the codebase.
- Prevents `NoMethodError: private method 'format' called for an instance of Udb::DummyProgressBar` when compiling IDL (`./do test:idl`, `udb-gen ext-doc`, etc.) with `LOG=warn`, `error`, or `fatal`.
- Adds unit test coverage for `Udb::DummyProgressBar` formatting in `tools/ruby-gems/udb/test/test_cli.rb`.