### PR TITLE
Fix EBADDEVENGINES node error

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -48,5 +48,6 @@ fi
 ''' }
 
 [settings]
+idiomatic_version_file_enable_tools = ["node"]
 ruby.compile = false
 ruby.default_packages_file = ".default-gems"


### PR DESCRIPTION
Sync node version with mise to avoid prek errors in CI.