### PR TITLE
fix(inst): add legacy FMV.S.X and FMV.X.S pseudoinstruction aliases

### DIFF
--- a/spec/std/isa/inst/F/fmv.w.x.yaml
+++ b/spec/std/isa/inst/F/fmv.w.x.yaml
@@ -28,6 +28,9 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
+pseudoinstructions:
+  - when: "true"
+    to: fmv.s.x fd, xs1
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/F/fmv.x.w.yaml
+++ b/spec/std/isa/inst/F/fmv.x.w.yaml
@@ -29,6 +29,9 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
+pseudoinstructions:
+  - when: "true"
+    to: fmv.x.s xd, fs1
 operation(): |
   check_f_ok($encoding);
 


### PR DESCRIPTION
Model the deprecated `fmv.s.x` and `fmv.x.s` mnemonics as pseudoinstruction aliases of the canonical `fmv.w.x` and `fmv.x.w` instructions.

Fixes #2417