### PR TITLE
fix(isa): remove misa guards that gate nothing, correct the rest

### DIFF
--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mva01s.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mva01s.yaml
@@ -28,7 +28,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};
   XReg xreg2 = (r2s[2:1]>0) ? {1,0,r2s[2:0]} : {0,1,r2s[2:0]};

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mva01s.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mva01s.yaml
@@ -27,7 +27,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mvsa01.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mvsa01.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};
   XReg xreg2 = (r2s[2:1]>0) ? {1,0,r2s[2:0]} : {0,1,r2s[2:0]};

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mvsa01.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.mvsa01.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.push.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.push.yaml
@@ -37,7 +37,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.push.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.push.yaml
@@ -38,7 +38,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -38,7 +38,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -39,7 +39,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Xqccmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);

--- a/spec/std/isa/csr/misa.yaml
+++ b/spec/std/isa/csr/misa.yaml
@@ -27,9 +27,6 @@ fields:
     location: 0
     description: |
       Indicates support for the `A` (atomic) extension.
-
-      [when,"MUTABLE_MISA_A == true"]
-      Writing 0 to this field will cause all atomic instructions to raise an `IllegalInstruction` exception.
     type(): |
       return (implemented?(ExtensionName::A) && MUTABLE_MISA_A) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
@@ -41,9 +38,6 @@ fields:
     location: 1
     description: |
       Indicates support for the `B` (bitmanip) extension.
-
-      [when,"MUTABLE_MISA_B == true"]
-      Writing 0 to this field will cause all bitmanip instructions to raise an `IllegalInstruction` exception.
     type(): |
       return (implemented?(ExtensionName::B) && MUTABLE_MISA_B) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
@@ -157,7 +151,9 @@ fields:
       Indicates support for the `M` (integer multiply/divide) extension.
 
       [when,"MUTABLE_MISA_M == true"]
-      Writing 0 to this field will cause all attempts to execute an integer multiply or divide instruction to raise an `IllegalInstruction` exception.
+      Writing 0 to this field will cause all attempts to execute an integer divide or
+      remainder instruction to raise an `IllegalInstruction` exception. The multiply
+      instructions are provided by `Zmmul` and are unaffected.
     type(): |
       return (implemented?(ExtensionName::M) && MUTABLE_MISA_M) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |

--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -32,8 +32,4 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs1] & ~X[xs2];

--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -32,7 +32,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -33,7 +33,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs1] & ~X[xs2];

--- a/spec/std/isa/inst/B/clmul.yaml
+++ b/spec/std/isa/inst/B/clmul.yaml
@@ -32,7 +32,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg xs1_val = X[xs1];

--- a/spec/std/isa/inst/B/clmul.yaml
+++ b/spec/std/isa/inst/B/clmul.yaml
@@ -31,10 +31,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg xs1_val = X[xs1];
   XReg xs2_val = X[xs2];
   XReg output = 0;

--- a/spec/std/isa/inst/B/clmul.yaml
+++ b/spec/std/isa/inst/B/clmul.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -32,7 +32,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg xs1_val = X[xs1];

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -31,10 +31,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg xs1_val = X[xs1];
   XReg xs2_val = X[xs2];
   XReg output = 0;

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/orn.yaml
+++ b/spec/std/isa/inst/B/orn.yaml
@@ -32,7 +32,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs1] | ~X[xs2];

--- a/spec/std/isa/inst/B/orn.yaml
+++ b/spec/std/isa/inst/B/orn.yaml
@@ -31,8 +31,4 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs1] | ~X[xs2];

--- a/spec/std/isa/inst/B/orn.yaml
+++ b/spec/std/isa/inst/B/orn.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/rev8.yaml
+++ b/spec/std/isa/inst/B/rev8.yaml
@@ -46,7 +46,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg input = X[xs1];

--- a/spec/std/isa/inst/B/rev8.yaml
+++ b/spec/std/isa/inst/B/rev8.yaml
@@ -45,7 +45,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/rev8.yaml
+++ b/spec/std/isa/inst/B/rev8.yaml
@@ -45,10 +45,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg input = X[xs1];
   XReg output = 0;
 

--- a/spec/std/isa/inst/B/rol.yaml
+++ b/spec/std/isa/inst/B/rol.yaml
@@ -31,10 +31,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg shamt = (xlen() == 32) ? X[xs2][4:0] : X[xs2][5:0];
 
   X[xd] = (X[xs1] << shamt) | (X[xs1] >> (xlen() - shamt));

--- a/spec/std/isa/inst/B/rol.yaml
+++ b/spec/std/isa/inst/B/rol.yaml
@@ -32,7 +32,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg shamt = (xlen() == 32) ? X[xs2][4:0] : X[xs2][5:0];

--- a/spec/std/isa/inst/B/rol.yaml
+++ b/spec/std/isa/inst/B/rol.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/rolw.yaml
+++ b/spec/std/isa/inst/B/rolw.yaml
@@ -34,10 +34,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg xs1_word = X[xs1][31:0];
   XReg shamt = X[xs2][4:0];
 

--- a/spec/std/isa/inst/B/rolw.yaml
+++ b/spec/std/isa/inst/B/rolw.yaml
@@ -35,7 +35,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg xs1_word = X[xs1][31:0];

--- a/spec/std/isa/inst/B/rolw.yaml
+++ b/spec/std/isa/inst/B/rolw.yaml
@@ -34,7 +34,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/ror.yaml
+++ b/spec/std/isa/inst/B/ror.yaml
@@ -31,10 +31,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg shamt = (xlen() == 32) ? X[xs2][4:0] : X[xs2][5:0];
 
   X[xd] = (X[xs1] >> shamt) | (X[xs1] << (xlen() - shamt));

--- a/spec/std/isa/inst/B/ror.yaml
+++ b/spec/std/isa/inst/B/ror.yaml
@@ -32,7 +32,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg shamt = (xlen() == 32) ? X[xs2][4:0] : X[xs2][5:0];

--- a/spec/std/isa/inst/B/ror.yaml
+++ b/spec/std/isa/inst/B/ror.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/rori.yaml
+++ b/spec/std/isa/inst/B/rori.yaml
@@ -42,7 +42,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/rori.yaml
+++ b/spec/std/isa/inst/B/rori.yaml
@@ -43,7 +43,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg shamt = (xlen() == 32) ? shamt[4:0] : shamt[5:0];

--- a/spec/std/isa/inst/B/rori.yaml
+++ b/spec/std/isa/inst/B/rori.yaml
@@ -42,10 +42,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg shamt = (xlen() == 32) ? shamt[4:0] : shamt[5:0];
 
   X[xd] = (X[xs1] >> shamt) | (X[xs1] << (xlen() - shamt));

--- a/spec/std/isa/inst/B/roriw.yaml
+++ b/spec/std/isa/inst/B/roriw.yaml
@@ -36,7 +36,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg xs1_word = X[xs1][31:0];

