### PR TITLE
fix(csr): forward mcyclecfgh and minstretcfgh accesses to their parent CSRs

### DIFF
--- a/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
@@ -27,6 +27,9 @@ fields:
         name: Sm
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[mcyclecfg].MINH = csr_value.MINH;
+      return csr_value.MINH;
 
   SINH:
     alias: mcyclecfg.SINH
@@ -37,6 +40,9 @@ fields:
         name: S
     description: If set, then counting of events in S/HS-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[mcyclecfg].SINH = csr_value.SINH;
+      return csr_value.SINH;
 
   UINH:
     alias: mcyclecfg.UINH
@@ -47,6 +53,9 @@ fields:
         name: U
     description: If set, then counting of events in U-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[mcyclecfg].UINH = csr_value.UINH;
+      return csr_value.UINH;
 
   VSINH:
     alias: mcyclecfg.VSINH
@@ -57,6 +66,9 @@ fields:
         name: H
     description: If set, then counting of events in VS-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[mcyclecfg].VSINH = csr_value.VSINH;
+      return csr_value.VSINH;
 
   VUINH:
     alias: mcyclecfg.VUINH
@@ -67,3 +79,8 @@ fields:
         name: H
     description: If set, then counting of events in VU-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[mcyclecfg].VUINH = csr_value.VUINH;
+      return csr_value.VUINH;
+sw_read(): |
+  return $bits(CSR[mcyclecfg])[63:32];

--- a/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
@@ -11,8 +11,10 @@ writable: true
 priv_mode: M
 length: 32
 definedBy:
-  extension:
-    name: Smcntrpmf
+  allOf:
+    - xlen: 32
+    - extension:
+        name: Smcntrpmf
 description: |
   Upper 32 bits of the 64-bit `mcyclecfg` CSR, used for RV32 systems to access
   the privilege mode filtering inhibit bits.

--- a/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/mcyclecfgh.yaml
@@ -30,7 +30,7 @@ fields:
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
     sw_write(csr_value): |
-      CSR[mcyclecfg].MINH = csr_value.MINH;
+      CSR[mcyclecfg][62] = csr_value.MINH;
       return csr_value.MINH;
 
   SINH:

--- a/spec/std/isa/csr/Smcntrpmf/minstretcfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/minstretcfgh.yaml
@@ -11,8 +11,10 @@ writable: true
 priv_mode: M
 length: 32
 definedBy:
-  extension:
-    name: Smcntrpmf
+  allOf:
+    - xlen: 32
+    - extension:
+        name: Smcntrpmf
 description: |
   Upper 32 bits of the 64-bit `minstretcfg` CSR, used on RV32 systems to access
   privilege mode filtering inhibit bits for instruction retirement.

--- a/spec/std/isa/csr/Smcntrpmf/minstretcfgh.yaml
+++ b/spec/std/isa/csr/Smcntrpmf/minstretcfgh.yaml
@@ -27,6 +27,9 @@ fields:
         name: Sm
     description: If set, then counting of events in M-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[minstretcfg].MINH = csr_value.MINH;
+      return csr_value.MINH;
 
   SINH:
     alias: minstretcfg.SINH
@@ -37,6 +40,9 @@ fields:
         name: S
     description: If set, then counting of events in S/HS-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[minstretcfg].SINH = csr_value.SINH;
+      return csr_value.SINH;
 
   UINH:
     alias: minstretcfg.UINH
@@ -47,6 +53,9 @@ fields:
         name: U
     description: If set, then counting of events in U-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[minstretcfg].UINH = csr_value.UINH;
+      return csr_value.UINH;
 
   VSINH:
     alias: minstretcfg.VSINH
@@ -57,6 +66,9 @@ fields:
         name: H
     description: If set, then counting of events in VS-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[minstretcfg].VSINH = csr_value.VSINH;
+      return csr_value.VSINH;
 
   VUINH:
     alias: minstretcfg.VUINH
@@ -67,3 +79,8 @@ fields:
         name: H
     description: If set, then counting of events in VU-mode is inhibited.
     reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      CSR[minstretcfg].VUINH = csr_value.VUINH;
+      return csr_value.VUINH;
+sw_read(): |
+  return $bits(CSR[minstretcfg])[63:32];


### PR DESCRIPTION
`mcyclecfgh` and `minstretcfgh` declare `alias` on every field but have no forwarding, so accesses hit the local CSR object rather than the upper half of the 64-bit parent. This adds a CSR-level `sw_read()` and per-field `sw_write()` in the shape `mstateen0h` already uses.

Same defect #2377 reports for `menvcfgh`. Following the count I posted on #781: of the 104 high-half CSRs carrying aliases, 71 already have a CSR-level `sw_read()` and 33 do not, 29 of them generated from `mhpmeventNh.layout`. This takes two of the four hand-written ones and deliberately leaves `menvcfgh` to #2377 and `mstatush` until #2427 merges.
