### PR TITLE
feat(param): add RNMI trap handler address parameters for Smrnmi (#2301)

### DIFF
--- a/spec/std/isa/param/RNMI_EXCEPTION_HANDLER_ADDRESS.yaml
+++ b/spec/std/isa/param/RNMI_EXCEPTION_HANDLER_ADDRESS.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/param_schema.json
+
+$schema: param_schema.json#
+kind: parameter
+name: RNMI_EXCEPTION_HANDLER_ADDRESS
+long_name: |
+  RNMI exception trap handler address
+definedBy:
+  extension:
+    name: Smrnmi
+description: |
+  The implementation-defined physical address of the Resumable Non-Maskable
+  Interrupt (RNMI) exception trap handler.
+schema:
+  $ref: schema_defs.json#/$defs/uint64

--- a/spec/std/isa/param/RNMI_INTERRUPT_HANDLER_ADDRESS.yaml
+++ b/spec/std/isa/param/RNMI_INTERRUPT_HANDLER_ADDRESS.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/param_schema.json
+
+$schema: param_schema.json#
+kind: parameter
+name: RNMI_INTERRUPT_HANDLER_ADDRESS
+long_name: |
+  RNMI interrupt trap handler address
+definedBy:
+  extension:
+    name: Smrnmi
+description: |
+  The implementation-defined physical address of the Resumable Non-Maskable
+  Interrupt (RNMI) trap handler.
+schema:
+  $ref: schema_defs.json#/$defs/uint64


### PR DESCRIPTION
- Add RNMI_INTERRUPT_HANDLER_ADDRESS (uint64) defined by Smrnmi to model implementation-defined RNMI interrupt trap handler addresses.
- Add RNMI_EXCEPTION_HANDLER_ADDRESS (uint64) defined by Smrnmi to model implementation-defined RNMI exception trap handler addresses.

refs: #2301 