### PR TITLE
fix(generators): interpret UDB definedBy format in extension filtering

### DIFF
--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -17,9 +17,28 @@ LOGGER = logging.getLogger(__name__)
 def check_requirement(req, exts):
     if isinstance(req, str):
         return req in exts
-    elif isinstance(req, dict) and "name" in req:
-        # If it has a name field, just match the extension name and ignore version
-        return req["name"] in exts
+    elif isinstance(req, dict):
+        if "extension" in req and req["extension"] is not None:
+            # UDB wraps requirements in an {extension: ...} term
+            return check_requirement(req["extension"], exts)
+        if "anyOf" in req:
+            alternatives = req["anyOf"] if isinstance(req["anyOf"], list) else [req["anyOf"]]
+            return any(check_requirement(alt, exts) for alt in alternatives)
+        if "oneOf" in req:
+            alternatives = req["oneOf"] if isinstance(req["oneOf"], list) else [req["oneOf"]]
+            return any(check_requirement(alt, exts) for alt in alternatives)
+        if "allOf" in req:
+            required = req["allOf"] if isinstance(req["allOf"], list) else [req["allOf"]]
+            return all(check_requirement(r, exts) for r in required)
+        if "not" in req and isinstance(req["not"], dict):
+            # A "not" term requires the nested requirement to be absent
+            return not check_requirement(req["not"], exts)
+        if isinstance(req.get("name"), str):
+            # If it has a name field, just match the extension name and ignore version
+            return req["name"] in exts
+        if "xlen" in req or "param" in req:
+            # xlen and param terms are not extension requirements
+            return True
     return False
 
 
@@ -134,6 +153,10 @@ def parse_extension_requirements(extensions_spec):
             return lambda enabled_exts: any(ext_part in enabled_exts for ext_part in ext_parts)
         return lambda exts: extension in exts
 
+    if "extension" in extensions_spec and extensions_spec["extension"] is not None:
+        # UDB wraps requirements in an {extension: ...} term
+        extensions_spec = extensions_spec["extension"]
+
     # Handle complex cases with allOf/oneOf/anyOf
     if "allOf" in extensions_spec:
         required = extensions_spec["allOf"]
@@ -149,14 +172,7 @@ def parse_extension_requirements(extensions_spec):
             alternatives = [alternatives]
 
         # Process each alternative, which could be a string or a dict with name/version
-        def check_alternative_one_of(alt, exts):
-            if isinstance(alt, str):
-                return alt in exts
-            elif isinstance(alt, dict) and "name" in alt:
-                return alt["name"] in exts
-            return False
-
-        return lambda exts: any(check_alternative_one_of(alt, exts) for alt in alternatives)
+        return lambda exts: any(check_requirement(alt, exts) for alt in alternatives)
 
     # Handle anyOf case (most common in the error output)
     if "anyOf" in extensions_spec:
@@ -165,23 +181,10 @@ def parse_extension_requirements(extensions_spec):
             alternatives = [alternatives]
 
         # Process each alternative, which could be a string, dict with name/version, or nested allOf
-        def check_alternative(alt, exts):
-            if isinstance(alt, str):
-                return alt in exts
-            elif isinstance(alt, dict):
-                if "allOf" in alt:
-                    reqs = alt["allOf"]
-                    if isinstance(reqs, str):
-                        reqs = [reqs]
-                    return all(check_requirement(r, exts) for r in reqs)
-                elif "name" in alt:
-                    return alt["name"] in exts
-            return False
-
-        return lambda exts: any(check_alternative(alt, exts) for alt in alternatives)
+        return lambda exts: any(check_requirement(alt, exts) for alt in alternatives)
 
     # Handle direct name/version specification
-    if "name" in extensions_spec and "version" in extensions_spec:
+    if isinstance(extensions_spec.get("name"), str):
         extension = extensions_spec["name"]
         # We don't actually check the version, just the extension name
         return lambda exts: extension in exts

