### PR TITLE
fix(data): populate long_name for 17 parameters (MUTABLE_MISA, TRAP_ON, LRSC) (#2241)

### DIFF
--- a/spec/std/isa/param/LRSC_FAIL_ON_NON_EXACT_LRSC.yaml
+++ b/spec/std/isa/param/LRSC_FAIL_ON_NON_EXACT_LRSC.yaml
@@ -10,7 +10,7 @@ description: |
   Whether or not a Store Conditional fails if its physical address and size do not
   exactly match the physical address and size of the last Load Reserved in program order
   (independent of whether or not the SC is in the current reservation set)
-long_name: TODO
+long_name: "LR/SC failure on non-exact address match"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/LRSC_FAIL_ON_VA_SYNONYM.yaml
+++ b/spec/std/isa/param/LRSC_FAIL_ON_VA_SYNONYM.yaml
@@ -9,7 +9,7 @@ name: LRSC_FAIL_ON_VA_SYNONYM
 description: |
   Whether or not an `sc.l`/`sc.d` will fail if its VA does not match the VA of the prior
   `lr.l`/`lr.d`, even if the physical address of the SC and LR are the same
-long_name: TODO
+long_name: "LR/SC failure on VA synonym mismatch"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/LRSC_MISALIGNED_BEHAVIOR.yaml
+++ b/spec/std/isa/param/LRSC_MISALIGNED_BEHAVIOR.yaml
@@ -12,7 +12,7 @@ description: |
     * 'always raise misaligned exception': self-explainitory
     * 'always raise access fault': self-explainitory
     * 'custom': Custom behavior; misaligned LR/SC may sometimes raise a misaligned exception and sometimes raise a access fault. Will lead to an 'unpredictable' call on any misaligned LR/SC access
-long_name: TODO
+long_name: "Misaligned LR/SC behavior"
 schema:
   type: string
   enum:

--- a/spec/std/isa/param/LRSC_RESERVATION_STRATEGY.yaml
+++ b/spec/std/isa/param/LRSC_RESERVATION_STRATEGY.yaml
@@ -13,7 +13,7 @@ description: |
     * "reserve naturally-aligned 128-byte region": Always reserve the 128-byte block containing the LR/SC address
     * "reserve exactly enough to cover the access": Always reserve exactly the LR/SC access, and no more
     * "custom": Custom behavior, leading to an 'unpredictable' call on any LR/SC
-long_name: TODO
+long_name: "LR/SC reservation set strategy"
 schema:
   type: string
   enum:

--- a/spec/std/isa/param/MUTABLE_MISA_A.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_A.yaml
@@ -9,7 +9,7 @@ name: MUTABLE_MISA_A
 description: |
   When the `A` extensions is supported, indicates whether or not
   the extension can be disabled in the `misa.A` bit.
-long_name: TODO
+long_name: "`misa.A` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_B.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_B.yaml
@@ -8,7 +8,7 @@ kind: parameter
 name: MUTABLE_MISA_B
 description: Indicates whether or not the `B` extension can be disabled with the
   `misa.B` bit.
-long_name: TODO
+long_name: "`misa.B` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_C.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_C.yaml
@@ -11,7 +11,7 @@ description:
   `misa.C` bit.
 
   "
-long_name: TODO
+long_name: "`misa.C` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_D.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_D.yaml
@@ -11,7 +11,7 @@ description:
   `misa.D` bit.
 
   "
-long_name: TODO
+long_name: "`misa.D` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_F.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_F.yaml
@@ -11,7 +11,7 @@ description:
   `misa.F` bit.
 
   "
-long_name: TODO
+long_name: "`misa.F` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_M.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_M.yaml
@@ -11,7 +11,7 @@ description:
   `misa.M` bit.
 
   "
-long_name: TODO
+long_name: "`misa.M` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_Q.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_Q.yaml
@@ -11,7 +11,7 @@ description:
   `misa.Q` bit.
 
   "
-long_name: TODO
+long_name: "`misa.Q` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_U.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_U.yaml
@@ -11,7 +11,7 @@ description:
   `misa.U` bit.
 
   "
-long_name: TODO
+long_name: "`misa.U` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_V.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_V.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: MUTABLE_MISA_V
 description: Indicates whether or not the `V` extension can be disabled with the `misa.V` bit.
-long_name: TODO
+long_name: "`misa.V` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/TRAP_ON_ECALL_FROM_S.yaml
+++ b/spec/std/isa/param/TRAP_ON_ECALL_FROM_S.yaml
@@ -11,7 +11,7 @@ description: |
 
   The spec states that implementations may handle ECALLs transparently
   without raising a trap, in which case the EEI must provide a builtin.
-long_name: TODO
+long_name: "Trap on ECALL from S-mode"
 schema:
   type: boolean
   default: true

--- a/spec/std/isa/param/TRAP_ON_ECALL_FROM_U.yaml
+++ b/spec/std/isa/param/TRAP_ON_ECALL_FROM_U.yaml
@@ -11,7 +11,7 @@ description: |
 
   The spec states that implementations may handle ECALLs transparently
   without raising a trap, in which case the EEI must provide a builtin.
-long_name: TODO
+long_name: "Trap on ECALL from U-mode"
 schema:
   type: boolean
   default: true

--- a/spec/std/isa/param/TRAP_ON_ECALL_FROM_VS.yaml
+++ b/spec/std/isa/param/TRAP_ON_ECALL_FROM_VS.yaml
@@ -11,7 +11,7 @@ description: |
 
   The spec states that implementations may handle ECALLs transparently
   without raising a trap, in which case the EEI must provide a builtin.
-long_name: TODO
+long_name: "Trap on ECALL from VS-mode"
 schema:
   type: boolean
   default: true

--- a/spec/std/isa/param/TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY.yaml
+++ b/spec/std/isa/param/TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY.yaml
@@ -17,7 +17,7 @@ description: |
 
   TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY has no effect when
   some virtual translation mode is supported.
-long_name: TODO
+long_name: "Trap on SFENCE.VMA when satp.MODE is read-only"
 schema:
   type: boolean
   default: false


### PR DESCRIPTION
Refs #2241

Replace placeholder `long_name: TODO` with descriptive names for 17 parameter files across three groups:

**MUTABLE_MISA (9 files)** — following the existing pattern from `MUTABLE_MISA_H` and `MUTABLE_MISA_S`:

| File | New `long_name` |
|------|-----------------|
| `MUTABLE_MISA_A.yaml` | `` `misa.A` mutability `` |
| `MUTABLE_MISA_B.yaml` | `` `misa.B` mutability `` |
| `MUTABLE_MISA_C.yaml` | `` `misa.C` mutability `` |
| `MUTABLE_MISA_D.yaml` | `` `misa.D` mutability `` |
| `MUTABLE_MISA_F.yaml` | `` `misa.F` mutability `` |
| `MUTABLE_MISA_M.yaml` | `` `misa.M` mutability `` |
| `MUTABLE_MISA_Q.yaml` | `` `misa.Q` mutability `` |
| `MUTABLE_MISA_U.yaml` | `` `misa.U` mutability `` |
| `MUTABLE_MISA_V.yaml` | `` `misa.V` mutability `` |

**TRAP_ON (4 files)**:

| File | New `long_name` |
|------|-----------------|
| `TRAP_ON_ECALL_FROM_S.yaml` | `Trap on ECALL from S-mode` |
| `TRAP_ON_ECALL_FROM_U.yaml` | `Trap on ECALL from U-mode` |
| `TRAP_ON_ECALL_FROM_VS.yaml` | `Trap on ECALL from VS-mode` |
| `TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY.yaml` | `Trap on SFENCE.VMA when satp.MODE is read-only` |

**LRSC (4 files)**:

| File | New `long_name` |
|------|-----------------|
| `LRSC_FAIL_ON_NON_EXACT_LRSC.yaml` | `LR/SC failure on non-exact address match` |
| `LRSC_FAIL_ON_VA_SYNONYM.yaml` | `LR/SC failure on VA synonym mismatch` |
| `LRSC_MISALIGNED_BEHAVIOR.yaml` | `Misaligned LR/SC behavior` |
| `LRSC_RESERVATION_STRATEGY.yaml` | `LR/SC reservation set strategy` |

None of these 17 parameters are covered by existing PRs (#2288, #2296, #2309).