### PR TITLE
Fix Zvkb instruction ownership

### DIFF
--- a/spec/std/isa/inst/Zvkb/vandn.vv.yaml
+++ b/spec/std/isa/inst/Zvkb/vandn.vv.yaml
@@ -11,7 +11,7 @@ description: |
   Performs a bitwise AND operation between vector register vs2 and the bitwise NOT of vector register vs1, storing results in vector register vd according to mask vm.
 definedBy:
   extension:
-    name: Zvbb
+    name: Zvkb
 assembly: vd, vs2, vs1, vm
 encoding:
   match: 000001-----------000-----1010111

--- a/spec/std/isa/inst/Zvkb/vandn.vx.yaml
+++ b/spec/std/isa/inst/Zvkb/vandn.vx.yaml
@@ -5,16 +5,16 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vror.vx
-long_name: Vector rotate right by scalar
+name: vandn.vx
+long_name: Vector AND-NOT with scalar
 description: |
-  Rotates each element in vector register vs2 right by the amount specified in scalar register xs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
+  Performs a bitwise AND operation between vector register vs2 and the bitwise NOT of scalar register xs1, storing results in vector register vd according to mask vm.
 definedBy:
   extension:
-    name: Zvbb
+    name: Zvkb
 assembly: vd, vs2, xs1, vm
 encoding:
-  match: 010100-----------100-----1010111
+  match: 000001-----------100-----1010111
   variables:
     - name: vm
       location: 25-25

--- a/spec/std/isa/inst/Zvkb/vbrev8.v.yaml
+++ b/spec/std/isa/inst/Zvkb/vbrev8.v.yaml
@@ -5,23 +5,21 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vrol.vv
-long_name: Vector rotate left by vector
+name: vbrev8.v
+long_name: Vector byte reverse within elements
 description: |
-  Rotates each element in vector register vs2 left by the amount specified in vector register vs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
+  Reverses the byte order within each element of vector register vs2, storing results in vector register vd according to mask vm. Similar to vrev8.v but with different encoding.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, vs1, vm
+    name: Zvkb
+assembly: vd, vs2, vm
 encoding:
-  match: 010101-----------000-----1010111
+  match: 010010------01000010-----1010111
   variables:
     - name: vm
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: vs1
-      location: 19-15
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/Zvkb/vrev8.v.yaml
+++ b/spec/std/isa/inst/Zvkb/vrev8.v.yaml
@@ -5,19 +5,17 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vror.vi
-long_name: Vector rotate right by immediate
+name: vrev8.v
+long_name: Vector byte reverse
 description: |
-  Rotates each element in vector register vs2 right by the immediate shift amount, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
+  Reverses the byte order within each element of vector register vs2, storing results in vector register vd according to mask vm. This is equivalent to a byte-level reversal of each element.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, imm, vm
+    name: Zvkb
+assembly: vd, vs2, vm
 encoding:
-  match: 01010------------011-----1010111
+  match: 010010------01001010-----1010111
   variables:
-    - name: imm
-      location: 26|19-15
     - name: vm
       location: 25-25
     - name: vs2

--- a/spec/std/isa/inst/Zvkb/vrol.vv.yaml
+++ b/spec/std/isa/inst/Zvkb/vrol.vv.yaml
@@ -5,22 +5,22 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vandn.vx
-long_name: Vector AND-NOT with scalar
+name: vrol.vv
+long_name: Vector rotate left by vector
 description: |
-  Performs a bitwise AND operation between vector register vs2 and the bitwise NOT of scalar register xs1, storing results in vector register vd according to mask vm.
+  Rotates each element in vector register vs2 left by the amount specified in vector register vs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, xs1, vm
+    name: Zvkb
+assembly: vd, vs2, vs1, vm
 encoding:
-  match: 000001-----------100-----1010111
+  match: 010101-----------000-----1010111
   variables:
     - name: vm
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: xs1
+    - name: vs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/spec/std/isa/inst/Zvkb/vrol.vx.yaml
+++ b/spec/std/isa/inst/Zvkb/vrol.vx.yaml
@@ -5,21 +5,23 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vrev8.v
-long_name: Vector byte reverse
+name: vrol.vx
+long_name: Vector rotate left by scalar
 description: |
