### PR TITLE
fix(inst): make ld/sd definition depend on XLEN

### DIFF
--- a/spec/std/isa/inst/I/ld.yaml
+++ b/spec/std/isa/inst/I/ld.yaml
@@ -18,10 +18,15 @@ description: |
   <% end %>
 
 definedBy:
-  extension:
-    anyOf:
-      - name: I
-      - name: Zilsd
+  anyOf:
+    - allOf:
+        - xlen: 64
+        - extension:
+            name: I
+    - allOf:
+        - xlen: 32
+        - extension:
+            name: Zilsd
 assembly: xd, imm(xs1)
 encoding:
   RV32:

--- a/spec/std/isa/inst/I/sd.yaml
+++ b/spec/std/isa/inst/I/sd.yaml
@@ -14,10 +14,15 @@ description: |
   For RV32, store doubleword from even/odd register pair.
   <% end %>
 definedBy:
-  extension:
-    anyOf:
-      - name: I
-      - name: Zilsd
+  anyOf:
+    - allOf:
+        - xlen: 64
+        - extension:
+            name: I
+    - allOf:
+        - xlen: 32
+        - extension:
+            name: Zilsd
 assembly: xs2, imm(xs1)
 encoding:
   RV32:

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -27873,8 +27873,8 @@ Included in::
 
 This instruction requires the following:
 
-xref:exts:I.adoc#udb:doc:ext:I[I]
-xref:exts:Zilsd.adoc#udb:doc:ext:Zilsd[Zilsd]
+++(++xlen+++()+++ == 64 && xref:exts:I.adoc#udb:doc:ext:I[I])
+++(++xlen+++()+++ == 32 && xref:exts:Zilsd.adoc#udb:doc:ext:Zilsd[Zilsd])
 
 
 [#udb:doc:inst:ld_aq]
@@ -36121,8 +36121,8 @@ Included in::
 
 This instruction requires the following:
 
-xref:exts:I.adoc#udb:doc:ext:I[I]
-xref:exts:Zilsd.adoc#udb:doc:ext:Zilsd[Zilsd]
+++(++xlen+++()+++ == 64 && xref:exts:I.adoc#udb:doc:ext:I[I])
+++(++xlen+++()+++ == 32 && xref:exts:Zilsd.adoc#udb:doc:ext:Zilsd[Zilsd])
 
 
 [#udb:doc:inst:sd_aqrl]


### PR DESCRIPTION
Make the `definedBy` conditions for `ld` and `sd` reflect their XLEN-specific definitions:

Closes #986.