--- a/spec/std/isa/inst/B/roriw.yaml
+++ b/spec/std/isa/inst/B/roriw.yaml
@@ -35,10 +35,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg xs1_word = X[xs1][31:0];
 
   XReg unextended_result = (xs1_word >> shamt) | (xs1_word << (32 - shamt));

--- a/spec/std/isa/inst/B/roriw.yaml
+++ b/spec/std/isa/inst/B/roriw.yaml
@@ -35,7 +35,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -36,7 +36,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg xs1_word = X[xs1][31:0];

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -35,10 +35,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg xs1_word = X[xs1][31:0];
   XReg shamt = X[xs2][4:0];
 

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -35,7 +35,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/B/xnor.yaml
+++ b/spec/std/isa/inst/B/xnor.yaml
@@ -31,8 +31,4 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = ~(X[xs1] ^ X[xs2]);

--- a/spec/std/isa/inst/B/xnor.yaml
+++ b/spec/std/isa/inst/B/xnor.yaml
@@ -32,7 +32,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = ~(X[xs1] ^ X[xs2]);

--- a/spec/std/isa/inst/B/xnor.yaml
+++ b/spec/std/isa/inst/B/xnor.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.addi.yaml
+++ b/spec/std/isa/inst/C/c.addi.yaml
@@ -34,7 +34,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xd] + $signed(imm);

--- a/spec/std/isa/inst/C/c.addi.yaml
+++ b/spec/std/isa/inst/C/c.addi.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.addi16sp.yaml
+++ b/spec/std/isa/inst/C/c.addi16sp.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.addi16sp.yaml
+++ b/spec/std/isa/inst/C/c.addi16sp.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[2] = X[2] + $signed(imm);

--- a/spec/std/isa/inst/C/c.addi4spn.yaml
+++ b/spec/std/isa/inst/C/c.addi4spn.yaml
@@ -32,7 +32,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = X[2] + imm;

--- a/spec/std/isa/inst/C/c.addi4spn.yaml
+++ b/spec/std/isa/inst/C/c.addi4spn.yaml
@@ -31,7 +31,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.addiw.yaml
+++ b/spec/std/isa/inst/C/c.addiw.yaml
@@ -35,7 +35,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = sext((X[xd] + sext(imm, 6)), 32);

