### PR TITLE
fix(param): populate long_name for LRSC, MISA, and trap parameters

### DIFF
--- a/spec/std/isa/param/LRSC_FAIL_ON_NON_EXACT_LRSC.yaml
+++ b/spec/std/isa/param/LRSC_FAIL_ON_NON_EXACT_LRSC.yaml
@@ -10,7 +10,7 @@ description: |
   Whether or not a Store Conditional fails if its physical address and size do not
   exactly match the physical address and size of the last Load Reserved in program order
   (independent of whether or not the SC is in the current reservation set)
-long_name: TODO
+long_name: "LR/SC failure on non-exact address match"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/LRSC_FAIL_ON_NON_EXACT_LRSC.yaml
+++ b/spec/std/isa/param/LRSC_FAIL_ON_NON_EXACT_LRSC.yaml
@@ -10,7 +10,7 @@ description: |
   Whether or not a Store Conditional fails if its physical address and size do not
   exactly match the physical address and size of the last Load Reserved in program order
   (independent of whether or not the SC is in the current reservation set)
-long_name: "LR/SC failure on non-exact address match"
+long_name: "Store Conditional fails on inexact match of address and size of Load Reserved"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/LRSC_FAIL_ON_VA_SYNONYM.yaml
+++ b/spec/std/isa/param/LRSC_FAIL_ON_VA_SYNONYM.yaml
@@ -9,7 +9,7 @@ name: LRSC_FAIL_ON_VA_SYNONYM
 description: |
   Whether or not an `sc.l`/`sc.d` will fail if its VA does not match the VA of the prior
   `lr.l`/`lr.d`, even if the physical address of the SC and LR are the same
-long_name: "LR/SC failure on VA synonym mismatch"
+long_name: "Store Conditional fails on virtual address mismatch of Load Reserved"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/LRSC_FAIL_ON_VA_SYNONYM.yaml
+++ b/spec/std/isa/param/LRSC_FAIL_ON_VA_SYNONYM.yaml
@@ -9,7 +9,7 @@ name: LRSC_FAIL_ON_VA_SYNONYM
 description: |
   Whether or not an `sc.l`/`sc.d` will fail if its VA does not match the VA of the prior
   `lr.l`/`lr.d`, even if the physical address of the SC and LR are the same
-long_name: TODO
+long_name: "LR/SC failure on VA synonym mismatch"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/LRSC_MISALIGNED_BEHAVIOR.yaml
+++ b/spec/std/isa/param/LRSC_MISALIGNED_BEHAVIOR.yaml
@@ -9,10 +9,10 @@ name: LRSC_MISALIGNED_BEHAVIOR
 description: |
   What to do when an LR/SC address is misaligned and MISALIGNED_AMO == false.
 
-    * 'always raise misaligned exception': self-explainitory
-    * 'always raise access fault': self-explainitory
-    * 'custom': Custom behavior; misaligned LR/SC may sometimes raise a misaligned exception and sometimes raise a access fault. Will lead to an 'unpredictable' call on any misaligned LR/SC access
-long_name: TODO
+    * 'always raise misaligned exception': self-explanatory
+    * 'always raise access fault': self-explanatory
+    * 'custom': Custom behavior; misaligned LR/SC may sometimes raise a misaligned exception and sometimes raise an access fault. Will lead to an 'unpredictable' call on any misaligned LR/SC access
+long_name: "Misaligned LR/SC behavior"
 schema:
   type: string
   enum:

--- a/spec/std/isa/param/LRSC_RESERVATION_STRATEGY.yaml
+++ b/spec/std/isa/param/LRSC_RESERVATION_STRATEGY.yaml
@@ -13,7 +13,7 @@ description: |
     * "reserve naturally-aligned 128-byte region": Always reserve the 128-byte block containing the LR/SC address
     * "reserve exactly enough to cover the access": Always reserve exactly the LR/SC access, and no more
     * "custom": Custom behavior, leading to an 'unpredictable' call on any LR/SC
-long_name: TODO
+long_name: "LR/SC reservation set strategy"
 schema:
   type: string
   enum:

--- a/spec/std/isa/param/MUTABLE_MISA_A.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_A.yaml
@@ -9,7 +9,7 @@ name: MUTABLE_MISA_A
 description: |
   When the `A` extensions is supported, indicates whether or not
   the extension can be disabled in the `misa.A` bit.
