### PR TITLE
fix(ruby): Preserve signedness through pruning and rendering to C++

### DIFF
--- a/backends/cpp_hart_gen/CMakeLists.txt
+++ b/backends/cpp_hart_gen/CMakeLists.txt
@@ -261,6 +261,7 @@ add_dependencies(test_bits_random ${RANDOM_TESTS})
 
 add_executable(test_util
   ${CMAKE_SOURCE_DIR}/test/test_util.cpp
+  ${CMAKE_SOURCE_DIR}/src/NotificationHandler.cpp
 )
 target_include_directories(test_util PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(test_util PRIVATE hart Catch2::Catch2WithMain)
@@ -304,6 +305,7 @@ include(CTest)
 include(Catch)
 catch_discover_tests(test_bits_directed)
 catch_discover_tests(test_regfile)
+catch_discover_tests(test_util)
 
 foreach (random_test IN LISTS RANDOM_TESTS)
   catch_discover_tests(${random_test})

--- a/backends/cpp_hart_gen/cpp/test/test_util.cpp
+++ b/backends/cpp_hart_gen/cpp/test/test_util.cpp
@@ -1,6 +1,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <udb/defines.hpp>
+#include <udb/hart_factory.hxx>
+#include <udb/iss_soc_model.hpp>
 #include <udb/util.hpp>
 
 using namespace udb;
@@ -10,4 +12,41 @@ TEST_CASE("concat", "[util]") {
   Bits<4> b{0x2};
   Bits<4> c{0x3};
   REQUIRE(concat(a, b, c) == 0x123_b);
+}
+
+// Regression test for highest_set_bit(0), the return code from which,
+// when cast with `$signed`, needs to be -1.
+static const std::string cfg_yaml = R"(
+$schema: https://riscv.org/udb/schemas/config_schema-0.1.0.json
+kind: architecture configuration
+type: fully configured
+name: rv64-highest-set-bit-test
+description: For highest_set_bit() testing
+
+implemented_extensions:
+  - [I, "2.1"]
+
+params:
+  MXLEN: 64
+)";
+
+TEST_CASE("highest_set_bit(0) returns -1", "[util]") {
+  IssSocModel soc(1024 * 1024, 0);
+  auto* hart_base = HartFactory::create("rv64", 0, cfg_yaml, soc);
+  auto* hart = static_cast<Rv64_Hart<IssSocModel>*>(hart_base);
+
+  REQUIRE(hart->highest_set_bit(Bits<64>{0}).make_signed() == SignedBits<8>{-1});
+
+  delete hart_base;
+}
+
+TEST_CASE("highest_set_bit finds the top set bit", "[util]") {
+  IssSocModel soc(1024 * 1024, 0);
+  auto* hart_base = HartFactory::create("rv64", 0, cfg_yaml, soc);
+  auto* hart = static_cast<Rv64_Hart<IssSocModel>*>(hart_base);
+
+  REQUIRE(hart->highest_set_bit(Bits<64>{0x1}) == Bits<8>{0});
+  REQUIRE(hart->highest_set_bit(Bits<64>{0x8000000000000000ULL}) == Bits<8>{63});
+
+  delete hart_base;
 }

--- a/backends/cpp_hart_gen/lib/gen_cpp.rb
+++ b/backends/cpp_hart_gen/lib/gen_cpp.rb
@@ -578,17 +578,35 @@ module Idl
       t = type(symtab)
 
       if w == :unknown
+        lit_width = symtab.possible_xlens.max
         if t.known?
-          "#{' ' * indent}_RuntimeBits<#{symtab.possible_xlens.max}, #{t.signed?}>{#{v}_b, __UDB_XLEN}"
+          "#{' ' * indent}_RuntimeBits<#{lit_width}, #{t.signed?}>{#{bits_literal_text(v, lit_width)}_b, __UDB_XLEN}"
         else
-          "#{' ' * indent}_PossiblyUnknownRuntimeBits<#{symtab.possible_xlens.max}, #{t.signed?}>{\"#{v}\"_xb, __UDB_XLEN}"
+          "#{' ' * indent}_PossiblyUnknownRuntimeBits<#{lit_width}, #{t.signed?}>{\"#{v}\"_xb, __UDB_XLEN}"
         end
       else
         if t.known?
