### PR TITLE
fix(csr): seven vector CSRs take XLEN, not MXLEN

### DIFF
--- a/spec/std/isa/csr/V/vcsr.yaml
+++ b/spec/std/isa/csr/V/vcsr.yaml
@@ -10,7 +10,7 @@ long_name: Vector Control and Status Register
 address: 0x00F
 writable: true
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Contains aliases to vxrm and vxsat CSRs
 definedBy:
   extension:

--- a/spec/std/isa/csr/V/vl.yaml
+++ b/spec/std/isa/csr/V/vl.yaml
@@ -10,7 +10,7 @@ long_name: Vector Length
 address: 0xC20
 writable: false
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Holds an unsigned integer specifying number of elements to be updated with results from a vector instruction.
 definedBy:
   extension:

--- a/spec/std/isa/csr/V/vlenb.yaml
+++ b/spec/std/isa/csr/V/vlenb.yaml
@@ -10,7 +10,7 @@ long_name: Vector Byte Length
 address: 0xC22
 writable: false
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Holds the value VLEN/8, the vector register length in bytes.
 definedBy:
   extension:

--- a/spec/std/isa/csr/V/vstart.yaml
+++ b/spec/std/isa/csr/V/vstart.yaml
@@ -10,7 +10,7 @@ long_name: Vector Start Index
 address: 0x008
 writable: true
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Specifies the index of the first element to be executed by a vector instruction.
 definedBy:
   extension:

--- a/spec/std/isa/csr/V/vtype.yaml
+++ b/spec/std/isa/csr/V/vtype.yaml
@@ -10,7 +10,7 @@ long_name: Vector Type
 address: 0xC21
 writable: false
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Provides the default type used to interpret the contents of the vector register file.
 definedBy:
   extension:

--- a/spec/std/isa/csr/V/vxrm.yaml
+++ b/spec/std/isa/csr/V/vxrm.yaml
@@ -10,7 +10,7 @@ long_name: Vector Fixed-Point Rounding Mode
 address: 0x00A
 writable: true
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Holds a 2-bit read-write rounding-mode field in the least-significant bits
 definedBy:
   extension:

--- a/spec/std/isa/csr/V/vxsat.yaml
+++ b/spec/std/isa/csr/V/vxsat.yaml
@@ -10,7 +10,7 @@ long_name: Vector Fixed-Point Saturate Flag
 address: 0x009
 writable: true
 priv_mode: U
-length: MXLEN
+length: XLEN
 description: Indicates if a fixed-point instruction has had to saturate an output value to fit into a destination format
 definedBy:
   extension:


### PR DESCRIPTION
Fix defined widths of `vcsr`, `vl`, `vlenb`, `vstart`, `vtype`, `vxrm` and `vxsat` to match ISA definitions.

Partially addresses #2463.