--- a/spec/std/isa/inst/C/c.addiw.yaml
+++ b/spec/std/isa/inst/C/c.addiw.yaml
@@ -34,7 +34,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.beqz.yaml
+++ b/spec/std/isa/inst/C/c.beqz.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (X[creg2reg(xs1)] == 0) {
     jump($pc + $signed(imm));

--- a/spec/std/isa/inst/C/c.beqz.yaml
+++ b/spec/std/isa/inst/C/c.beqz.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   if (X[creg2reg(xs1)] == 0) {

--- a/spec/std/isa/inst/C/c.bnez.yaml
+++ b/spec/std/isa/inst/C/c.bnez.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   if (X[creg2reg(xs1)] != 0) {

--- a/spec/std/isa/inst/C/c.bnez.yaml
+++ b/spec/std/isa/inst/C/c.bnez.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (X[creg2reg(xs1)] != 0) {
     jump($pc + $signed(imm));

--- a/spec/std/isa/inst/C/c.ebreak.yaml
+++ b/spec/std/isa/inst/C/c.ebreak.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   if (TRAP_ON_EBREAK) {

--- a/spec/std/isa/inst/C/c.ebreak.yaml
+++ b/spec/std/isa/inst/C/c.ebreak.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (TRAP_ON_EBREAK) {
     raise_precise(ExceptionCode::Breakpoint, mode(), $pc);

--- a/spec/std/isa/inst/C/c.j.yaml
+++ b/spec/std/isa/inst/C/c.j.yaml
@@ -28,7 +28,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   jump($pc + $signed(imm));

--- a/spec/std/isa/inst/C/c.j.yaml
+++ b/spec/std/isa/inst/C/c.j.yaml
@@ -27,7 +27,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.jal.yaml
+++ b/spec/std/isa/inst/C/c.jal.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.jal.yaml
+++ b/spec/std/isa/inst/C/c.jal.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg return_addr = $pc + 2;

--- a/spec/std/isa/inst/C/c.jalr.yaml
+++ b/spec/std/isa/inst/C/c.jalr.yaml
@@ -26,7 +26,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   XReg addr = X[xs1];

--- a/spec/std/isa/inst/C/c.jalr.yaml
+++ b/spec/std/isa/inst/C/c.jalr.yaml
@@ -27,7 +27,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   XReg addr = X[xs1];
   XReg returnaddr;

--- a/spec/std/isa/inst/C/c.jr.yaml
+++ b/spec/std/isa/inst/C/c.jr.yaml
@@ -26,7 +26,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.jr.yaml
+++ b/spec/std/isa/inst/C/c.jr.yaml
@@ -27,7 +27,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   jump(X[xs1]);

--- a/spec/std/isa/inst/C/c.ld.yaml
+++ b/spec/std/isa/inst/C/c.ld.yaml
@@ -50,7 +50,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.ld.yaml
+++ b/spec/std/isa/inst/C/c.ld.yaml
@@ -51,7 +51,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (xlen() == 32) {

--- a/spec/std/isa/inst/C/c.ldsp.yaml
+++ b/spec/std/isa/inst/C/c.ldsp.yaml
@@ -50,7 +50,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/C/c.ldsp.yaml
+++ b/spec/std/isa/inst/C/c.ldsp.yaml
@@ -49,7 +49,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.li.yaml
+++ b/spec/std/isa/inst/C/c.li.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.li.yaml
+++ b/spec/std/isa/inst/C/c.li.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = $signed(imm);

--- a/spec/std/isa/inst/C/c.lui.yaml
+++ b/spec/std/isa/inst/C/c.lui.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.lui.yaml
+++ b/spec/std/isa/inst/C/c.lui.yaml
@@ -34,7 +34,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = $signed(imm);

--- a/spec/std/isa/inst/C/c.lw.yaml
+++ b/spec/std/isa/inst/C/c.lw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/C/c.lw.yaml
+++ b/spec/std/isa/inst/C/c.lw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.lwsp.yaml
+++ b/spec/std/isa/inst/C/c.lwsp.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.lwsp.yaml
+++ b/spec/std/isa/inst/C/c.lwsp.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/C/c.mv.yaml
+++ b/spec/std/isa/inst/C/c.mv.yaml
@@ -31,7 +31,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2];

--- a/spec/std/isa/inst/C/c.mv.yaml
+++ b/spec/std/isa/inst/C/c.mv.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.nop.yaml
+++ b/spec/std/isa/inst/C/c.nop.yaml
@@ -32,6 +32,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }

--- a/spec/std/isa/inst/C/c.nop.yaml
+++ b/spec/std/isa/inst/C/c.nop.yaml
@@ -33,5 +33,5 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/C/c.sd.yaml
+++ b/spec/std/isa/inst/C/c.sd.yaml
@@ -50,7 +50,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/C/c.sd.yaml
+++ b/spec/std/isa/inst/C/c.sd.yaml
@@ -49,7 +49,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.sdsp.yaml
+++ b/spec/std/isa/inst/C/c.sdsp.yaml
@@ -45,7 +45,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.sdsp.yaml
+++ b/spec/std/isa/inst/C/c.sdsp.yaml
@@ -46,7 +46,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/C/c.sw.yaml
+++ b/spec/std/isa/inst/C/c.sw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/C/c.sw.yaml
+++ b/spec/std/isa/inst/C/c.sw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.swsp.yaml
+++ b/spec/std/isa/inst/C/c.swsp.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/C/c.swsp.yaml
+++ b/spec/std/isa/inst/C/c.swsp.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/M/div.yaml
+++ b/spec/std/isa/inst/M/div.yaml
@@ -34,7 +34,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg src1 = X[xs1];

--- a/spec/std/isa/inst/M/div.yaml
+++ b/spec/std/isa/inst/M/div.yaml
@@ -33,10 +33,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/div.yaml
+++ b/spec/std/isa/inst/M/div.yaml
@@ -33,6 +33,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/div.yaml
+++ b/spec/std/isa/inst/M/div.yaml
@@ -33,7 +33,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/divu.yaml
+++ b/spec/std/isa/inst/M/divu.yaml
@@ -32,6 +32,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/divu.yaml
+++ b/spec/std/isa/inst/M/divu.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg src1 = X[xs1];

--- a/spec/std/isa/inst/M/divu.yaml
+++ b/spec/std/isa/inst/M/divu.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/divu.yaml
+++ b/spec/std/isa/inst/M/divu.yaml
@@ -32,10 +32,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/divuw.yaml
+++ b/spec/std/isa/inst/M/divuw.yaml
@@ -34,7 +34,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/divuw.yaml
+++ b/spec/std/isa/inst/M/divuw.yaml
@@ -34,10 +34,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/divuw.yaml
+++ b/spec/std/isa/inst/M/divuw.yaml
@@ -34,6 +34,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/divuw.yaml
+++ b/spec/std/isa/inst/M/divuw.yaml
@@ -35,7 +35,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   Bits<32> src1 = X[xs1][31:0];

--- a/spec/std/isa/inst/M/divw.yaml
+++ b/spec/std/isa/inst/M/divw.yaml
@@ -39,7 +39,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   Bits<32> src1 = X[xs1][31:0];

--- a/spec/std/isa/inst/M/divw.yaml
+++ b/spec/std/isa/inst/M/divw.yaml
@@ -38,10 +38,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/divw.yaml
+++ b/spec/std/isa/inst/M/divw.yaml
@@ -38,6 +38,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/divw.yaml
+++ b/spec/std/isa/inst/M/divw.yaml
@@ -38,7 +38,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/mul.yaml
+++ b/spec/std/isa/inst/M/mul.yaml
@@ -40,7 +40,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/mul.yaml
+++ b/spec/std/isa/inst/M/mul.yaml
@@ -40,6 +40,10 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/mul.yaml
+++ b/spec/std/isa/inst/M/mul.yaml
@@ -41,7 +41,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg src1 = X[xs1];

--- a/spec/std/isa/inst/M/mul.yaml
+++ b/spec/std/isa/inst/M/mul.yaml
@@ -40,10 +40,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/mulh.yaml
+++ b/spec/std/isa/inst/M/mulh.yaml
@@ -39,6 +39,10 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   # enlarge and sign extend the sources
   Bits<1> xs1_sign_bit = X[xs1][xlen()-1];
   Bits<MXLEN `* 2> src1 = {{xlen(){xs1_sign_bit}}, X[xs1]};

--- a/spec/std/isa/inst/M/mulh.yaml
+++ b/spec/std/isa/inst/M/mulh.yaml
@@ -40,7 +40,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   # enlarge and sign extend the sources

--- a/spec/std/isa/inst/M/mulh.yaml
+++ b/spec/std/isa/inst/M/mulh.yaml
@@ -39,7 +39,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/mulh.yaml
+++ b/spec/std/isa/inst/M/mulh.yaml
@@ -39,10 +39,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   # enlarge and sign extend the sources
   Bits<1> xs1_sign_bit = X[xs1][xlen()-1];
   Bits<MXLEN `* 2> src1 = {{xlen(){xs1_sign_bit}}, X[xs1]};

--- a/spec/std/isa/inst/M/mulhsu.yaml
+++ b/spec/std/isa/inst/M/mulhsu.yaml
@@ -39,10 +39,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   # enlarge and extend the sources
   Bits<1> xs1_sign_bit = X[xs1][MXLEN-1];
   Bits<MXLEN*8'd2> src1 = {{MXLEN{xs1_sign_bit}}, X[xs1]};

--- a/spec/std/isa/inst/M/mulhsu.yaml
+++ b/spec/std/isa/inst/M/mulhsu.yaml
@@ -39,6 +39,10 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   # enlarge and extend the sources
   Bits<1> xs1_sign_bit = X[xs1][MXLEN-1];
   Bits<MXLEN*8'd2> src1 = {{MXLEN{xs1_sign_bit}}, X[xs1]};

--- a/spec/std/isa/inst/M/mulhsu.yaml
+++ b/spec/std/isa/inst/M/mulhsu.yaml
@@ -39,7 +39,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/mulhsu.yaml
+++ b/spec/std/isa/inst/M/mulhsu.yaml
@@ -40,7 +40,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   # enlarge and extend the sources

--- a/spec/std/isa/inst/M/mulhu.yaml
+++ b/spec/std/isa/inst/M/mulhu.yaml
@@ -39,6 +39,10 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   # enlarge and zero-extend the sources
   Bits<MXLEN*8'd2> src1 = {{MXLEN{1'b0}}, X[xs1]};
   Bits<MXLEN*8'd2> src2 = {{MXLEN{1'b0}}, X[xs2]};

--- a/spec/std/isa/inst/M/mulhu.yaml
+++ b/spec/std/isa/inst/M/mulhu.yaml
@@ -39,7 +39,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/mulhu.yaml
+++ b/spec/std/isa/inst/M/mulhu.yaml
@@ -39,10 +39,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   # enlarge and zero-extend the sources
   Bits<MXLEN*8'd2> src1 = {{MXLEN{1'b0}}, X[xs1]};
   Bits<MXLEN*8'd2> src2 = {{MXLEN{1'b0}}, X[xs2]};

--- a/spec/std/isa/inst/M/mulhu.yaml
+++ b/spec/std/isa/inst/M/mulhu.yaml
@@ -40,7 +40,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   # enlarge and zero-extend the sources

--- a/spec/std/isa/inst/M/mulw.yaml
+++ b/spec/std/isa/inst/M/mulw.yaml
@@ -40,7 +40,7 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/mulw.yaml
+++ b/spec/std/isa/inst/M/mulw.yaml
@@ -40,6 +40,10 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/mulw.yaml
+++ b/spec/std/isa/inst/M/mulw.yaml
@@ -41,7 +41,7 @@ access:
 data_independent_timing: true
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   Bits<32> src1 = X[xs1][31:0];