--- a/backends/generators/test_generator.py
+++ b/backends/generators/test_generator.py
@@ -1,0 +1,93 @@
+import pytest
+from generator import parse_extension_requirements
+
+
+@pytest.mark.parametrize(
+    "defined_by,enabled,expected",
+    [
+        # Single extension via the nested {extension: {name}} form used throughout UDB
+        ({"extension": {"name": "I"}}, ["I"], True),
+        ({"extension": {"name": "I"}}, ["M"], False),
+        # {allOf: [xlen, extension]} form: the xlen term is neutral
+        ({"allOf": [{"xlen": 64}, {"extension": {"name": "Zbb"}}]}, ["Zbb"], True),
+        ({"allOf": [{"xlen": 64}, {"extension": {"name": "Zbb"}}]}, ["I"], False),
+        # {allOf: [extension, param]} form: the param term is neutral
+        (
+            {"allOf": [{"extension": {"name": "I"}}, {"param": {"name": "MXLEN", "equal": 64}}]},
+            ["I"],
+            True,
+        ),
+        # extension.anyOf: any alternative enables the instruction
+        ({"extension": {"anyOf": [{"name": "I"}, {"name": "Zilsd"}]}}, ["I"], True),
+        ({"extension": {"anyOf": [{"name": "I"}, {"name": "Zilsd"}]}}, ["Zilsd"], True),
+        ({"extension": {"anyOf": [{"name": "I"}, {"name": "Zilsd"}]}}, ["M"], False),
+        # extension.oneOf behaves as an OR for filtering purposes
+        ({"extension": {"oneOf": [{"name": "A"}, {"name": "B"}]}}, ["B"], True),
+        ({"extension": {"oneOf": [{"name": "A"}, {"name": "B"}]}}, ["C"], False),
+        # extension.allOf: every named extension must be enabled
+        ({"extension": {"allOf": [{"name": "A"}, {"name": "B"}]}}, ["A", "B"], True),
+        ({"extension": {"allOf": [{"name": "A"}, {"name": "B"}]}}, ["A"], False),
+        # extension.allOf with a "not" term: zext.h requires Zbb and not Zbkb
+        (
+            {"extension": {"allOf": [{"name": "Zbb"}, {"not": {"name": "Zbkb"}}]}},
+            ["Zbb"],
+            True,
+        ),
+        (
+            {"extension": {"allOf": [{"name": "Zbb"}, {"not": {"name": "Zbkb"}}]}},
+            ["Zbb", "Zbkb"],
+            False,
+        ),
+        # extension with an anyOf alongside a null name (custom data form)
+        (
+            {"extension": {"name": None, "anyOf": [{"name": "Zcmt"}, {"name": "Xqccmt"}]}},
+            ["Xqccmt"],
+            True,
+        ),
+        # top-level anyOf with a nested allOf alternative
+        (
+            {
+                "anyOf": [
+                    {"allOf": [{"xlen": 64}, {"extension": {"name": "Zca"}}]},
+                    {"extension": {"name": "Zclsd"}},
+                ]
+            },
+            ["Zclsd"],
+            True,
+        ),
+        (
+            {
+                "anyOf": [
+                    {"allOf": [{"xlen": 64}, {"extension": {"name": "Zca"}}]},
+                    {"extension": {"name": "Zclsd"}},
+                ]
+            },
+            ["Zca"],
+            True,
+        ),
+        (
+            {
+                "anyOf": [
+                    {"allOf": [{"xlen": 64}, {"extension": {"name": "Zca"}}]},
+                    {"extension": {"name": "Zclsd"}},
+                ]
+            },
+            ["I"],
+            False,
+        ),
+        # Plain {name} and {name, version} forms
+        ({"name": "I"}, ["I"], True),
+        ({"name": "I", "version": ">= 2.0"}, ["I"], True),
+        ({"name": "I"}, ["M"], False),
+        # Legacy plain string forms
+        ("I", ["I"], True),
+        ("I", ["M"], False),
+        ("RV64I", ["I"], True),
+        ("RV64I", ["M"], False),
+        # None means the data is malformed and should never match
+        (None, ["I"], False),
+    ],
+)
+def test_parse_extension_requirements(defined_by, enabled, expected):
+    predicate = parse_extension_requirements(defined_by)
+    assert predicate(enabled) is expected


### PR DESCRIPTION
Fixes #2344

### Summary

`parse_extension_requirements()` in `backends/generators/generator.py` expected `definedBy` to be a plain string or a flat dict (`{allOf: [...]}`, `{anyOf: [...]}`, `{name, version}`), but every instruction and CSR in `spec/std/isa` uses the nested UDB format, e.g. `{extension: {name: X}}` or `{allOf: [{xlen: N}, {extension: {name: Y}}]}`.

This broke the documented `--extensions` filter of the Go, C-header, and SystemVerilog generators in both directions:

- `{extension: {name: X}}` (1212 instructions / 150 CSRs) fell through to the permissive default, so instructions were included even when their extension was not in `--extensions`.
- `{allOf: [{xlen}, {extension: ...}]}` (139 instructions / 246 CSRs) always failed, so RV64-only instructions such as `ctzw` and `clzw` were dropped.
- `{extension: {anyOf: [...]}}` and top-level `anyOf` with nested `allOf` were likewise misclassified.

### Changes

- Rewrite `check_requirement()` to interpret the nested UDB structure recursively: `extension.name` must be in the enabled set, `anyOf`/`oneOf` behave as OR, `allOf` as AND, `not` negates (used by `zext.h`), and `xlen`/`param` terms are neutral.
- Unwrap the `{extension: ...}` term in `parse_extension_requirements()` and use the recursive helper uniformly for `allOf`/`oneOf`/`anyOf`; the plain `{name}` form is now also recognized.
- Add `backends/generators/test_generator.py` with parametrized unit tests covering each `definedBy` shape present in the repository.

### Validation

- New unit tests: 26 passed.
- End-to-end: `go_generator.py --extensions=Zbb --arch=RV64` now emits exactly the 24 Zbb instructions (previously 1234, with `ctzw`/`clzw`/`cpopw`/`zext.h` missing).
- Cross-checked the filter against every instruction (1377) and CSR (396) in `spec/std/isa` for multiple extension combinations with zero mismatches.
- `ruff format`/`ruff check` clean; all pre-commit hooks pass.
- `./bin/regress -n regress-gen-go`, `regress-gen-c-header`, `regress-gen-sverilog` all pass.

