### PR TITLE
fix(csr): model misa F/D dependency on writes

### DIFF
--- a/spec/std/isa/csr/misa.yaml
+++ b/spec/std/isa/csr/misa.yaml
@@ -84,6 +84,13 @@ fields:
     definedBy:
       extension:
         name: D
+    sw_write(csr_value): |
+      if (csr_value.F == 0 && csr_value.D == 1) {
+        return 0;
+      }
+
+      # fall-through; write the intended value
+      return csr_value.D;
   F:
     location: 5
     description: |
@@ -93,7 +100,7 @@ fields:
       --
       Writing 0 to this field will cause all floating point (single and double precision) instructions to raise an `IllegalInstruction` exception.
 
-      Writing 0 to this field with `misa.D` set will result in UNDEFINED behavior.
+      Writing 0 to this field while writing 1 to `misa.D` results in both `misa.F` and `misa.D` being cleared.
       --
     type(): |
       return (implemented?(ExtensionName::F) && MUTABLE_MISA_F) ? CsrFieldType::RW : CsrFieldType::RO;
@@ -104,7 +111,7 @@ fields:
         name: F
     sw_write(csr_value): |
       if (csr_value.F == 0 && csr_value.D == 1) {
-        return UNDEFINED_LEGAL_DETERMINISTIC;
+        return 0;
       }
 
       # fall-through; write the intended value


### PR DESCRIPTION
## Summary

Implement the `misa` F/D dependency behavior described by the privileged ISA for software writes.

This PR updates the existing `misa.F` write handling so that writing `F=0` while `D=1` clears `F` instead of returning `UNDEFINED_LEGAL_DETERMINISTIC`, and adds a corresponding `misa.D` `sw_write` so that the same write also clears `D`. The `misa.F` description is also updated to match the current specification.

## Changes

- Update `misa.F.sw_write` to return `0` instead of `UNDEFINED_LEGAL_DETERMINISTIC` when `F=0` and `D=1` are written together.
- Add `misa.D.sw_write` to clear `D` under the same condition.
- Update the `misa.F` description to reflect the current privileged ISA behavior.

## Scope

This PR intentionally implements only the `F`/`D` case from fixes #2429 as a small, reviewable change. It does not attempt to address the other extension dependency relationships discussed in the issue.