--- a/spec/std/isa/inst/M/mulw.yaml
+++ b/spec/std/isa/inst/M/mulw.yaml
@@ -40,10 +40,6 @@ access:
   vu: always
 data_independent_timing: true
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/rem.yaml
+++ b/spec/std/isa/inst/M/rem.yaml
@@ -32,6 +32,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/rem.yaml
+++ b/spec/std/isa/inst/M/rem.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg src1 = X[xs1];

--- a/spec/std/isa/inst/M/rem.yaml
+++ b/spec/std/isa/inst/M/rem.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/rem.yaml
+++ b/spec/std/isa/inst/M/rem.yaml
@@ -32,10 +32,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/remu.yaml
+++ b/spec/std/isa/inst/M/remu.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg src1 = X[xs1];

--- a/spec/std/isa/inst/M/remu.yaml
+++ b/spec/std/isa/inst/M/remu.yaml
@@ -28,10 +28,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/remu.yaml
+++ b/spec/std/isa/inst/M/remu.yaml
@@ -28,6 +28,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];
 

--- a/spec/std/isa/inst/M/remu.yaml
+++ b/spec/std/isa/inst/M/remu.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/remuw.yaml
+++ b/spec/std/isa/inst/M/remuw.yaml
@@ -34,7 +34,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   Bits<32> src1 = X[xs1][31:0];

--- a/spec/std/isa/inst/M/remuw.yaml
+++ b/spec/std/isa/inst/M/remuw.yaml
@@ -33,10 +33,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/remuw.yaml
+++ b/spec/std/isa/inst/M/remuw.yaml
@@ -33,7 +33,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/remuw.yaml
+++ b/spec/std/isa/inst/M/remuw.yaml
@@ -33,6 +33,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/remw.yaml
+++ b/spec/std/isa/inst/M/remw.yaml
@@ -35,10 +35,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/M/remw.yaml
+++ b/spec/std/isa/inst/M/remw.yaml
@@ -36,7 +36,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   Bits<32> src1 = X[xs1][31:0];

--- a/spec/std/isa/inst/M/remw.yaml
+++ b/spec/std/isa/inst/M/remw.yaml
@@ -35,7 +35,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/M/remw.yaml
+++ b/spec/std/isa/inst/M/remw.yaml
@@ -35,6 +35,10 @@ access:
   vs: always
   vu: always
 operation(): |
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   Bits<32> src1 = X[xs1][31:0];
   Bits<32> src2 = X[xs2][31:0];
 

--- a/spec/std/isa/inst/Zaamo/amoadd.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoadd.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amoadd.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Add, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoadd.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Add, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoadd.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoadd.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoand.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoand.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amoand.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::And, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoand.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::And, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoand.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoand.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amomax.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomax.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amomax.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Max, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amomax.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Max, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amomax.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amomax.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amomaxu.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomaxu.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amomin.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomin.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amomin.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Min, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amomin.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Min, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amomin.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amomin.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amominu.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amominu.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amominu.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amominu.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Minu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amominu.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amominu.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoor.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoor.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amoor.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Or, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoor.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Or, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoor.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoor.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoswap.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoswap.SIZE.AQRL.layout
@@ -68,10 +68,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amoswap.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.aq.yaml
@@ -38,10 +38,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.aqrl.yaml
@@ -38,10 +38,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.rl.yaml
@@ -38,10 +38,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoswap.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.yaml
@@ -38,9 +38,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Swap, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoswap.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.aq.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.aqrl.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.rl.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoswap.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.yaml
@@ -36,9 +36,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoxor.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoxor.SIZE.AQRL.layout
@@ -69,10 +69,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
 <% if aq -%>
   memory_model_acquire();
 