-  Reverses the byte order within each element of vector register vs2, storing results in vector register vd according to mask vm. This is equivalent to a byte-level reversal of each element.
+  Rotates each element in vector register vs2 left by the amount specified in scalar register xs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, vm
+    name: Zvkb
+assembly: vd, vs2, xs1, vm
 encoding:
-  match: 010010------01001010-----1010111
+  match: 010101-----------100-----1010111
   variables:
     - name: vm
       location: 25-25
     - name: vs2
       location: 24-20
+    - name: xs1
+      location: 19-15
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/Zvkb/vror.vi.yaml
+++ b/spec/std/isa/inst/Zvkb/vror.vi.yaml
@@ -5,23 +5,23 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vrol.vx
-long_name: Vector rotate left by scalar
+name: vror.vi
+long_name: Vector rotate right by immediate
 description: |
-  Rotates each element in vector register vs2 left by the amount specified in scalar register xs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
+  Rotates each element in vector register vs2 right by the immediate shift amount, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, xs1, vm
+    name: Zvkb
+assembly: vd, vs2, imm, vm
 encoding:
-  match: 010101-----------100-----1010111
+  match: 01010------------011-----1010111
   variables:
+    - name: imm
+      location: 26|19-15
     - name: vm
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: xs1
-      location: 19-15
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/Zvkb/vror.vv.yaml
+++ b/spec/std/isa/inst/Zvkb/vror.vv.yaml
@@ -5,21 +5,23 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vbrev8.v
-long_name: Vector byte reverse within elements
+name: vror.vv
+long_name: Vector rotate right by vector
 description: |
-  Reverses the byte order within each element of vector register vs2, storing results in vector register vd according to mask vm. Similar to vrev8.v but with different encoding.
+  Rotates each element in vector register vs2 right by the amount specified in vector register vs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, vm
+    name: Zvkb
+assembly: vd, vs2, vs1, vm
 encoding:
-  match: 010010------01000010-----1010111
+  match: 010100-----------000-----1010111
   variables:
     - name: vm
       location: 25-25
     - name: vs2
       location: 24-20
+    - name: vs1
+      location: 19-15
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/Zvkb/vror.vx.yaml
+++ b/spec/std/isa/inst/Zvkb/vror.vx.yaml
@@ -5,22 +5,22 @@
 
 $schema: "inst_schema.json#"
 kind: instruction
-name: vror.vv
-long_name: Vector rotate right by vector
+name: vror.vx
+long_name: Vector rotate right by scalar
 description: |
-  Rotates each element in vector register vs2 right by the amount specified in vector register vs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
+  Rotates each element in vector register vs2 right by the amount specified in scalar register xs1, storing results in vector register vd according to mask vm. The rotation amount is taken modulo the element width.
 definedBy:
   extension:
-    name: Zvbb
-assembly: vd, vs2, vs1, vm
+    name: Zvkb
+assembly: vd, vs2, xs1, vm
 encoding:
-  match: 010100-----------000-----1010111
+  match: 010100-----------100-----1010111
   variables:
     - name: vm
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: vs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -41323,7 +41323,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -41376,7 +41376,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -41692,7 +41692,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -62980,7 +62980,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -63245,7 +63245,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -63298,7 +63298,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -63351,7 +63351,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -63404,7 +63404,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 
@@ -63457,7 +63457,7 @@ Included in::
 |===
 | Extension | Version
 
-| *Zvbb*
+| *Zvkb*
 | any
 |===
 


### PR DESCRIPTION
Move the nine instructions defined by Zvkb from the Zvbb instruction directory to the Zvkb instruction directory.

Update their definedBy fields from Zvbb to Zvkb. Zvbb already requires Zvkb, so no extension dependency changes are needed.

Signed-off-by: Abhik Gude <abhigude@qti.qualcomm.com>