### PR TITLE
fix(udb): DummyProgressBar ignores format so quiet log levels don't crash the idlc compiler

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -521,6 +521,7 @@ jobs:
           - mmr_schema
           - schema_versioning
           - instruction
+          - log
           - z3
           - z3_extensions
           - z3_finite_array

--- a/tools/ruby-gems/udb/lib/udb/log.rb
+++ b/tools/ruby-gems/udb/lib/udb/log.rb
@@ -83,6 +83,16 @@ module Udb
     def finish
       # do nothing
     end
+
+    sig { returns(String) }
+    def format
+      ""
+    end
+
+    sig { params(fmt: String).void }
+    def format=(fmt)
+      # do nothing
+    end
   end
 
   class DummyMultiProgressBar

--- a/tools/ruby-gems/udb/test/test_log.rb
+++ b/tools/ruby-gems/udb/test/test_log.rb
@@ -1,0 +1,60 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# typed: false
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "udb/log"
+
+# this is needed for tty-progressbar to work with minitest
+unless StringIO.method_defined? :ioctl
+  class StringIO
+    def ioctl(*)
+      # :nocov:
+      80
+      # :nocov:
+    end
+  end
+end
+
+class TestLog < Minitest::Test
+  include Udb
+
+  def test_dummy_progressbar_supports_format_interface
+    bar = Udb::DummyProgressBar.new
+
+    # idlc's compiler calls format= and format on the progress bar it is given.
+    bar.format = "Parsing foo [:bar]"
+    assert_kind_of String, bar.format
+  end
+
+  def test_create_progressbar_at_quiet_log_levels_returns_a_dummy_that_accepts_format
+    [LogLevel::Warn, LogLevel::Error, LogLevel::Fatal].each do |level|
+      old = Udb.log_level
+      Udb.log_level = level
+      begin
+        bar = Udb.create_progressbar("Compiling IDL for x [:bar]")
+        assert_kind_of Udb::DummyProgressBar, bar
+        bar.format = "Parsing foo [:bar]"
+        assert_kind_of String, bar.format
+        bar.advance
+        bar.finish
+      ensure
+        Udb.log_level = old
+      end
+    end
+  end
+
+  def test_create_progressbar_at_default_level_returns_a_real_progress_bar
+    old = Udb.log_level
+    Udb.log_level = LogLevel::Info
+    begin
+      bar = Udb.create_progressbar("Compiling IDL for x [:bar]")
+      assert_kind_of TTY::ProgressBar, bar
+    ensure
+      Udb.log_level = old
+    end
+  end
+end

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -176,6 +176,7 @@ tests:
           - mmr_schema
           - schema_versioning
           - instruction
+          - log
           - z3
           - z3_extensions
           - z3_finite_array


### PR DESCRIPTION
Idl::Compiler#compile_file calls `pb.format` and `pb.format=` on the progress bar it is handed. When the log level is warn, error, or fatal, `Udb.create_progressbar` returns `Udb::DummyProgressBar`, which only implements `advance` and `finish`. The `format` call then resolves to the private `Kernel#format` and raises `NoMethodError`, so every tool that compiles IDL aborts as soon as verbosity is reduced (for example `LOG=warn ./do test:idl CFG=rv64`).

Give `DummyProgressBar` no-op `format` and `format=` methods so it stays a faithful stand-in for `TTY::ProgressBar`, and add a regression test that is wired into the udb unit test CI matrix.

Fixes #2407

---

_Automated by pr-pipeline (com.ashutosh.prpipeline)._