### PR TITLE
fix(csr): forward ADUE writes through henvcfg

### DIFF
--- a/spec/std/isa/csr/H/henvcfgh.yaml
+++ b/spec/std/isa/csr/H/henvcfgh.yaml
@@ -94,6 +94,9 @@ fields:
   ADUE:
     location: 29
     alias: henvcfg.ADUE
+    sw_write(csr_value): |
+      CSR[henvcfg].ADUE = csr_value.ADUE;
+      return csr_value.ADUE;
     description: |
       If the `Svadu` extension is implemented, the ADUE bit controls whether hardware updating of
       PTE A/D bits is enabled for VS-stage address translation.


### PR DESCRIPTION
## Summary

`henvcfgh` forwards software reads through `CSR[henvcfg].sw_read()[63:32]`, but `ADUE` does not forward software writes to the parent CSR.

## Problem

Writes update only the local `henvcfgh` field storage, while reads return the value from `henvcfg`, creating a read/write asymmetry on RV32 when `Svadu` is implemented.

## Fix

Add a field-level `sw_write()` for `henvcfgh.ADUE` that forwards writes to `CSR[henvcfg].ADUE`.

Closes #2415 