### PR TITLE
fix(csr): enforce RV64 MDT/MIE write semantics

### DIFF
--- a/spec/std/isa/csr/mstatus.yaml
+++ b/spec/std/isa/csr/mstatus.yaml
@@ -623,6 +623,16 @@ fields:
       * When 1, interrupts that are not otherwise disabled with a field in `mie` are enabled.
 
     type: RW-H
+    sw_write(csr_value): |
+      if ((MXLEN == 64) && implemented?(ExtensionName::Smdbltrp)) {
+        if (csr_value.MDT == 1'b1) {
+          return 0;
+        } else {
+          return csr_value.MIE;
+        }
+      } else {
+        return csr_value.MIE;
+      }
     reset_value: 0
   SIE:
     location: 1


### PR DESCRIPTION
## Summary

This PR implements the RV64 explicit CSR write behavior described for `mstatus.MDT` and `mstatus.MIE`.

Spec reference:

> When the MDT bit is set to 1 by an explicit CSR write, the MIE bit is cleared to 0. For RV64, this clearing occurs regardless of the value written, if any, to the MIE bit by the same write. The MIE bit can only be set to 1 by an explicit CSR write if the MDT bit is already 0 or is being set to 0 by the same write.

## Implementation

- Adds a `sw_write(csr_value)` handler to `mstatus.MIE`.
- On RV64 with `Smdbltrp` implemented:
  - if the incoming write has `MDT = 1`, `MIE` is forced to `0`;
  - otherwise the incoming `MIE` value is preserved.
- The implementation uses the incoming `csr_value`, so it does not depend on field write ordering and naturally handles the "same write" case.

## Scope

This PR intentionally targets the RV64 explicit CSR write behavior only.

It does **not** address:
- MDT reset values (handled separately),
- the RV32 `mstatush.MDT` ↔ `mstatus.MIE` interaction.

## Notes

I could not find an existing repository precedent using an XLEN-guarded `csr_value.<xlen-specific-field>` access inside `sw_write`, although the IDL type-checking logic appears to skip unreachable branches when `MXLEN` is compile-time known. If there is a preferred implementation pattern for this RV32/RV64 split, I'm happy to adjust the implementation accordingly.

Fixes part 2 of #2421