--- a/spec/std/isa/inst/Zaamo/amoxor.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.aq.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.aqrl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.rl.yaml
@@ -39,10 +39,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoxor.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.yaml
@@ -39,9 +39,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(64, virtual_address, X[xs2], AmoOperation::Xor, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zaamo/amoxor.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zaamo/amoxor.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoadd.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoadd.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoadd.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoadd.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoand.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoand.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoand.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoand.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amomax.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amomax.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amomax.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amomax.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amomaxu.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amomaxu.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amomaxu.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amomaxu.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amomin.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amomin.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amomin.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amomin.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amominu.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amominu.b.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amominu.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amominu.h.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoor.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoor.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoor.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoor.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoswap.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.aq.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.aqrl.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.rl.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoswap.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.yaml
@@ -36,9 +36,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoswap.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.aq.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.aqrl.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.rl.yaml
@@ -36,10 +36,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoswap.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.yaml
@@ -36,9 +36,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoxor.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoxor.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zabha/amoxor.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.aq.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.aqrl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.rl.yaml
@@ -37,10 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
 

--- a/spec/std/isa/inst/Zabha/amoxor.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.yaml
@@ -37,9 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
@@ -119,10 +119,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(<%= current_size[:align_bits] %>, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
@@ -120,9 +120,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
@@ -119,7 +119,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.d.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.aq.yaml
@@ -73,7 +73,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.d.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.aq.yaml
@@ -74,9 +74,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.d.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.aq.yaml
@@ -73,10 +73,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(64, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.aqrl.yaml
@@ -73,7 +73,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.aqrl.yaml
@@ -74,9 +74,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.aqrl.yaml
@@ -73,10 +73,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(64, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.d.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.rl.yaml
@@ -73,7 +73,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.d.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.rl.yaml
@@ -74,9 +74,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.d.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.rl.yaml
@@ -73,10 +73,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(64, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.d.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.yaml
@@ -73,7 +73,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.d.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.yaml
@@ -74,9 +74,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.d.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.d.yaml
@@ -73,10 +73,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(64, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
@@ -76,10 +76,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(32, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
@@ -77,9 +77,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
@@ -76,7 +76,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
@@ -76,10 +76,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(32, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
@@ -77,9 +77,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
@@ -76,7 +76,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
@@ -76,10 +76,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(32, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
@@ -77,9 +77,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
@@ -76,7 +76,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/lr.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.yaml
@@ -76,10 +76,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned(32, virtual_address)) {

--- a/spec/std/isa/inst/Zalrsc/lr.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.yaml
@@ -77,9 +77,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/lr.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.yaml
@@ -76,7 +76,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/sc.SIZE.AQRL.layout
@@ -175,7 +175,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/sc.SIZE.AQRL.layout
@@ -175,10 +175,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/sc.SIZE.AQRL.layout
@@ -176,9 +176,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.d.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.aq.yaml
@@ -132,7 +132,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.d.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.aq.yaml
@@ -132,10 +132,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.d.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.aq.yaml
@@ -133,9 +133,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.aqrl.yaml
@@ -132,7 +132,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.aqrl.yaml
@@ -132,10 +132,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.aqrl.yaml
@@ -133,9 +133,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.d.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.rl.yaml
@@ -132,7 +132,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.d.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.rl.yaml
@@ -132,10 +132,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.d.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.rl.yaml
@@ -133,9 +133,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.d.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.yaml
@@ -132,7 +132,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.d.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.yaml
@@ -132,10 +132,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.d.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.d.yaml
@@ -133,9 +133,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.aq.yaml
@@ -134,10 +134,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.aq.yaml
@@ -135,9 +135,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.aq.yaml
@@ -134,7 +134,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.aqrl.yaml
@@ -134,10 +134,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.aqrl.yaml
@@ -135,9 +135,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.aqrl.yaml
@@ -134,7 +134,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.rl.yaml
@@ -134,10 +134,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.rl.yaml
@@ -135,9 +135,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.rl.yaml
@@ -134,7 +134,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zalrsc/sc.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.yaml
@@ -134,10 +134,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg virtual_address = X[xs1];
   XReg value = X[xs2];
 

--- a/spec/std/isa/inst/Zalrsc/sc.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.yaml
@@ -135,9 +135,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
-    # even though this is a memory operation, the exception occurs before that would be known,
-    # so mode() is the correct reporting mode rathat than effective_ldst_mode()
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zalrsc/sc.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/sc.w.yaml
@@ -134,7 +134,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::A) && (CSR[misa].A == 1'b0)) {
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0)) {
     # even though this is a memory operation, the exception occurs before that would be known,
     # so mode() is the correct reporting mode rathat than effective_ldst_mode()
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);

--- a/spec/std/isa/inst/Zba/add.uw.yaml
+++ b/spec/std/isa/inst/Zba/add.uw.yaml
@@ -34,8 +34,4 @@ pseudoinstructions:
   - when: xs2 == 0
     to: zext.w xd, xs1
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + X[xs1][31:0];

--- a/spec/std/isa/inst/Zba/add.uw.yaml
+++ b/spec/std/isa/inst/Zba/add.uw.yaml
@@ -34,7 +34,7 @@ pseudoinstructions:
   - when: xs2 == 0
     to: zext.w xd, xs1
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/add.uw.yaml
+++ b/spec/std/isa/inst/Zba/add.uw.yaml
@@ -35,7 +35,7 @@ pseudoinstructions:
     to: zext.w xd, xs1
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + X[xs1][31:0];

--- a/spec/std/isa/inst/Zba/sh1add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.uw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/sh1add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.uw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + (X[xs1][31:0] << 1);

--- a/spec/std/isa/inst/Zba/sh1add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.uw.yaml
@@ -32,8 +32,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + (X[xs1][31:0] << 1);

--- a/spec/std/isa/inst/Zba/sh1add.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.yaml
@@ -28,8 +28,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + (X[xs1] << 1);

--- a/spec/std/isa/inst/Zba/sh1add.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + (X[xs1] << 1);

--- a/spec/std/isa/inst/Zba/sh1add.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/sh2add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.uw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/sh2add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.uw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + (X[xs1][31:0] << 2);

--- a/spec/std/isa/inst/Zba/sh2add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.uw.yaml
@@ -32,8 +32,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + (X[xs1][31:0] << 2);

--- a/spec/std/isa/inst/Zba/sh2add.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.yaml
@@ -28,8 +28,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + (X[xs1] << 2);

--- a/spec/std/isa/inst/Zba/sh2add.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/sh2add.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + (X[xs1] << 2);

--- a/spec/std/isa/inst/Zba/sh3add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.uw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/sh3add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.uw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + (X[xs1][31:0] << 3);

--- a/spec/std/isa/inst/Zba/sh3add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.uw.yaml
@@ -32,8 +32,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + (X[xs1][31:0] << 3);

--- a/spec/std/isa/inst/Zba/sh3add.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.yaml
@@ -28,8 +28,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs2] + (X[xs1] << 3);

--- a/spec/std/isa/inst/Zba/sh3add.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/sh3add.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs2] + (X[xs1] << 3);

--- a/spec/std/isa/inst/Zba/slli.uw.yaml
+++ b/spec/std/isa/inst/Zba/slli.uw.yaml
@@ -34,8 +34,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs1][31:0] << shamt;

--- a/spec/std/isa/inst/Zba/slli.uw.yaml
+++ b/spec/std/isa/inst/Zba/slli.uw.yaml
@@ -34,7 +34,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zba/slli.uw.yaml
+++ b/spec/std/isa/inst/Zba/slli.uw.yaml
@@ -35,7 +35,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs1][31:0] << shamt;

--- a/spec/std/isa/inst/Zbb/clz.yaml
+++ b/spec/std/isa/inst/Zbb/clz.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/clz.yaml
+++ b/spec/std/isa/inst/Zbb/clz.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = (xlen() - 1) - $signed(highest_set_bit(X[xs1]));

--- a/spec/std/isa/inst/Zbb/clz.yaml
+++ b/spec/std/isa/inst/Zbb/clz.yaml
@@ -29,8 +29,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = (xlen() - 1) - $signed(highest_set_bit(X[xs1]));

--- a/spec/std/isa/inst/Zbb/clzw.yaml
+++ b/spec/std/isa/inst/Zbb/clzw.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/clzw.yaml
+++ b/spec/std/isa/inst/Zbb/clzw.yaml
@@ -30,8 +30,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = 31 - $signed(highest_set_bit(X[xs1][31:0]));

--- a/spec/std/isa/inst/Zbb/clzw.yaml
+++ b/spec/std/isa/inst/Zbb/clzw.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = 31 - $signed(highest_set_bit(X[xs1][31:0]));

--- a/spec/std/isa/inst/Zbb/cpop.yaml
+++ b/spec/std/isa/inst/Zbb/cpop.yaml
@@ -38,10 +38,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg bitcount = 0;
   XReg xs1_val = X[xs1];
 

--- a/spec/std/isa/inst/Zbb/cpop.yaml
+++ b/spec/std/isa/inst/Zbb/cpop.yaml
@@ -38,7 +38,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/cpop.yaml
+++ b/spec/std/isa/inst/Zbb/cpop.yaml
@@ -39,7 +39,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg bitcount = 0;

--- a/spec/std/isa/inst/Zbb/cpopw.yaml
+++ b/spec/std/isa/inst/Zbb/cpopw.yaml
@@ -41,7 +41,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg bitcount = 0;

--- a/spec/std/isa/inst/Zbb/cpopw.yaml
+++ b/spec/std/isa/inst/Zbb/cpopw.yaml
@@ -40,10 +40,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg bitcount = 0;
   XReg xs1_val = X[xs1];
 

--- a/spec/std/isa/inst/Zbb/cpopw.yaml
+++ b/spec/std/isa/inst/Zbb/cpopw.yaml
@@ -40,7 +40,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/ctz.yaml
+++ b/spec/std/isa/inst/Zbb/ctz.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/ctz.yaml
+++ b/spec/std/isa/inst/Zbb/ctz.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (xlen() == 32) {

--- a/spec/std/isa/inst/Zbb/ctz.yaml
+++ b/spec/std/isa/inst/Zbb/ctz.yaml
@@ -30,10 +30,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (xlen() == 32) {
     X[xd] = lowest_set_bit(X[xs1][31:0]);
   } else {

--- a/spec/std/isa/inst/Zbb/ctzw.yaml
+++ b/spec/std/isa/inst/Zbb/ctzw.yaml
@@ -32,10 +32,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   # lowest_set_bit() reports xlen() (64 here) for a zero input, but ctzw must report 32
   if (X[xs1][31:0] == 0) {
     X[xd] = 32;

--- a/spec/std/isa/inst/Zbb/ctzw.yaml
+++ b/spec/std/isa/inst/Zbb/ctzw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/ctzw.yaml
+++ b/spec/std/isa/inst/Zbb/ctzw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   # lowest_set_bit() reports xlen() (64 here) for a zero input, but ctzw must report 32

--- a/spec/std/isa/inst/Zbb/max.yaml
+++ b/spec/std/isa/inst/Zbb/max.yaml
@@ -36,8 +36,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = ($signed(X[xs1]) > $signed(X[xs2])) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/max.yaml
+++ b/spec/std/isa/inst/Zbb/max.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = ($signed(X[xs1]) > $signed(X[xs2])) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/max.yaml
+++ b/spec/std/isa/inst/Zbb/max.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/maxu.yaml
+++ b/spec/std/isa/inst/Zbb/maxu.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = (X[xs1] > X[xs2]) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/maxu.yaml
+++ b/spec/std/isa/inst/Zbb/maxu.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/maxu.yaml
+++ b/spec/std/isa/inst/Zbb/maxu.yaml
@@ -28,8 +28,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = (X[xs1] > X[xs2]) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/min.yaml
+++ b/spec/std/isa/inst/Zbb/min.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = ($signed(X[xs1]) < $signed(X[xs2])) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/min.yaml
+++ b/spec/std/isa/inst/Zbb/min.yaml
@@ -28,8 +28,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = ($signed(X[xs1]) < $signed(X[xs2])) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/min.yaml
+++ b/spec/std/isa/inst/Zbb/min.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/minu.yaml
+++ b/spec/std/isa/inst/Zbb/minu.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = (X[xs1] < X[xs2]) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/minu.yaml
+++ b/spec/std/isa/inst/Zbb/minu.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/minu.yaml
+++ b/spec/std/isa/inst/Zbb/minu.yaml
@@ -28,8 +28,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = (X[xs1] < X[xs2]) ? X[xs1] : X[xs2];

--- a/spec/std/isa/inst/Zbb/orc.b.yaml
+++ b/spec/std/isa/inst/Zbb/orc.b.yaml
@@ -28,10 +28,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg input = X[xs1];
   XReg output = 0;
 

--- a/spec/std/isa/inst/Zbb/orc.b.yaml
+++ b/spec/std/isa/inst/Zbb/orc.b.yaml
@@ -29,7 +29,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg input = X[xs1];

--- a/spec/std/isa/inst/Zbb/orc.b.yaml
+++ b/spec/std/isa/inst/Zbb/orc.b.yaml
@@ -28,7 +28,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/sext.b.yaml
+++ b/spec/std/isa/inst/Zbb/sext.b.yaml
@@ -27,10 +27,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (xlen() == 32) {
     X[xd] = {{24{X[xs1][7]}}, X[xs1][7:0]};
   } else if (xlen() == 64) {

--- a/spec/std/isa/inst/Zbb/sext.b.yaml
+++ b/spec/std/isa/inst/Zbb/sext.b.yaml
@@ -27,7 +27,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/sext.b.yaml
+++ b/spec/std/isa/inst/Zbb/sext.b.yaml
@@ -28,7 +28,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (xlen() == 32) {

--- a/spec/std/isa/inst/Zbb/sext.h.yaml
+++ b/spec/std/isa/inst/Zbb/sext.h.yaml
@@ -27,7 +27,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/sext.h.yaml
+++ b/spec/std/isa/inst/Zbb/sext.h.yaml
@@ -27,10 +27,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (xlen() == 32) {
     X[xd] = {{16{X[xs1][15]}}, X[xs1][15:0]};
   } else if (xlen() == 64) {

--- a/spec/std/isa/inst/Zbb/sext.h.yaml
+++ b/spec/std/isa/inst/Zbb/sext.h.yaml
@@ -28,7 +28,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (xlen() == 32) {

--- a/spec/std/isa/inst/Zbb/zext.h.yaml
+++ b/spec/std/isa/inst/Zbb/zext.h.yaml
@@ -45,8 +45,4 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   X[xd] = X[xs1][15:0];

--- a/spec/std/isa/inst/Zbb/zext.h.yaml
+++ b/spec/std/isa/inst/Zbb/zext.h.yaml
@@ -45,7 +45,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbb/zext.h.yaml
+++ b/spec/std/isa/inst/Zbb/zext.h.yaml
@@ -46,7 +46,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[xd] = X[xs1][15:0];

--- a/spec/std/isa/inst/Zbc/clmulr.yaml
+++ b/spec/std/isa/inst/Zbc/clmulr.yaml
@@ -28,10 +28,6 @@ encoding:
     - name: xd
       location: 11-7
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg xs1_val = X[xs1];
   XReg xs2_val = X[xs2];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbc/clmulr.yaml
+++ b/spec/std/isa/inst/Zbc/clmulr.yaml
@@ -28,7 +28,7 @@ encoding:
     - name: xd
       location: 11-7
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbc/clmulr.yaml
+++ b/spec/std/isa/inst/Zbc/clmulr.yaml
@@ -29,7 +29,7 @@ encoding:
       location: 11-7
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg xs1_val = X[xs1];

--- a/spec/std/isa/inst/Zbs/bclr.yaml
+++ b/spec/std/isa/inst/Zbs/bclr.yaml
@@ -29,9 +29,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = X[xs2] & (xlen() - 1);
   X[xd] = X[xs1] & ~(1 << index);

--- a/spec/std/isa/inst/Zbs/bclr.yaml
+++ b/spec/std/isa/inst/Zbs/bclr.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/bclr.yaml
+++ b/spec/std/isa/inst/Zbs/bclr.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = X[xs2] & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/bclri.yaml
+++ b/spec/std/isa/inst/Zbs/bclri.yaml
@@ -41,7 +41,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = shamt & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/bclri.yaml
+++ b/spec/std/isa/inst/Zbs/bclri.yaml
@@ -40,7 +40,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/bclri.yaml
+++ b/spec/std/isa/inst/Zbs/bclri.yaml
@@ -40,9 +40,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = shamt & (xlen() - 1);
   X[xd] = X[xs1] & ~(1 << index);

--- a/spec/std/isa/inst/Zbs/bext.yaml
+++ b/spec/std/isa/inst/Zbs/bext.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/bext.yaml
+++ b/spec/std/isa/inst/Zbs/bext.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = X[xs2] & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/bext.yaml
+++ b/spec/std/isa/inst/Zbs/bext.yaml
@@ -29,9 +29,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = X[xs2] & (xlen() - 1);
   X[xd] = (X[xs1] >> index) & 1;

--- a/spec/std/isa/inst/Zbs/bexti.yaml
+++ b/spec/std/isa/inst/Zbs/bexti.yaml
@@ -41,7 +41,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = shamt & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/bexti.yaml
+++ b/spec/std/isa/inst/Zbs/bexti.yaml
@@ -40,9 +40,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = shamt & (xlen() - 1);
   X[xd] = (X[xs1] >> index) & 1;

--- a/spec/std/isa/inst/Zbs/bexti.yaml
+++ b/spec/std/isa/inst/Zbs/bexti.yaml
@@ -40,7 +40,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/binv.yaml
+++ b/spec/std/isa/inst/Zbs/binv.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/binv.yaml
+++ b/spec/std/isa/inst/Zbs/binv.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = X[xs2] & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/binv.yaml
+++ b/spec/std/isa/inst/Zbs/binv.yaml
@@ -29,9 +29,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = X[xs2] & (xlen() - 1);
   X[xd] = X[xs1] ^ (1 << index);

--- a/spec/std/isa/inst/Zbs/binvi.yaml
+++ b/spec/std/isa/inst/Zbs/binvi.yaml
@@ -41,7 +41,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = shamt & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/binvi.yaml
+++ b/spec/std/isa/inst/Zbs/binvi.yaml
@@ -40,9 +40,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = shamt & (xlen() - 1);
   X[xd] = X[xs1] ^ (1 << index);

--- a/spec/std/isa/inst/Zbs/binvi.yaml
+++ b/spec/std/isa/inst/Zbs/binvi.yaml
@@ -40,7 +40,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/bset.yaml
+++ b/spec/std/isa/inst/Zbs/bset.yaml
@@ -29,9 +29,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = X[xs2] & (xlen() - 1);
   X[xd] = X[xs1] | (1 << index);

--- a/spec/std/isa/inst/Zbs/bset.yaml
+++ b/spec/std/isa/inst/Zbs/bset.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zbs/bset.yaml
+++ b/spec/std/isa/inst/Zbs/bset.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = X[xs2] & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/bseti.yaml
+++ b/spec/std/isa/inst/Zbs/bseti.yaml
@@ -40,9 +40,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   XReg index = shamt & (xlen() - 1);
   X[xd] = X[xs1] | (1 << index);

--- a/spec/std/isa/inst/Zbs/bseti.yaml
+++ b/spec/std/isa/inst/Zbs/bseti.yaml
@@ -41,7 +41,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg index = shamt & (xlen() - 1);

--- a/spec/std/isa/inst/Zbs/bseti.yaml
+++ b/spec/std/isa/inst/Zbs/bseti.yaml
@@ -40,7 +40,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.lbu.yaml
+++ b/spec/std/isa/inst/Zcb/c.lbu.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.lbu.yaml
+++ b/spec/std/isa/inst/Zcb/c.lbu.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcb/c.lh.yaml
+++ b/spec/std/isa/inst/Zcb/c.lh.yaml
@@ -31,7 +31,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.lh.yaml
+++ b/spec/std/isa/inst/Zcb/c.lh.yaml
@@ -32,7 +32,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcb/c.lhu.yaml
+++ b/spec/std/isa/inst/Zcb/c.lhu.yaml
@@ -31,7 +31,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.lhu.yaml
+++ b/spec/std/isa/inst/Zcb/c.lhu.yaml
@@ -32,7 +32,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -32,11 +32,11 @@ data_independent_timing: true
 operation(): |
 
   if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = X[creg2reg(xd)] * X[creg2reg(xs2)];

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -31,6 +31,10 @@ access:
 data_independent_timing: true
 operation(): |
 
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
+    reserved_instruction($encoding);
+  }
+
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -31,11 +31,11 @@ access:
 data_independent_timing: true
 operation(): |
 
-  if (implemented?(ExtensionName::M) && (CSR[misa].M == 1'b0)) {
+  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -31,10 +31,6 @@ access:
 data_independent_timing: true
 operation(): |
 
-  if (implemented?(ExtensionName::M) && MISA_CSR_IMPLEMENTED && (CSR[misa].M == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/Zcb/c.not.yaml
+++ b/spec/std/isa/inst/Zcb/c.not.yaml
@@ -28,7 +28,7 @@ access:
 data_independent_timing: true
 operation(): |
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.not.yaml
+++ b/spec/std/isa/inst/Zcb/c.not.yaml
@@ -29,7 +29,7 @@ data_independent_timing: true
 operation(): |
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = ~X[creg2reg(xd)];

--- a/spec/std/isa/inst/Zcb/c.sb.yaml
+++ b/spec/std/isa/inst/Zcb/c.sb.yaml
@@ -30,7 +30,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.sb.yaml
+++ b/spec/std/isa/inst/Zcb/c.sb.yaml
@@ -31,7 +31,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcb/c.sext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.b.yaml
@@ -30,10 +30,6 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/Zcb/c.sext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.b.yaml
@@ -31,11 +31,11 @@ access:
 operation(): |2
 
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = $signed(X[creg2reg(xd)][7:0]);

--- a/spec/std/isa/inst/Zcb/c.sext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.b.yaml
@@ -30,11 +30,11 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.sext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.h.yaml
@@ -30,10 +30,6 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/Zcb/c.sext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.h.yaml
@@ -30,11 +30,11 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.sext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.h.yaml
@@ -31,11 +31,11 @@ access:
 operation(): |2
 
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = $signed(X[creg2reg(xd)][15:0]);

--- a/spec/std/isa/inst/Zcb/c.sh.yaml
+++ b/spec/std/isa/inst/Zcb/c.sh.yaml
@@ -31,7 +31,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.sh.yaml
+++ b/spec/std/isa/inst/Zcb/c.sh.yaml
@@ -32,7 +32,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcb/c.zext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.b.yaml
@@ -29,7 +29,7 @@ access:
 data_independent_timing: true
 operation(): |2
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.zext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.b.yaml
@@ -30,7 +30,7 @@ data_independent_timing: true
 operation(): |2
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = X[creg2reg(xd)][7:0];

--- a/spec/std/isa/inst/Zcb/c.zext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.h.yaml
@@ -31,11 +31,11 @@ access:
 operation(): |2
 
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = X[creg2reg(xd)][15:0];

--- a/spec/std/isa/inst/Zcb/c.zext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.h.yaml
@@ -30,10 +30,6 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/Zcb/c.zext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.h.yaml
@@ -30,11 +30,11 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.zext.w.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.w.yaml
@@ -31,10 +31,6 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    reserved_instruction($encoding);
-  }
-
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     reserved_instruction($encoding);
   }

--- a/spec/std/isa/inst/Zcb/c.zext.w.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.w.yaml
@@ -31,11 +31,11 @@ access:
   vu: always
 operation(): |2
 
-  if (implemented?(ExtensionName::B) && (CSR[misa].B == 1'b0)) {
+  if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcb/c.zext.w.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.w.yaml
@@ -32,11 +32,11 @@ access:
 operation(): |2
 
   if (implemented?(ExtensionName::B) && MISA_CSR_IMPLEMENTED && (CSR[misa].B == 1'b0)) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   X[creg2reg(xd)] = X[creg2reg(xd)][31:0];

--- a/spec/std/isa/inst/Zcd/c.fld.yaml
+++ b/spec/std/isa/inst/Zcd/c.fld.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcd/c.fld.yaml
+++ b/spec/std/isa/inst/Zcd/c.fld.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcd/c.fldsp.yaml
+++ b/spec/std/isa/inst/Zcd/c.fldsp.yaml
@@ -30,10 +30,10 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
-  if (implemented?(ExtensionName::D) && (CSR[misa].D == 1'b0)) {
+  if (implemented?(ExtensionName::D) && MISA_CSR_IMPLEMENTED && (CSR[misa].D == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcd/c.fldsp.yaml
+++ b/spec/std/isa/inst/Zcd/c.fldsp.yaml
@@ -31,10 +31,10 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (implemented?(ExtensionName::D) && MISA_CSR_IMPLEMENTED && (CSR[misa].D == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/Zcd/c.fsd.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsd.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcd/c.fsd.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsd.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcd/c.fsdsp.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsdsp.yaml
@@ -30,10 +30,10 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
-  if (implemented?(ExtensionName::D) && (CSR[misa].D == 1'b0)) {
+  if (implemented?(ExtensionName::D) && MISA_CSR_IMPLEMENTED && (CSR[misa].D == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcd/c.fsdsp.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsdsp.yaml
@@ -31,10 +31,10 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (implemented?(ExtensionName::D) && MISA_CSR_IMPLEMENTED && (CSR[misa].D == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/Zcf/c.flw.yaml
+++ b/spec/std/isa/inst/Zcf/c.flw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcf/c.flw.yaml
+++ b/spec/std/isa/inst/Zcf/c.flw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcf/c.flwsp.yaml
+++ b/spec/std/isa/inst/Zcf/c.flwsp.yaml
@@ -31,10 +31,10 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (implemented?(ExtensionName::F) && MISA_CSR_IMPLEMENTED && (CSR[misa].F == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/Zcf/c.flwsp.yaml
+++ b/spec/std/isa/inst/Zcf/c.flwsp.yaml
@@ -30,10 +30,10 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
-  if (implemented?(ExtensionName::F) && (CSR[misa].F == 1'b0)) {
+  if (implemented?(ExtensionName::F) && MISA_CSR_IMPLEMENTED && (CSR[misa].F == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcf/c.fsw.yaml
+++ b/spec/std/isa/inst/Zcf/c.fsw.yaml
@@ -33,7 +33,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;

--- a/spec/std/isa/inst/Zcf/c.fsw.yaml
+++ b/spec/std/isa/inst/Zcf/c.fsw.yaml
@@ -32,7 +32,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcf/c.fswsp.yaml
+++ b/spec/std/isa/inst/Zcf/c.fswsp.yaml
@@ -31,10 +31,10 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   if (implemented?(ExtensionName::F) && MISA_CSR_IMPLEMENTED && (CSR[misa].F == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[2] + imm;

--- a/spec/std/isa/inst/Zcf/c.fswsp.yaml
+++ b/spec/std/isa/inst/Zcf/c.fswsp.yaml
@@ -30,10 +30,10 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::C) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::C) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
-  if (implemented?(ExtensionName::F) && (CSR[misa].F == 1'b0)) {
+  if (implemented?(ExtensionName::F) && MISA_CSR_IMPLEMENTED && (CSR[misa].F == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcmp/cm.mva01s.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.mva01s.yaml
@@ -28,7 +28,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};
   XReg xreg2 = (r2s[2:1]>0) ? {1,0,r2s[2:0]} : {0,1,r2s[2:0]};

--- a/spec/std/isa/inst/Zcmp/cm.mva01s.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.mva01s.yaml
@@ -27,7 +27,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};

--- a/spec/std/isa/inst/Zcmp/cm.mvsa01.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.mvsa01.yaml
@@ -30,7 +30,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};
   XReg xreg2 = (r2s[2:1]>0) ? {1,0,r2s[2:0]} : {0,1,r2s[2:0]};

--- a/spec/std/isa/inst/Zcmp/cm.mvsa01.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.mvsa01.yaml
@@ -29,7 +29,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
   XReg xreg1 = (r1s[2:1]>0) ? {1,0,r1s[2:0]} : {0,1,r1s[2:0]};

--- a/spec/std/isa/inst/Zcmp/cm.pop.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.pop.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg size = xlen() / 8;

--- a/spec/std/isa/inst/Zcmp/cm.pop.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.pop.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcmp/cm.popret.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.popret.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg size = xlen() / 8;

--- a/spec/std/isa/inst/Zcmp/cm.popret.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.popret.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcmp/cm.popretz.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.popretz.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg size = xlen() / 8;

--- a/spec/std/isa/inst/Zcmp/cm.popretz.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.popretz.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 

--- a/spec/std/isa/inst/Zcmp/cm.push.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.push.yaml
@@ -37,7 +37,7 @@ access:
   vu: always
 operation(): |
   if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
-    raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
+    reserved_instruction($encoding);
   }
 
   XReg size = xlen() / 8;

--- a/spec/std/isa/inst/Zcmp/cm.push.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.push.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (implemented?(ExtensionName::Zcmp) && (CSR[misa].C == 1'b0)) {
+  if (implemented?(ExtensionName::Zcmp) && MISA_CSR_IMPLEMENTED && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 


### PR DESCRIPTION
Of the 292 misa-gated illegal-instruction checks, 224 test a bit whose clearing does not make the instruction unimplemented, and are removed: all 171 `misa.A` sites, all 47 `misa.B`, and the 6 `misa.M` sites on instructions that are `definedBy: Zmmul`. Zalrsc and Zaamo are independently implementable, as are Zba, Zbb and Zbs, so clearing the bit leaves them implemented.

The remaining 68 keep the guard and are brought into line: they check `MISA_CSR_IMPLEMENTED` before reading the bit, and call `reserved_instruction()` instead of raising directly. Those are 56 for `misa.C`, which `ialign()` and the four `*epc` registers also read, the 8 division instructions that are `definedBy: M`, and 4 for `misa.F` and `misa.D`. `reserved_instruction()` honours `TRAP_ON_UNIMPLEMENTED_INSTRUCTION`, which `Ssstrict` requires to be true, so routing through it is what lets `Ssstrict` govern these traps.

`misa.yaml` loses the `misa.A` and `misa.B` sentences claiming that writing 0 raises `IllegalInstruction`, since neither bit gates anything now, and the `misa.M` sentence is narrowed to divide and remainder. No behaviour change in the tree: all 38 `MUTABLE_MISA_*` assignments in `cfgs/` are `false`. The 23 `misa.S` and `misa.H` sites test `== 1` to select behaviour rather than to trap, so they remain a separate question.

Closes #2434
Closes #1175
