### PR TITLE
fix(csr): correct MDT reset values

### DIFF
--- a/spec/std/isa/csr/mstatus.yaml
+++ b/spec/std/isa/csr/mstatus.yaml
@@ -71,7 +71,7 @@ fields:
         - extension:
             name: Smdbltrp
     type: RW-H
-    reset_value: UNDEFINED_LEGAL
+    reset_value: 1
   MPELP:
     location: 41
     long_name: M-mode Previous Expected Landing Pad state

--- a/spec/std/isa/csr/mstatush.yaml
+++ b/spec/std/isa/csr/mstatush.yaml
@@ -26,7 +26,7 @@ fields:
     description: |
       see `mstatus.MDT`
     type: RW-H
-    reset_value: UNDEFINED_LEGAL
+    reset_value: 1
     alias: mstatus.MDT
     definedBy:
       extension:


### PR DESCRIPTION
Correct the reset value of the `MDT` field in `mstatus` and `mstatush` to match the privileged specification.

Part of #2421.