### PR TITLE
Add missing Smctr CSR models and CTR depth parameter (#2478)

### DIFF
--- a/spec/std/isa/csr/Smctr/sctrdepth.yaml
+++ b/spec/std/isa/csr/Smctr/sctrdepth.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sctrdepth
+long_name: Supervisor Control Transfer Records Depth
+address: 0x15F
+writable: true
+priv_mode: S
+length: 32
+description: |
+  The `sctrdepth` register is a 32-bit read/write register used to select the number
+  of records that can be held in the CTR buffer.
+definedBy:
+  extension:
+    name: Smctr
+fields:
+  DEPTH:
+    location: 2-0
+    description: |
+      Selects the depth of the CTR buffer.
+    type(): |
+      return ($array_size(SCTRDEPTH_DEPTH_LEGAL_VALUES) == 1) ? CsrFieldType::RO : CsrFieldType::RW;
+    reset_value(): |
+      if ($array_size(SCTRDEPTH_DEPTH_LEGAL_VALUES) == 1) {
+        if (SCTRDEPTH_DEPTH_LEGAL_VALUES[0] == 16) { return 0; }
+        else if (SCTRDEPTH_DEPTH_LEGAL_VALUES[0] == 32) { return 1; }
+        else if (SCTRDEPTH_DEPTH_LEGAL_VALUES[0] == 64) { return 2; }
+        else if (SCTRDEPTH_DEPTH_LEGAL_VALUES[0] == 128) { return 3; }
+        else if (SCTRDEPTH_DEPTH_LEGAL_VALUES[0] == 256) { return 4; }
+        else { return UNDEFINED_LEGAL; }
+      } else {
+        return UNDEFINED_LEGAL;
+      }
+    sw_write(csr_value): |
+      if ($array_includes?(SCTRDEPTH_DEPTH_LEGAL_VALUES, 32'd16 << csr_value.DEPTH)) {
+        return csr_value.DEPTH;
+      } else {
+        return UNDEFINED_LEGAL_DETERMINISTIC;
+      }

--- a/spec/std/isa/csr/Smctr/sctrstatus.yaml
+++ b/spec/std/isa/csr/Smctr/sctrstatus.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sctrstatus
+long_name: Supervisor Control Transfer Records Status
+address: 0x14F
+writable: true
+priv_mode: S
+length: 32
+description: |
+  The `sctrstatus` register provides access to CTR status information and is
+  updated by hardware whenever CTR is active.
+definedBy:
+  extension:
+    name: Smctr
+fields:
+  WRPTR:
+    location: 7-0
+    description: |
+      Write Pointer. Indicates the physical CTR buffer entry to be written next.
+
+      Note: Bits above depth-1 are read-only zero depending on the configured CTR depth.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      Bits<8> mask = (9'd16 << CSR[sctrdepth].DEPTH) - 1;
+      return csr_value.WRPTR & mask;
+  FROZEN:
+    location: 31
+    description: |
+      When set, inhibits transfer recording.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/param/SCTRDEPTH_DEPTH_LEGAL_VALUES.yaml
+++ b/spec/std/isa/param/SCTRDEPTH_DEPTH_LEGAL_VALUES.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/param_schema.json
+
+$schema: param_schema.json#
+kind: parameter
+name: SCTRDEPTH_DEPTH_LEGAL_VALUES
+description: |
+  The set of supported actual depths for the Control Transfer Records (CTR) buffer.
+long_name: Supported CTR buffer depths
+schema:
+  type: array
+  items:
+    type: integer
+    enum:
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+  maxItems: 5
+  minItems: 1
+  uniqueItems: true
+definedBy:
+  extension:
+    name: Smctr


### PR DESCRIPTION
## Summary

This PR addresses the missing Smctr models identified in #2478.

Changes:
- Added UDB CSR model for `sctrdepth`.
- Added UDB CSR model for `sctrstatus`.
- Added implementation-specific `SCTRDEPTH_DEPTH_LEGAL_VALUES` parameter support.
- Left `ctrsource`, `ctrtarget`, and `ctrdata` unchanged pending clarification on indirect CSR authoring.

## Testing

Validated with:

- `./bin/pre-commit`
- `./do test:udb:unit`
- `./do test:schema`

All checks passed locally.

Fixes #2478