### PR TITLE
fix(isa): c.sdsp must use its full 5-bit register index

### DIFF
--- a/spec/std/isa/inst/C/c.sdsp.yaml
+++ b/spec/std/isa/inst/C/c.sdsp.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: c.sdsp
 long_name: Store doubleword to stack
 description: |
-  Stores a 64-bit value in register rs2 to memory.
+  Stores a 64-bit value in register xs2 to memory.
   It computes an effective address by adding the zero-extended offset, scaled by 8,
   to the stack pointer, x2.
   It expands to `sd` `xs2, offset(x2)`.

--- a/spec/std/isa/inst/C/c.sdsp.yaml
+++ b/spec/std/isa/inst/C/c.sdsp.yaml
@@ -53,11 +53,11 @@ operation(): |
 
   if (xlen() == 32) {
     if (implemented?(ExtensionName::Zclsd)) {
-      Bits<64> data = {X[creg2reg(xs2) + 1], X[creg2reg(xs2)]};
+      Bits<64> data = {X[xs2 + 1], X[xs2]};
       write_memory(64, virtual_address, data, $encoding);
     } else {
       raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
     }
   } else {
-    write_memory(64, virtual_address, X[creg2reg(xs2)], $encoding);
+    write_memory(64, virtual_address, X[xs2], $encoding);
   }

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -14358,7 +14358,7 @@ RV64::
 ....
 
 Description::
-Stores a 64-bit value in register rs2 to memory.
+Stores a 64-bit value in register xs2 to memory.
 It computes an effective address by adding the zero-extended offset, scaled by 8,
 to the stack pointer, x2.
 It expands to xref:insts:sd.adoc#udb:doc:inst:sd[sd] `xs2, offset(x2)`.


### PR DESCRIPTION
`c.sdsp` is a CSS-format instruction, so its `rs2` is a full 5-bit register specifier, and `c.sdsp.yaml` declares it that way (`location: 6-2`). Both branches then pass that field to `creg2reg`, which takes a 3-bit compressed index and returns `{2'b01, creg_idx}`. Its range is `x8`-`x15`, so on RV64 `c.sdsp x20, 0(sp)` stores from `x12`.

Drop `creg2reg` from both branches.

Closes #2418