### PR TITLE
fix(zalrsc): sign-extend the lr.w result on RV64

### DIFF
--- a/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zalrsc/lr.SIZE.AQRL.layout
@@ -147,11 +147,7 @@ operation(): |
 
   XReg load_value = load_reserved(<%= current_size[:load_reserved_bits] %>, virtual_address, aq, rl, $encoding);
 <%- if size == "w" -%>
-  if (xlen() == 64) {
-    X[xd] = load_value;
-  } else {
-    X[xd] = sext(load_value[31:0], 32);
-  }
+  X[xd] = sext(load_value[31:0], 32);
 <%- else -%>
   X[xd] = load_value;
 <%- end -%>

--- a/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aq.yaml
@@ -103,8 +103,4 @@ operation(): |
   }
 
   XReg load_value = load_reserved(32, virtual_address, aq, rl, $encoding);
-  if (xlen() == 64) {
-    X[xd] = load_value;
-  } else {
-    X[xd] = sext(load_value[31:0], 32);
-  }
+  X[xd] = sext(load_value[31:0], 32);

--- a/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.aqrl.yaml
@@ -103,8 +103,4 @@ operation(): |
   }
 
   XReg load_value = load_reserved(32, virtual_address, aq, rl, $encoding);
-  if (xlen() == 64) {
-    X[xd] = load_value;
-  } else {
-    X[xd] = sext(load_value[31:0], 32);
-  }
+  X[xd] = sext(load_value[31:0], 32);

--- a/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.rl.yaml
@@ -103,8 +103,4 @@ operation(): |
   }
 
   XReg load_value = load_reserved(32, virtual_address, aq, rl, $encoding);
-  if (xlen() == 64) {
-    X[xd] = load_value;
-  } else {
-    X[xd] = sext(load_value[31:0], 32);
-  }
+  X[xd] = sext(load_value[31:0], 32);

--- a/spec/std/isa/inst/Zalrsc/lr.w.yaml
+++ b/spec/std/isa/inst/Zalrsc/lr.w.yaml
@@ -103,8 +103,4 @@ operation(): |
   }
 
   XReg load_value = load_reserved(32, virtual_address, aq, rl, $encoding);
-  if (xlen() == 64) {
-    X[xd] = load_value;
-  } else {
-    X[xd] = sext(load_value[31:0], 32);
-  }
+  X[xd] = sext(load_value[31:0], 32);


### PR DESCRIPTION
The `size == "w"` path in `lr.SIZE.AQRL.layout` had its two branches swapped: `sext()` was called on the RV32 path, where it is a no-op because it returns early when `first_extended_bit == MXLEN`, and the RV64 path assigned `load_value` directly. Since `load_reserved(32, ...)` returns a zero-extended `Bits<32>`, `lr.w` put a zero-extended word in `xd` on RV64.

That contradicts the instruction's own description ("places the sign-extended value in xd") and the Zalrsc spec: "For RV64, LR.W and SC.W sign-extend the value placed in rd." Removing the `xlen()` check and always calling `sext(load_value[31:0], 32)` is correct on both bases and matches how `lw` is written.

Part 1 of #2432.