-long_name: TODO
+long_name: "`misa.A` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_B.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_B.yaml
@@ -8,7 +8,7 @@ kind: parameter
 name: MUTABLE_MISA_B
 description: Indicates whether or not the `B` extension can be disabled with the
   `misa.B` bit.
-long_name: TODO
+long_name: "`misa.B` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_C.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_C.yaml
@@ -11,7 +11,7 @@ description:
   `misa.C` bit.
 
   "
-long_name: TODO
+long_name: "`misa.C` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_D.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_D.yaml
@@ -11,7 +11,7 @@ description:
   `misa.D` bit.
 
   "
-long_name: TODO
+long_name: "`misa.D` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_F.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_F.yaml
@@ -11,7 +11,7 @@ description:
   `misa.F` bit.
 
   "
-long_name: TODO
+long_name: "`misa.F` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_M.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_M.yaml
@@ -11,7 +11,7 @@ description:
   `misa.M` bit.
 
   "
-long_name: TODO
+long_name: "`misa.M` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_Q.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_Q.yaml
@@ -11,7 +11,7 @@ description:
   `misa.Q` bit.
 
   "
-long_name: TODO
+long_name: "`misa.Q` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_U.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_U.yaml
@@ -11,7 +11,7 @@ description:
   `misa.U` bit.
 
   "
-long_name: TODO
+long_name: "`misa.U` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/MUTABLE_MISA_V.yaml
+++ b/spec/std/isa/param/MUTABLE_MISA_V.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: MUTABLE_MISA_V
 description: Indicates whether or not the `V` extension can be disabled with the `misa.V` bit.
-long_name: TODO
+long_name: "`misa.V` mutability"
 schema:
   type: boolean
 definedBy:

--- a/spec/std/isa/param/TRAP_ON_ECALL_FROM_S.yaml
+++ b/spec/std/isa/param/TRAP_ON_ECALL_FROM_S.yaml
@@ -11,7 +11,7 @@ description: |
 
   The spec states that implementations may handle ECALLs transparently
   without raising a trap, in which case the EEI must provide a builtin.
-long_name: TODO
+long_name: "Trap on ECALL from S-mode"
 schema:
   type: boolean
   default: true

--- a/spec/std/isa/param/TRAP_ON_ECALL_FROM_U.yaml
+++ b/spec/std/isa/param/TRAP_ON_ECALL_FROM_U.yaml
@@ -11,7 +11,7 @@ description: |
 
   The spec states that implementations may handle ECALLs transparently
   without raising a trap, in which case the EEI must provide a builtin.
-long_name: TODO
+long_name: "Trap on ECALL from U-mode"
 schema:
   type: boolean
   default: true

--- a/spec/std/isa/param/TRAP_ON_ECALL_FROM_VS.yaml
+++ b/spec/std/isa/param/TRAP_ON_ECALL_FROM_VS.yaml
@@ -11,7 +11,7 @@ description: |
 
   The spec states that implementations may handle ECALLs transparently
   without raising a trap, in which case the EEI must provide a builtin.
-long_name: TODO
+long_name: "Trap on ECALL from VS-mode"
 schema:
   type: boolean
   default: true

--- a/spec/std/isa/param/TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY.yaml
+++ b/spec/std/isa/param/TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY.yaml
@@ -17,7 +17,7 @@ description: |
 
   TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY has no effect when
   some virtual translation mode is supported.
-long_name: TODO
+long_name: "Trap on SFENCE.VMA when satp.MODE is read-only"
 schema:
   type: boolean
   default: false


### PR DESCRIPTION
## Summary

Populate missing `long_name` metadata for 17 ISA parameter definitions under `spec/std/isa/param/`.

The changes cover:

- 9 `MUTABLE_MISA_*` parameters
- 3 `TRAP_ON_ECALL_FROM_*` parameters
- `TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY`
- 4 `LRSC_*` parameters

These replace placeholder `long_name: TODO` values with concise, human-readable names based on the parameter descriptions and existing RISC-V terminology used in the repository.

This is a focused batch of the remaining `long_name: TODO` parameters tracked by #2241. The selected parameters were checked against currently open contributions to avoid overlap.

## Validation

- `./do test:schema` passes
- `./do test:udb:unit` passes
- `git diff --check` passes
- Only the 17 parameter YAML files are modified
- No unrelated or generated files are changed

Refs #2241