-          "#{' ' * indent}_Bits<#{t.width}, #{t.signed?}>(#{v}_b)"
+          "#{' ' * indent}_Bits<#{t.width}, #{t.signed?}>(#{bits_literal_text(v, t.width)}_b)"
         else
           "#{' ' * indent}_PossiblyUnknownBits<#{t.width}, #{t.signed?}>(\"#{v}\"_xb)"
         end
+      end
+    end
+
+    private
+
+    # Render +value+ as the unsigned decimal text of its +width+-bit two's-complement
+    # bit pattern. The C++ "_b" literal operator always produces an unsigned _Bits
+    # whose width is derived from the digit text itself (e.g. "1_b" is 1 bit wide), so
+    # emitting a negative value directly (e.g. "-1_b") relies on C++ unary minus over
+    # that undersized unsigned literal, which loses the sign (e.g. -15_b becomes +1,
+    # because "15_b" is only four bits and negation drops the sign bit). Pre-masking to
+    # the literal's real width avoids that and always yields the correct bit pattern.
+    def bits_literal_text(value, width)
+      if value.is_a?(Integer) && value.negative?
+        (value & ((1 << width) - 1)).to_s
+      else
+        value.to_s
       end
     end
   end

--- a/backends/cpp_hart_gen/tasks.rake
+++ b/backends/cpp_hart_gen/tasks.rake
@@ -434,6 +434,7 @@ namespace :test do
       sh "make -j #{$jobs} test_bits_random"
       sh "make -j #{$jobs} test_softfloat_fp"
       sh "make -j #{$jobs} test_regfile"
+      sh "make -j #{$jobs} test_util"
       sh "ctest -T coverage -T test"
     end
   end
@@ -471,6 +472,7 @@ namespace :test do
       "srl", "srli", "srliw", "srlw",
       "sub", "subw",
       "xor", "xori"]
