### PR TITLE
docs(isa): descriptions should name the operands their instruction declares

### DIFF
--- a/spec/std/isa/inst/B/rev8.yaml
+++ b/spec/std/isa/inst/B/rev8.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: rev8
 long_name: Byte-reverse register (RV64 encoding)
 description: |
-  Reverses the order of the bytes in rs1.
+  Reverses the order of the bytes in xs1.
 
   [NOTE]
   The rev8 mnemonic corresponds to different instruction encodings in RV32 and RV64.

--- a/spec/std/isa/inst/C/c.addi4spn.yaml
+++ b/spec/std/isa/inst/C/c.addi4spn.yaml
@@ -8,9 +8,9 @@ kind: instruction
 name: c.addi4spn
 long_name: Add a zero-extended non-zero immediate, scaled by 4, to the stack pointer
 description: |
-  Adds a zero-extended non-zero immediate, scaled by 4, to the stack pointer, x2, and writes the result to rd'.
+  Adds a zero-extended non-zero immediate, scaled by 4, to the stack pointer, x2, and writes the result to xd'.
   This instruction is used to generate pointers to stack-allocated variables.
-  It expands to `addi rd', x2, nzuimm[9:2]`.
+  It expands to `addi xd', x2, nzuimm[9:2]`.
   C.ADDI4SPN is only valid when nzuimm &ne; 0; the code points with nzuimm=0 are reserved.
 definedBy:
   extension:

--- a/spec/std/isa/inst/C/c.sw.yaml
+++ b/spec/std/isa/inst/C/c.sw.yaml
@@ -11,7 +11,7 @@ description: |
   Stores a 32-bit value in register xs2 to memory.
   It computes an effective address by adding the zero-extended offset, scaled by 4,
   to the base address in register xs1.
-  It expands to `sw` `rs2, offset(xs1)`.
+  It expands to `sw` `xs2, offset(xs1)`.
 definedBy:
   extension:
     name: Zca

--- a/spec/std/isa/inst/V/vadd.vx.yaml
+++ b/spec/std/isa/inst/V/vadd.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vadd.vx
 long_name: Vector-scalar integer addition
 description: |
-  Adds elements from vector register vs2 to scalar register rs1 according to mask vm and stores results in vector register vd. Element width is determined by SEW setting.
+  Adds elements from vector register vs2 to scalar register xs1 according to mask vm and stores results in vector register vd. Element width is determined by SEW setting.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmseq.vx.yaml
+++ b/spec/std/isa/inst/V/vmseq.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmseq.vx
 long_name: Vector mask equal scalar
 description: |
-  Sets mask bits where elements in vs2 equal scalar in rs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 equal scalar in xs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmsgt.vx.yaml
+++ b/spec/std/isa/inst/V/vmsgt.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmsgt.vx
 long_name: Vector mask greater than signed scalar
 description: |
-  Sets mask bits where elements in vs2 are greater than scalar in rs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 are greater than scalar in xs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmsgtu.vx.yaml
+++ b/spec/std/isa/inst/V/vmsgtu.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmsgtu.vx
 long_name: Vector mask greater than unsigned scalar
 description: |
-  Sets mask bits where elements in vs2 are greater than scalar in rs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 are greater than scalar in xs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmsle.vx.yaml
+++ b/spec/std/isa/inst/V/vmsle.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmsle.vx
 long_name: Vector mask less than or equal signed scalar
 description: |
-  Sets mask bits where elements in vs2 are less than or equal to scalar in rs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 are less than or equal to scalar in xs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmsleu.vx.yaml
+++ b/spec/std/isa/inst/V/vmsleu.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmsleu.vx
 long_name: Vector mask less than or equal unsigned scalar
 description: |
-  Sets mask bits where elements in vs2 are less than or equal to scalar in rs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 are less than or equal to scalar in xs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmslt.vx.yaml
+++ b/spec/std/isa/inst/V/vmslt.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmslt.vx
 long_name: Vector mask less than signed scalar
 description: |
-  Sets mask bits where elements in vs2 are less than scalar in rs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 are less than scalar in xs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmsltu.vx.yaml
+++ b/spec/std/isa/inst/V/vmsltu.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmsltu.vx
 long_name: Vector mask less than unsigned scalar
 description: |
