### PR TITLE
fix(csr): hstateen0h-3h must read through their parent's sw_read

### DIFF
--- a/spec/std/isa/csr/hstateen0h.yaml
+++ b/spec/std/isa/csr/hstateen0h.yaml
@@ -156,4 +156,4 @@ fields:
       `mstateen0.CTR=0`.
     type: RW
     reset_value: 0
-sw_read(): return $bits(CSR[hstateen0])[63:32];
+sw_read(): return CSR[hstateen0].sw_read()[63:32];

--- a/spec/std/isa/csr/hstateen1h.yaml
+++ b/spec/std/isa/csr/hstateen1h.yaml
@@ -44,4 +44,4 @@ fields:
       The SE0 bit in `hstateen1h` controls access to the `sstateen1` CSR.
     type: RW
     reset_value: UNDEFINED_LEGAL
-sw_read(): return $bits(CSR[hstateen1])[63:32];
+sw_read(): return CSR[hstateen1].sw_read()[63:32];

--- a/spec/std/isa/csr/hstateen2h.yaml
+++ b/spec/std/isa/csr/hstateen2h.yaml
@@ -44,4 +44,4 @@ fields:
       The SE0 bit in `hstateen2h` controls access to the `sstateen2` CSR.
     type: RW
     reset_value: UNDEFINED_LEGAL
-sw_read(): return $bits(CSR[hstateen2])[63:32];
+sw_read(): return CSR[hstateen2].sw_read()[63:32];

--- a/spec/std/isa/csr/hstateen3h.yaml
+++ b/spec/std/isa/csr/hstateen3h.yaml
@@ -44,4 +44,4 @@ fields:
       The SE0 bit in `hstateen3h` controls access to the `sstateen3` CSR.
     type: RW
     reset_value: UNDEFINED_LEGAL
-sw_read(): return $bits(CSR[hstateen3])[63:32];
+sw_read(): return CSR[hstateen3].sw_read()[63:32];


### PR DESCRIPTION
`hstateen0h` through `hstateen3h` read their parent with `$bits(CSR[hstateenN])[63:32]`, which returns raw field storage and never runs the parent's `sw_read()`. That body is where the `mstateen` read-only-zero rule is implemented, so on RV32 the rule is not applied to any bit only the high half can reach.

Switch the four to `CSR[hstateenN].sw_read()[63:32]`, the form `henvcfgh` already uses.

Closes #2413