+    #rv64uiTests = ["add"]
 
     rv32umTests = ["div", "divu",
       "mul", "mulh", "mulhsu", "mulhu",

--- a/doc/docs/idl/functions.mdx
+++ b/doc/docs/idl/functions.mdx
@@ -63,6 +63,36 @@ function divmod {
 (quot, rem) = divmod(x, y);
 ```
 
+## Return Value Signedness
+
+There is no support for declaring a signed return type, so every function returns an unsigned value.
+
+When a function's result is conceptually signed (e.g., `-1`), the value is encoded as a two's-complement bit pattern, and callers must reinterpret the result with `$signed()` before using it anywhere signedness matters.
+
+```idl title="highest_set_bit, from util.idl"
+function highest_set_bit {
+  returns Bits<8>
+  arguments XReg value
+  description {
+    Returns the position of the highest (nearest MSB) bit that is '1',
+    or -1 if value is zero.
+  }
+  body {
+    for (Bits<8> i=xlen(); i > 0; i--) {
+      if (value[i-1] == 1) {
+        return i-1;
+      }
+    }
+    return -'sd1;   # falls through when value == 0
+  }
+}
+```
+
+The returned bit pattern for `highest_set_bit(0)` is `0xff` -- 255 if read as unsigned. Use `$signed` to treat the return value as signed.
+```idl title="clz, from Zbb/clz.yaml"
+X[xd] = (xlen() - 1) - $signed(highest_set_bit(X[xs1]));
+```
+
 ## Function Declarations
 
 The basic form of a function declaration:

--- a/doc/docs/idl/operators.mdx
+++ b/doc/docs/idl/operators.mdx
@@ -14,6 +14,24 @@ Binary operators between operands of different bit widths extend the smaller ope
 
 The result of a binary operation is signed if both operands are signed; otherwise the result is unsigned.
 
+## Signedness of Arithmetic Results
+
+For arithmetic operators (`+`, `-`, `*`, and their widening variants), the operand types decide the signedness of the result.
+
+- **Both operands signed** -> result is signed.
+- **Either operand unsigned** -> result is unsigned.
+
+For example:
+
+```idl
+Bits<8> a = 5;
+Bits<8> b = 8;
+
+Bits<32> c = $signed(a) - $signed(b);  # both signed   -> -3, sign-extended to 0xfffffffd
+Bits<32> d = a - b;                    # both unsigned -> zero-extended to 0x000000fd (253)
+Bits<32> e = $signed(a - b);           # reinterpret a - b's bit pattern as signed: -3, sign-extended to 0xfffffffd
+```
+
 ## Widening Operators
 
 IDL includes widening variants of several binary operators, indicated by a backtick (`` ` ``) prefix. These are unique to IDL and have no direct C or Verilog equivalent. They are useful when you need to preserve the full result of an operation that would otherwise overflow or lose bits.

--- a/spec/std/isa/isa/util.idl
+++ b/spec/std/isa/isa/util.idl
@@ -71,6 +71,7 @@ function highest_set_bit {
   description {
     Returns the position of the highest (nearest MSB) bit that is '1',
     or -1 if value is zero.
+    Callers should cast the return value with $signed().
   }
   body {
     for (Bits<8> i=xlen(); i > 0; i--) {

--- a/tests/data/golden/Xqci@0.13.0.adoc
+++ b/tests/data/golden/Xqci@0.13.0.adoc
@@ -39597,6 +39597,7 @@ return sp;
 === highest_set_bit
 Returns the position of the highest (nearest MSB) bit that is '1',
 or -1 if value is zero.
+Callers should cast the return value with $signed().
   
 
 [cols="1,4"]

--- a/tools/ruby-gems/idlc/lib/idlc/passes/prune.rb
+++ b/tools/ruby-gems/idlc/lib/idlc/passes/prune.rb
@@ -20,8 +20,18 @@ module Idl
       width = forced_type ? forced_type.width : value.bit_length
       raise "pruning error: attempting to prune an integer with unknown width" unless width.is_a?(Integer)
       width = 1 if width == 0
-      v = value <= 512 ? value.to_s : "h#{value.to_s(16)}"
-      str = "#{width}'#{v}"
+
+      # negative values must keep an explicit sign marker and their native decimal
+      # text; the literal grammar already parses signed negative decimals correctly,
+      # while re-encoding as an unsigned magnitude (with no sign marker) silently
+      # drops the sign once rendered to C++ (see IntLiteralAst#gen_cpp)
+      str =
+        if value.is_a?(Integer) && value.negative?
+          "#{width}'sd#{value}"
+        else
+          v = value <= 512 ? value.to_s : "h#{value.to_s(16)}"
+          "#{width}'#{v}"
+        end
       Idl::IntLiteralAst.new(str, 0...str.size, str)
     end
 
@@ -694,7 +704,10 @@ module Idl
     def prune(symtab, forced_type: nil)
       if forced_type
         raise "pruning error: attempt to force bitwidth when width is unknown" if forced_type.width.nil? || forced_type.width == :unknown
-        s = "#{forced_type.width}'d#{value(symtab)}"
+        v = value(symtab)
+        # negative values need an explicit sign marker; without it, the literal
+        # re-parses as unsigned and loses its sign once rendered to C++
+        s = v.negative? ? "#{forced_type.width}'sd#{v}" : "#{forced_type.width}'d#{v}"
         IntLiteralAst.new(s, 0...s.size, s)
       else
         dup

--- a/tools/ruby-gems/idlc/test/test_prune.rb
+++ b/tools/ruby-gems/idlc/test/test_prune.rb
@@ -72,6 +72,60 @@ class TestVariables < Minitest::Test
     end
   end
 
+  def test_prune_forced_type_negative_value
+    # regression test: a negative value pruned into a forced (signed) type must
+    # keep its sign marker ('sd, not just 'd), or the literal re-parses as
+    # unsigned and its sign is lost when later rendered to C++
+    orig_idl = "false ? 4'sb0 : -(8'sd1)"
+
+    expected_idl = "8'sd-1"
+
+    symtab = Idl::SymbolTable.new
+    m = @compiler.parser.parse(orig_idl, root: :expression)
+    refute_nil m
+
+    ast = m.to_ast
+    assert_instance_of Idl::TernaryOperatorExpressionAst, ast
+
+    pruned = ast.prune(symtab)
+    assert_instance_of Idl::IntLiteralAst, pruned
+
+    assert_equal expected_idl, pruned.to_idl
+  end
+
+  def test_prune_function_body_negative_return_value
+    # regression test for the highest_set_bit() bug: a function whose declared
+    # return type is signed, that falls through to a bare negative literal
+    # return (e.g. "return -'sd1;"), must prune to a literal that keeps its
+    # sign marker so the value survives C++ codegen (see gen_cpp.rb IntLiteralAst#gen_cpp)
+    orig_idl = <<~IDL
+      if (false) {
+        return 1;
+      }
+      return -(64'sd1);
+    IDL
+
+    symtab = Idl::SymbolTable.new(possible_xlens_cb: proc { [32, 64] })
+    ast =
+      @compiler.compile_func_body(
+        orig_idl,
+        return_type: Idl::Type.new(:bits, width: 64, qualifiers: [:signed]),
+        symtab:,
+        input_file: "temp"
+      )
+    refute_nil(ast)
+
+    pruned = ast.prune(symtab)
+    return_stmt = pruned.statements.last
+    assert_instance_of Idl::ReturnStatementAst, return_stmt
+
+    literal = return_stmt.return_expression.return_value_nodes.first
+    assert_instance_of Idl::IntLiteralAst, literal
+    assert_equal "64'sd-1", literal.to_idl
+    assert literal.type(symtab).signed?
+    assert_equal(-1, literal.value(symtab))
+  end
+
   def test_ternary_prune
     orig_idl = "(true) ? {1'b1, {31{1'b0}}} : {1'b1, {63{1'b0}}}"
     expected_idl = "64'h80000000"


### PR DESCRIPTION
A failure occurred when running riscv-tests for `clz` instruction.

The IDL for `clz` is:
```
X[xd] = (xlen() - 1) - $signed(highest_set_bit(X[xs1]));
```

The return code from `highest_set_bit(0)`, when cast with `$signed`, should be -1.

The value returned from `highest_set_bit(0)` is `-'sd1` (negative signed decimal 1),
but the sign bit was lost in translation.

An AI-assisted investigation concluded:

- The bug is in `IntLiteralAst#gen_cpp`, triggered specifically by how the prune pass const-folds `-'sd1`.

  Chain of events:

  1. `highest_set_bit`'s returns `-'sd1`. `'sd1` (no explicit width) gets type `Bits<64, signed>`.
     The unary `-` clones that type, so the whole expression `-'sd1` is `Bits<64,signed>`, value -1.

  2. The `func.prune(symtab)` pass const-folds this. `UnaryOperatorExpressionAst#prune` calls
     `PruneHelpers.create_literal(symtab, -1, Bits<64,signed>)` -> `create_int_literal(-1, forced_type:)`:
     ```
     width = forced_type.width          # 64
     v = value.to_s                     # "-1"
     str = "#{width}'#{v}"              # "64'-1"   <-- BUG: no 's' signed marker
     ```

  3. This synthesizes the text "64'-1" and re-parses it as a new `IntLiteralAst`. Since there's no "s" after the "'", the regex captures
     signed-group as empty -- the new literal is silently unsigned `Bits<64, false>`, even though it originated from a signed value. (The numeric value -1 survives only by
     accident, because the trailing `(.*)$` group in the regex is permissive enough that Ruby's `"-1".to_i(10)` still parses to -1.)

  4. `IntLiteralAst#gen_cpp` then renders this pruned literal as:
     "`_Bits<#{t.width}, #{t.signed?}>(#{v}_b)`"   # => "`_Bits<64, false>(-1_b)`"

  5. This is exactly what appears in the generated `return _Bits<64, false>(-1_b);`

  6. The real killer is the C++ token "-1_b" itself. "1_b" is a user-defined literal; `BitsStrHelpers::get_width` computes its width purely from the digit
     string "1" -> 1 bit. So "1_b" is `_Bits<1,false>(1)`. The leading "-" is a separate unary-minus applied after that: `_Bits<1,false>::operator-()`, which negates modulo 2,
     i.e. -1 mod 2 = 1. The result (still 1) is then zero-extended (not sign-extended, since it's unsigned) into `_Bits<64,false>`. This is precisely the footgun the library
     authors warned about in bits.hpp: "be careful with negative numbers here, since literals are always unsigned... -15_b will be +1, because 15_b is only four
     bits, and negation loses the sign bit."

  This matches every GDB observation: highest_set_bit(0) returns 1 instead of -1/0xFF, so clz(0) computes 63 - 1 = 62 (later confirmed to become xlen()-1 overall)
  instead of 63 - (-1) = 64.

  Fix location would be `PruneHelpers.create_int_literal` (needs to preserve the "s" marker / emit a correctly-signed literal string) and/or `IntLiteralAst#gen_cpp` (needs to
  avoid emitting bare "-N_b" for negative values -- e.g. construct the full-width unsigned two's-complement pattern directly, or use `-_Bits<width,signed>(N_b)` instead of
  `(-N)_b`).

Both fixes are included, and are AI-generated. AI-generated tests are also included as well as AI-assisted documentation improvements.

Signed-off-by: Paul A. Clarke <paul.clarke@qti.qualcomm.com>