-  Sets mask bits where elements in vs2 are less than scalar in rs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 are less than scalar in xs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vmsne.vx.yaml
+++ b/spec/std/isa/inst/V/vmsne.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vmsne.vx
 long_name: Vector mask not equal scalar
 description: |
-  Sets mask bits where elements in vs2 do not equal scalar in rs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+  Sets mask bits where elements in vs2 do not equal scalar in xs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vsetivli.yaml
+++ b/spec/std/isa/inst/V/vsetivli.yaml
@@ -7,7 +7,7 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: vsetivli
 long_name: Vector Set Vector Type Immediate and Vector Length Immediate
-description: Set the vtype and vl CSRs, and write the new value of vl into rd.
+description: Set the vtype and vl CSRs, and write the new value of vl into xd.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vsetvl.yaml
+++ b/spec/std/isa/inst/V/vsetvl.yaml
@@ -7,7 +7,7 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: vsetvl
 long_name: Vector Set Vector Type and Vector Length
-description: Set the vtype and vl CSRs, and write the new value of vl into rd.
+description: Set the vtype and vl CSRs, and write the new value of vl into xd.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vsll.vx.yaml
+++ b/spec/std/isa/inst/V/vsll.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vsll.vx
 long_name: Vector shift left logical scalar
 description: |
-  Performs logical left shift on elements from vs2 using shift amount from rs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
+  Performs logical left shift on elements from vs2 using shift amount from xs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vsra.vx.yaml
+++ b/spec/std/isa/inst/V/vsra.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vsra.vx
 long_name: Vector shift right arithmetic scalar
 description: |
-  Performs arithmetic right shift on elements from vs2 using shift amount from rs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
+  Performs arithmetic right shift on elements from vs2 using shift amount from xs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vsrl.vx.yaml
+++ b/spec/std/isa/inst/V/vsrl.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vsrl.vx
 long_name: Vector shift right logical scalar
 description: |
-  Performs logical right shift on elements from vs2 using shift amount from rs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
+  Performs logical right shift on elements from vs2 using shift amount from xs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
 definedBy:
   extension:
     name: Zvl32b

--- a/spec/std/isa/inst/V/vsub.vx.yaml
+++ b/spec/std/isa/inst/V/vsub.vx.yaml
@@ -8,7 +8,7 @@ kind: instruction
 name: vsub.vx
 long_name: Vector-scalar integer subtraction
 description: |
-  Subtracts elements of vs2 from scalar rs1 according to mask vm and stores results in vd. Element width is determined by SEW setting.
+  Subtracts elements of vs2 from scalar xs1 according to mask vm and stores results in vd. Element width is determined by SEW setting.
 definedBy:
   extension:
     name: Zvl32b

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -11732,9 +11732,9 @@ Encoding::
 ....
 
 Description::
-Adds a zero-extended non-zero immediate, scaled by 4, to the stack pointer, x2, and writes the result to rd'.
+Adds a zero-extended non-zero immediate, scaled by 4, to the stack pointer, x2, and writes the result to xd'.
 This instruction is used to generate pointers to stack-allocated variables.
-It expands to `addi rd', x2, nzuimm[9:2]`.
+It expands to `addi xd', x2, nzuimm[9:2]`.
 C.ADDI4SPN is only valid when nzuimm ≠ 0; the code points with nzuimm=0 are reserved.
 
 
@@ -15025,7 +15025,7 @@ Description::
 Stores a 32-bit value in register xs2 to memory.
 It computes an effective address by adding the zero-extended offset, scaled by 4,
 to the base address in register xs1.
-It expands to xref:insts:sw.adoc#udb:doc:inst:sw[sw] `rs2, offset(xs1)`.
+It expands to xref:insts:sw.adoc#udb:doc:inst:sw[sw] `xs2, offset(xs1)`.
 
 
 Decode Variables::
@@ -34262,7 +34262,7 @@ RV64::
 ....
 
 Description::
-Reverses the order of the bytes in rs1.
+Reverses the order of the bytes in xs1.
 
 [NOTE]
 The rev8 mnemonic corresponds to different instruction encodings in RV32 and RV64.
@@ -40528,7 +40528,7 @@ Encoding::
 ....
 
 Description::
