### PR TITLE
fix(csr): read stateen *_TYPE parameters in field type and reset_value

### DIFF
--- a/spec/std/isa/csr/hstateen0.yaml
+++ b/spec/std/isa/csr/hstateen0.yaml
@@ -74,7 +74,6 @@ fields:
       if (HSTATEEN_ENVCFG_TYPE == "read-only-0" || HSTATEEN_ENVCFG_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(HSTATEEN_ENVCFG_TYPE == "rw", "Unhandled HSTATEEN_ENVCFG_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (HSTATEEN_ENVCFG_TYPE == "read-only-0") {
@@ -82,7 +81,6 @@ fields:
       } else if (HSTATEEN_ENVCFG_TYPE == "read-only-1") {
         return 1;
       }
-      assert(HSTATEEN_ENVCFG_TYPE == "rw", "Unhandled HSTATEEN_ENVCFG_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].ENVCFG == 1'b0){
@@ -103,7 +101,6 @@ fields:
       if (HSTATEEN_CSRIND_TYPE == "read-only-0" || HSTATEEN_CSRIND_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(HSTATEEN_CSRIND_TYPE == "rw", "Unhandled HSTATEEN_CSRIND_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (HSTATEEN_CSRIND_TYPE == "read-only-0") {
@@ -111,7 +108,6 @@ fields:
       } else if (HSTATEEN_CSRIND_TYPE == "read-only-1") {
         return 1;
       }
-      assert(HSTATEEN_CSRIND_TYPE == "rw", "Unhandled HSTATEEN_CSRIND_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].CSRIND == 1'b0){
@@ -132,7 +128,6 @@ fields:
       if (HSTATEEN_AIA_TYPE == "read-only-0" || HSTATEEN_AIA_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(HSTATEEN_AIA_TYPE == "rw", "Unhandled HSTATEEN_AIA_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (HSTATEEN_AIA_TYPE == "read-only-0") {
@@ -140,7 +135,6 @@ fields:
       } else if (HSTATEEN_AIA_TYPE == "read-only-1") {
         return 1;
       }
-      assert(HSTATEEN_AIA_TYPE == "rw", "Unhandled HSTATEEN_AIA_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].AIA == 1'b0){
@@ -163,7 +157,6 @@ fields:
       if (HSTATEEN_IMSIC_TYPE == "read-only-0" || HSTATEEN_IMSIC_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(HSTATEEN_IMSIC_TYPE == "rw", "Unhandled HSTATEEN_IMSIC_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (HSTATEEN_IMSIC_TYPE == "read-only-0") {
@@ -171,7 +164,6 @@ fields:
       } else if (HSTATEEN_IMSIC_TYPE == "read-only-1") {
         return 1;
       }
-      assert(HSTATEEN_IMSIC_TYPE == "rw", "Unhandled HSTATEEN_IMSIC_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].IMSIC == 1'b0){
@@ -191,7 +183,6 @@ fields:
       if (HSTATEEN_CONTEXT_TYPE == "read-only-0" || HSTATEEN_CONTEXT_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(HSTATEEN_CONTEXT_TYPE == "rw", "Unhandled HSTATEEN_CONTEXT_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (HSTATEEN_CONTEXT_TYPE == "read-only-0") {
@@ -199,7 +190,6 @@ fields:
       } else if (HSTATEEN_CONTEXT_TYPE == "read-only-1") {
         return 1;
       }
-      assert(HSTATEEN_CONTEXT_TYPE == "rw", "Unhandled HSTATEEN_CONTEXT_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].CONTEXT == 1'b0){
@@ -233,7 +223,6 @@ fields:
       if (HSTATEEN_JVT_TYPE == "read-only-0" || HSTATEEN_JVT_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(HSTATEEN_JVT_TYPE == "rw", "Unhandled HSTATEEN_JVT_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (HSTATEEN_JVT_TYPE == "read-only-0") {
@@ -241,7 +230,6 @@ fields:
       } else if (HSTATEEN_JVT_TYPE == "read-only-1") {
         return 1;
       }
-      assert(HSTATEEN_JVT_TYPE == "rw", "Unhandled HSTATEEN_JVT_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].JVT == 1'b0){

--- a/spec/std/isa/csr/hstateen0.yaml
+++ b/spec/std/isa/csr/hstateen0.yaml
@@ -70,8 +70,20 @@ fields:
         version: ">= 1.11"
     description: |
       The ENVCFG bit in `hstateen0` controls access to the `senvcfg` CSRs.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (HSTATEEN_ENVCFG_TYPE == "read-only-0" || HSTATEEN_ENVCFG_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(HSTATEEN_ENVCFG_TYPE == "rw", "Unhandled HSTATEEN_ENVCFG_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (HSTATEEN_ENVCFG_TYPE == "read-only-0") {
+        return 0;
+      } else if (HSTATEEN_ENVCFG_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(HSTATEEN_ENVCFG_TYPE == "rw", "Unhandled HSTATEEN_ENVCFG_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].ENVCFG == 1'b0){
         return 0;
@@ -87,8 +99,20 @@ fields:
       The CSRIND bit in `hstateen0` controls access to the `siselect` and the
       `sireg*`, (really `vsiselect` and `vsireg*`) CSRs provided by the Sscsrind
       extensions.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (HSTATEEN_CSRIND_TYPE == "read-only-0" || HSTATEEN_CSRIND_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(HSTATEEN_CSRIND_TYPE == "rw", "Unhandled HSTATEEN_CSRIND_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (HSTATEEN_CSRIND_TYPE == "read-only-0") {
+        return 0;
+      } else if (HSTATEEN_CSRIND_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(HSTATEEN_CSRIND_TYPE == "rw", "Unhandled HSTATEEN_CSRIND_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].CSRIND == 1'b0){
         return 0;
@@ -104,8 +128,20 @@ fields:
       The AIA bit in `hstateen0` controls access to all state introduced by
       the Ssaia extension and is not controlled by either the CSRIND or the
       IMSIC bits of `hstateen0`.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (HSTATEEN_AIA_TYPE == "read-only-0" || HSTATEEN_AIA_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(HSTATEEN_AIA_TYPE == "rw", "Unhandled HSTATEEN_AIA_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (HSTATEEN_AIA_TYPE == "read-only-0") {
+        return 0;
+      } else if (HSTATEEN_AIA_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(HSTATEEN_AIA_TYPE == "rw", "Unhandled HSTATEEN_AIA_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].AIA == 1'b0){
         return 0;
@@ -123,8 +159,20 @@ fields:
 
       Setting the IMSIC bit in `hstateen0` to zero prevents a virtual machine
       from accessing the hart’s IMSIC the same as setting `hstatus.`VGEIN = 0.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (HSTATEEN_IMSIC_TYPE == "read-only-0" || HSTATEEN_IMSIC_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(HSTATEEN_IMSIC_TYPE == "rw", "Unhandled HSTATEEN_IMSIC_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (HSTATEEN_IMSIC_TYPE == "read-only-0") {
+        return 0;
+      } else if (HSTATEEN_IMSIC_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(HSTATEEN_IMSIC_TYPE == "rw", "Unhandled HSTATEEN_IMSIC_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].IMSIC == 1'b0){
         return 0;
@@ -139,8 +187,20 @@ fields:
     description: |
       The CONTEXT bit in `hstateen0` controls access to the `scontext` CSR provided
       by the Sdtrig extension.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (HSTATEEN_CONTEXT_TYPE == "read-only-0" || HSTATEEN_CONTEXT_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(HSTATEEN_CONTEXT_TYPE == "rw", "Unhandled HSTATEEN_CONTEXT_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (HSTATEEN_CONTEXT_TYPE == "read-only-0") {
+        return 0;
+      } else if (HSTATEEN_CONTEXT_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(HSTATEEN_CONTEXT_TYPE == "rw", "Unhandled HSTATEEN_CONTEXT_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].CONTEXT == 1'b0){
         return 0;
@@ -169,8 +229,20 @@ fields:
         name: Zcmt
     description: |
       The JVT bit controls access to the `jvt` CSR provided by the Zcmt extension.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (HSTATEEN_JVT_TYPE == "read-only-0" || HSTATEEN_JVT_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(HSTATEEN_JVT_TYPE == "rw", "Unhandled HSTATEEN_JVT_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (HSTATEEN_JVT_TYPE == "read-only-0") {
+        return 0;
+      } else if (HSTATEEN_JVT_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(HSTATEEN_JVT_TYPE == "rw", "Unhandled HSTATEEN_JVT_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].JVT == 1'b0){
         return 0;

--- a/spec/std/isa/csr/mstateen0.yaml
+++ b/spec/std/isa/csr/mstateen0.yaml
@@ -72,8 +72,20 @@ fields:
         version: ">= 1.11"
     description: |
       The ENVCFG bit in `mstateen0` controls access to the `henvcfg`, `henvcfgh`, and the `senvcfg` CSRs.
-    type: RW
-    reset_value: 0
+    type(): |
+      if (MSTATEEN_ENVCFG_TYPE == "read-only-0" || MSTATEEN_ENVCFG_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(MSTATEEN_ENVCFG_TYPE == "rw", "Unhandled MSTATEEN_ENVCFG_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (MSTATEEN_ENVCFG_TYPE == "read-only-0") {
+        return 0;
+      } else if (MSTATEEN_ENVCFG_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(MSTATEEN_ENVCFG_TYPE == "rw", "Unhandled MSTATEEN_ENVCFG_TYPE value");
+      return 0;
   CSRIND:
     long_name: siselect, sireg*, vsiselect, and vsireg* access control
     location: 60
@@ -83,8 +95,20 @@ fields:
     description: |
       The CSRIND bit in `mstateen0` controls access to the `siselect`, `sireg*`, `vsiselect`, and the `vsireg*`
       CSRs provided by the Sscsrind extensions.
-    type: RW
-    reset_value: 0
+    type(): |
+      if (MSTATEEN_CSRIND_TYPE == "read-only-0" || MSTATEEN_CSRIND_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(MSTATEEN_CSRIND_TYPE == "rw", "Unhandled MSTATEEN_CSRIND_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (MSTATEEN_CSRIND_TYPE == "read-only-0") {
+        return 0;
+      } else if (MSTATEEN_CSRIND_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(MSTATEEN_CSRIND_TYPE == "rw", "Unhandled MSTATEEN_CSRIND_TYPE value");
+      return 0;
   AIA:
     long_name: Ssaia state access control
     location: 59
@@ -94,8 +118,20 @@ fields:
     description: |
       The AIA bit in `mstateen0` controls access to all state introduced by the Ssaia extension and is not
       controlled by either the CSRIND or the IMSIC bits.
-    type: RW
-    reset_value: 0
+    type(): |
+      if (MSTATEEN_AIA_TYPE == "read-only-0" || MSTATEEN_AIA_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(MSTATEEN_AIA_TYPE == "rw", "Unhandled MSTATEEN_AIA_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (MSTATEEN_AIA_TYPE == "read-only-0") {
+        return 0;
+      } else if (MSTATEEN_AIA_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(MSTATEEN_AIA_TYPE == "rw", "Unhandled MSTATEEN_AIA_TYPE value");
+      return 0;
   IMSIC:
     long_name: IMSIC state access control
     location: 58
@@ -105,8 +141,20 @@ fields:
     description: |
       The IMSIC bit in `mstateen0` controls access to the IMSIC state, including CSRs `stopei` and `vstopei`,
       provided by the Ssaia extension.
-    type: RW
-    reset_value: 0
+    type(): |
+      if (MSTATEEN_IMSIC_TYPE == "read-only-0" || MSTATEEN_IMSIC_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(MSTATEEN_IMSIC_TYPE == "rw", "Unhandled MSTATEEN_IMSIC_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (MSTATEEN_IMSIC_TYPE == "read-only-0") {
+        return 0;
+      } else if (MSTATEEN_IMSIC_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(MSTATEEN_IMSIC_TYPE == "rw", "Unhandled MSTATEEN_IMSIC_TYPE value");
+      return 0;
   CONTEXT:
     long_name: scontext and hcontext access control
     location: 57
@@ -116,8 +164,20 @@ fields:
     description: |
       The CONTEXT bit in `mstateen0` controls access to the `scontext` and `hcontext` CSRs provided by the
       Sdtrig extension.
-    type: RW
-    reset_value: 0
+    type(): |
+      if (MSTATEEN_CONTEXT_TYPE == "read-only-0" || MSTATEEN_CONTEXT_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(MSTATEEN_CONTEXT_TYPE == "rw", "Unhandled MSTATEEN_CONTEXT_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (MSTATEEN_CONTEXT_TYPE == "read-only-0") {
+        return 0;
+      } else if (MSTATEEN_CONTEXT_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(MSTATEEN_CONTEXT_TYPE == "rw", "Unhandled MSTATEEN_CONTEXT_TYPE value");
+      return 0;
   P1P13:
     long_name: hedelegh access control
     location: 56
@@ -153,8 +213,20 @@ fields:
         name: Zcmt
     description: |
       The JVT bit controls access to the `jvt` CSR provided by the Zcmt extension.
-    type: RW
-    reset_value: 0
+    type(): |
+      if (MSTATEEN_JVT_TYPE == "read-only-0" || MSTATEEN_JVT_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(MSTATEEN_JVT_TYPE == "rw", "Unhandled MSTATEEN_JVT_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (MSTATEEN_JVT_TYPE == "read-only-0") {
+        return 0;
+      } else if (MSTATEEN_JVT_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(MSTATEEN_JVT_TYPE == "rw", "Unhandled MSTATEEN_JVT_TYPE value");
+      return 0;
   FCSR:
     long_name: fcsr access control
     location: 1

--- a/spec/std/isa/csr/mstateen0.yaml
+++ b/spec/std/isa/csr/mstateen0.yaml
@@ -76,15 +76,11 @@ fields:
       if (MSTATEEN_ENVCFG_TYPE == "read-only-0" || MSTATEEN_ENVCFG_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(MSTATEEN_ENVCFG_TYPE == "rw", "Unhandled MSTATEEN_ENVCFG_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
-      if (MSTATEEN_ENVCFG_TYPE == "read-only-0") {
-        return 0;
-      } else if (MSTATEEN_ENVCFG_TYPE == "read-only-1") {
+      if (MSTATEEN_ENVCFG_TYPE == "read-only-1") {
         return 1;
       }
-      assert(MSTATEEN_ENVCFG_TYPE == "rw", "Unhandled MSTATEEN_ENVCFG_TYPE value");
       return 0;
   CSRIND:
     long_name: siselect, sireg*, vsiselect, and vsireg* access control
@@ -99,15 +95,11 @@ fields:
       if (MSTATEEN_CSRIND_TYPE == "read-only-0" || MSTATEEN_CSRIND_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(MSTATEEN_CSRIND_TYPE == "rw", "Unhandled MSTATEEN_CSRIND_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
-      if (MSTATEEN_CSRIND_TYPE == "read-only-0") {
-        return 0;
-      } else if (MSTATEEN_CSRIND_TYPE == "read-only-1") {
+      if (MSTATEEN_CSRIND_TYPE == "read-only-1") {
         return 1;
       }
-      assert(MSTATEEN_CSRIND_TYPE == "rw", "Unhandled MSTATEEN_CSRIND_TYPE value");
       return 0;
   AIA:
     long_name: Ssaia state access control
@@ -122,15 +114,11 @@ fields:
       if (MSTATEEN_AIA_TYPE == "read-only-0" || MSTATEEN_AIA_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(MSTATEEN_AIA_TYPE == "rw", "Unhandled MSTATEEN_AIA_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
-      if (MSTATEEN_AIA_TYPE == "read-only-0") {
-        return 0;
-      } else if (MSTATEEN_AIA_TYPE == "read-only-1") {
+      if (MSTATEEN_AIA_TYPE == "read-only-1") {
         return 1;
       }
-      assert(MSTATEEN_AIA_TYPE == "rw", "Unhandled MSTATEEN_AIA_TYPE value");
       return 0;
   IMSIC:
     long_name: IMSIC state access control
@@ -145,15 +133,11 @@ fields:
       if (MSTATEEN_IMSIC_TYPE == "read-only-0" || MSTATEEN_IMSIC_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(MSTATEEN_IMSIC_TYPE == "rw", "Unhandled MSTATEEN_IMSIC_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
-      if (MSTATEEN_IMSIC_TYPE == "read-only-0") {
-        return 0;
-      } else if (MSTATEEN_IMSIC_TYPE == "read-only-1") {
+      if (MSTATEEN_IMSIC_TYPE == "read-only-1") {
         return 1;
       }
-      assert(MSTATEEN_IMSIC_TYPE == "rw", "Unhandled MSTATEEN_IMSIC_TYPE value");
       return 0;
   CONTEXT:
     long_name: scontext and hcontext access control
@@ -168,15 +152,11 @@ fields:
       if (MSTATEEN_CONTEXT_TYPE == "read-only-0" || MSTATEEN_CONTEXT_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(MSTATEEN_CONTEXT_TYPE == "rw", "Unhandled MSTATEEN_CONTEXT_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
-      if (MSTATEEN_CONTEXT_TYPE == "read-only-0") {
-        return 0;
-      } else if (MSTATEEN_CONTEXT_TYPE == "read-only-1") {
+      if (MSTATEEN_CONTEXT_TYPE == "read-only-1") {
         return 1;
       }
-      assert(MSTATEEN_CONTEXT_TYPE == "rw", "Unhandled MSTATEEN_CONTEXT_TYPE value");
       return 0;
   P1P13:
     long_name: hedelegh access control
@@ -217,15 +197,11 @@ fields:
       if (MSTATEEN_JVT_TYPE == "read-only-0" || MSTATEEN_JVT_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(MSTATEEN_JVT_TYPE == "rw", "Unhandled MSTATEEN_JVT_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
-      if (MSTATEEN_JVT_TYPE == "read-only-0") {
-        return 0;
-      } else if (MSTATEEN_JVT_TYPE == "read-only-1") {
+      if (MSTATEEN_JVT_TYPE == "read-only-1") {
         return 1;
       }
-      assert(MSTATEEN_JVT_TYPE == "rw", "Unhandled MSTATEEN_JVT_TYPE value");
       return 0;
   FCSR:
     long_name: fcsr access control

--- a/spec/std/isa/csr/sstateen0.yaml
+++ b/spec/std/isa/csr/sstateen0.yaml
@@ -71,7 +71,6 @@ fields:
       if (SSTATEEN_JVT_TYPE == "read-only-0" || SSTATEEN_JVT_TYPE == "read-only-1") {
         return CsrFieldType::RO;
       }
-      assert(SSTATEEN_JVT_TYPE == "rw", "Unhandled SSTATEEN_JVT_TYPE value");
       return CsrFieldType::RW;
     reset_value(): |
       if (SSTATEEN_JVT_TYPE == "read-only-0") {
@@ -79,7 +78,6 @@ fields:
       } else if (SSTATEEN_JVT_TYPE == "read-only-1") {
         return 1;
       }
-      assert(SSTATEEN_JVT_TYPE == "rw", "Unhandled SSTATEEN_JVT_TYPE value");
       return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].JVT == 1'b0){

--- a/spec/std/isa/csr/sstateen0.yaml
+++ b/spec/std/isa/csr/sstateen0.yaml
@@ -67,8 +67,20 @@ fields:
         name: Zcmt
     description: |
       The JVT bit controls access to the `jvt` CSR provided by the Zcmt extension.
-    type: RW
-    reset_value: UNDEFINED_LEGAL
+    type(): |
+      if (SSTATEEN_JVT_TYPE == "read-only-0" || SSTATEEN_JVT_TYPE == "read-only-1") {
+        return CsrFieldType::RO;
+      }
+      assert(SSTATEEN_JVT_TYPE == "rw", "Unhandled SSTATEEN_JVT_TYPE value");
+      return CsrFieldType::RW;
+    reset_value(): |
+      if (SSTATEEN_JVT_TYPE == "read-only-0") {
+        return 0;
+      } else if (SSTATEEN_JVT_TYPE == "read-only-1") {
+        return 1;
+      }
+      assert(SSTATEEN_JVT_TYPE == "rw", "Unhandled SSTATEEN_JVT_TYPE value");
+      return UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (CSR[mstateen0].JVT == 1'b0){
         return 0;


### PR DESCRIPTION
Wires the 13 `*STATEEN_*_TYPE` parameters into the fields they describe. Addresses #2451.

Each of these parameters offers `rw`, `read-only-0` and `read-only-1`, but nothing under `spec/std/isa/csr/` read any of them, and the fields hardcoded `type: RW`.

This follows the pattern already in `dcsr.yaml` for the `DCSR_*_TYPE` parameters, which have the same enum:

```yaml
    type(): |
      if (MSTATEEN_ENVCFG_TYPE == "read-only-0" || MSTATEEN_ENVCFG_TYPE == "read-only-1") {
        return CsrFieldType::RO;
      }
      assert(MSTATEEN_ENVCFG_TYPE == "rw", "Unhandled MSTATEEN_ENVCFG_TYPE value");
      return CsrFieldType::RW;
    reset_value(): |
      if (MSTATEEN_ENVCFG_TYPE == "read-only-0") {
        return 0;
      } else if (MSTATEEN_ENVCFG_TYPE == "read-only-1") {
        return 1;
      }
      assert(MSTATEEN_ENVCFG_TYPE == "rw", "Unhandled MSTATEEN_ENVCFG_TYPE value");
      return 0;
```

13 fields across 3 CSRs: 6 in `mstateen0`, 6 in `hstateen0`, 1 in `sstateen0`.

No behavior change in tree. The `rw` branch returns each field's existing reset value, `0` for `mstateen0` and `UNDEFINED_LEGAL` for `hstateen0` and `sstateen0`, and every config in tree sets these parameters to `rw`.

Testing: the three files parse and validate against `csr_schema.json`. I could not run the Ruby toolchain or the container locally on Windows, so I am relying on CI for the IDL compile.

Happy to close this if the answer to the first question in #2451 is that the current arrangement is deliberate.
