### PR TITLE
fix(isa): compressed FP load/stores must use the float register file

### DIFF
--- a/spec/std/isa/inst/Zcd/c.fld.yaml
+++ b/spec/std/isa/inst/Zcd/c.fld.yaml
@@ -38,4 +38,4 @@ operation(): |
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  F[fd] = sext(read_memory(64, virtual_address, $encoding), 64);
+  F[creg2reg(fd)] = sext(read_memory(64, virtual_address, $encoding), 64);

--- a/spec/std/isa/inst/Zcd/c.fsd.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsd.yaml
@@ -38,4 +38,4 @@ operation(): |
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  write_memory(64, virtual_address, X[creg2reg(fs2)], $encoding);
+  write_memory(64, virtual_address, F[creg2reg(fs2)][63:0], $encoding);

--- a/spec/std/isa/inst/Zcf/c.flw.yaml
+++ b/spec/std/isa/inst/Zcf/c.flw.yaml
@@ -38,4 +38,4 @@ operation(): |
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  X[creg2reg(fd)] = sext(read_memory(32, virtual_address, $encoding), 32);
+  F[creg2reg(fd)] = read_memory(32, virtual_address, $encoding);

--- a/spec/std/isa/inst/Zcf/c.fsw.yaml
+++ b/spec/std/isa/inst/Zcf/c.fsw.yaml
@@ -38,4 +38,4 @@ operation(): |
 
   XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  write_memory(32, virtual_address, X[creg2reg(fs2)][31:0], $encoding);
+  write_memory(32, virtual_address, F[creg2reg(fs2)][31:0], $encoding);


### PR DESCRIPTION
`c.fsd` and `c.fsw` store from `X[creg2reg(fs2)]` and `c.flw` loads into `X[creg2reg(fd)]`, so all three use the integer register file where their `sp` siblings use `F[]`. `c.fld` uses `F[]` but indexes it with its raw three-bit `fd` field, reaching `f0`-`f7` instead of `f8`-`f15`.

Four one-line changes, each matching the corresponding `sp` form.

Closes #2490
