### PR TITLE
fix(zaamo,zabha): sign-extend narrow AMO results into xd

### DIFF
--- a/spec/std/isa/inst/Zaamo/amoadd.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoadd.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Add, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Add, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoadd.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoadd.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoadd.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoadd.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Add, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoand.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoand.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::And, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::And, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoand.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoand.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoand.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoand.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::And, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amomax.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomax.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Max, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Max, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomax.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amomax.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomax.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomax.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Max, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amomaxu.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomaxu.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Maxu, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Maxu, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amomin.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomin.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Min, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Min, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomin.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amomin.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomin.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amomin.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Min, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amominu.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amominu.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Minu, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Minu, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amominu.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amominu.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amominu.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amominu.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoor.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoor.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Or, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Or, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoor.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoor.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoor.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoor.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Or, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoswap.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoswap.SIZE.AQRL.layout
@@ -73,7 +73,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Swap, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Swap, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoswap.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.aq.yaml
@@ -39,4 +39,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoswap.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.aqrl.yaml
@@ -39,6 +39,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoswap.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.rl.yaml
@@ -37,6 +37,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoswap.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.yaml
@@ -37,4 +37,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoxor.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoxor.SIZE.AQRL.layout
@@ -74,7 +74,7 @@ operation(): |
 
 <% end -%>
   XReg virtual_address = X[xs1];
-  X[xd] = amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Xor, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding);
+  X[xd] = <%= %w[b h w].include?(size) ? "sext(" : "" %>amo(<%= current_size[:operation_bits] %>, virtual_address, X[xs2]<%= %w[b h w].include?(size) ? "[#{current_size[:bits]-1}:0]" : "" %>, AmoOperation::Xor, <%= aq ? "1'b1" : "1'b0" %>, <%= rl ? "1'b1" : "1'b0" %>, $encoding)<%= %w[b h w].include?(size) ? ", #{current_size[:bits]})" : "" %>;
 <% if rl -%>
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoxor.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b1, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zaamo/amoxor.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b1, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoxor.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding), 32);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zaamo/amoxor.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(32, virtual_address, X[xs2][31:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding), 32);

--- a/spec/std/isa/inst/Zabha/amoadd.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoadd.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoadd.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoadd.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Add, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoadd.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoadd.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoadd.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoadd.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Add, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoand.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoand.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoand.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoand.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::And, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoand.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoand.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoand.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoand.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::And, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amomax.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amomax.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomax.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomax.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Max, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amomax.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amomax.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomax.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomax.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Max, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amomaxu.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amomaxu.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomaxu.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomaxu.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amomaxu.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amomaxu.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomaxu.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomaxu.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Maxu, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amomin.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amomin.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomin.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomin.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Min, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amomin.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amomin.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomin.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amomin.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Min, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amominu.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amominu.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amominu.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amominu.b.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amominu.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amominu.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amominu.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amominu.h.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Minu, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoor.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoor.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoor.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoor.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Or, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoor.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoor.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoor.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoor.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Or, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoswap.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.aq.yaml
@@ -39,4 +39,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoswap.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.aqrl.yaml
@@ -39,6 +39,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoswap.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.rl.yaml
@@ -37,6 +37,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoswap.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.yaml
@@ -37,4 +37,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoswap.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.aq.yaml
@@ -39,4 +39,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoswap.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.aqrl.yaml
@@ -39,6 +39,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoswap.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.rl.yaml
@@ -37,6 +37,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoswap.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.yaml
@@ -37,4 +37,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Swap, 1'b0, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoxor.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b1, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoxor.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b1, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoxor.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding), 8);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoxor.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(8, virtual_address, X[xs2][7:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding), 8);

--- a/spec/std/isa/inst/Zabha/amoxor.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.aq.yaml
@@ -40,4 +40,4 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b1, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b1, 1'b0, $encoding), 16);

--- a/spec/std/isa/inst/Zabha/amoxor.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.aqrl.yaml
@@ -40,6 +40,6 @@ operation(): |
   memory_model_acquire();
 
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b1, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b1, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoxor.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.rl.yaml
@@ -38,6 +38,6 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b0, 1'b1, $encoding), 16);
 
   memory_model_release();

--- a/spec/std/isa/inst/Zabha/amoxor.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.yaml
@@ -38,4 +38,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[xs1];
-  X[xd] = amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding);
+  X[xd] = sext(amo(16, virtual_address, X[xs2][15:0], AmoOperation::Xor, 1'b0, 1'b0, $encoding), 16);


### PR DESCRIPTION
The nine `Zaamo/amo*.SIZE.AQRL.layout` templates assigned the result of `amo()` straight to `X[xd]`. `amo()` is declared to return `XReg` but produces its value from `atomic_read_modify_write_32/64`, and widening a narrower Bits is a zero-extension, so `amoadd.w` and friends put a zero-extended word in `xd` on RV64, and the Zabha `.b/.h` variants never sign-extended at all.

The spec requires the opposite in both cases: "For RV64, 32-bit AMOs always sign-extend the value placed in rd" (Zaamo) and "Byte and halfword AMOs always sign-extend the value placed in `rd`" (Zabha). Each instruction's own description already said "Write the sign-extended value into xd". Wrapping the call in `sext(..., <access width>)` for the b/h/w sizes matches how `lw` is written; `.d` is unchanged.

Only the 9 `.layout` files are hand-edited; the other 108 YAML files were regenerated with `./do gen:arch` (3 sizes × 9 ops × 4 ordering variants). This corrects the value written to `xd`; the `.b/.h` variants still perform a 64-bit read-modify-write until part 3 is fixed.

Part 2 of #2432.