-Adds elements from vector register vs2 to scalar register rs1 according to mask vm and stores results in vector register vd. Element width is determined by SEW setting.
+Adds elements from vector register vs2 to scalar register xs1 according to mask vm and stores results in vector register vd. Element width is determined by SEW setting.
 
 
 Decode Variables::
@@ -59263,7 +59263,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 equal scalar in rs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 equal scalar in xs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -59369,7 +59369,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 are greater than scalar in rs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 are greater than scalar in xs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -59475,7 +59475,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 are greater than scalar in rs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 are greater than scalar in xs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -59686,7 +59686,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 are less than or equal to scalar in rs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 are less than or equal to scalar in xs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -59845,7 +59845,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 are less than or equal to scalar in rs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 are less than or equal to scalar in xs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -59951,7 +59951,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 are less than scalar in rs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 are less than scalar in xs1 (signed), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -60057,7 +60057,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 are less than scalar in rs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 are less than scalar in xs1 (unsigned), according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -60216,7 +60216,7 @@ Encoding::
 ....
 
 Description::
-Sets mask bits where elements in vs2 do not equal scalar in rs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
+Sets mask bits where elements in vs2 do not equal scalar in xs1, according to mask vm, and stores results in vd. Element width is determined by SEW setting. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -64430,7 +64430,7 @@ Encoding::
 ....
 
 Description::
-Set the vtype and vl CSRs, and write the new value of vl into rd.
+Set the vtype and vl CSRs, and write the new value of vl into xd.
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
@@ -64481,7 +64481,7 @@ Encoding::
 ....
 
 Description::
-Set the vtype and vl CSRs, and write the new value of vl into rd.
+Set the vtype and vl CSRs, and write the new value of vl into xd.
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
@@ -65320,7 +65320,7 @@ Encoding::
 ....
 
 Description::
-Performs logical left shift on elements from vs2 using shift amount from rs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
+Performs logical left shift on elements from vs2 using shift amount from xs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -67590,7 +67590,7 @@ Encoding::
 ....
 
 Description::
-Performs arithmetic right shift on elements from vs2 using shift amount from rs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
+Performs arithmetic right shift on elements from vs2 using shift amount from xs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -67749,7 +67749,7 @@ Encoding::
 ....
 
 Description::
-Performs logical right shift on elements from vs2 using shift amount from rs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
+Performs logical right shift on elements from vs2 using shift amount from xs1, according to mask vm, and stores results in vd. Only the low lg2(SEW) bits of the shift amount are used. Supports vector masking and follows vector tail policy.
 
 
 Decode Variables::
@@ -71537,7 +71537,7 @@ Encoding::
 ....
 
 Description::
-Subtracts elements of vs2 from scalar rs1 according to mask vm and stores results in vd. Element width is determined by SEW setting.
+Subtracts elements of vs2 from scalar xs1 according to mask vm and stores results in vd. Element width is determined by SEW setting.
 
 
 Decode Variables::


### PR DESCRIPTION
Eighteen instruction descriptions name an operand the file never declares. `vadd.vx` says "scalar register `rs1`" while its encoding declares `xs1` and its assembly is `vd, vs2, xs1, vm`. `c.sw` is the clearest, using both spellings for the same operand three words apart: "Stores a 32-bit value in register `xs2` ... It expands to `sw` `rs2, offset(xs1)`".

This is not a convention change. Both spellings are legitimate: across the 1,544 instruction files, `xs1` is a declared encoding variable in 878 and `rs1` in 116, and a file that declares `rs1` and says `rs1` is consistent and untouched. Only the mismatch is fixed.

Descriptions only, 19 lines. Every token was confirmed to occur the same number of times in the file as in its description before editing, so no encoding variable, `assembly` string or `operation()` body changes. All 18 still validate against `inst_schema.json`. `c.addi4spn` keeps its RVC prime and gains the prefix, `rd'` to `xd'`, matching `c.beqz`, `c.bnez`, `c.not` and `c.mul`.

The sweep found 33 files in this shape. Three are correct and left alone: `fround.q`, `froundnx.q` and `fround.s` name the `rs2` encoding field at bits 24-20, and the match strings agree. Eleven need a decision rather than a rename, and are enumerated in the issue, along with a separate defect in `vsub.vx` whose description states `vrsub.vx`'s semantics.

Closes #2458
