### PR TITLE
feat(ext): add Smpmpind, Smcfiss, Smucfiss and Sspmpss definitions

### DIFF
--- a/spec/std/isa/ext/Smcfiss.yaml
+++ b/spec/std/isa/ext/Smcfiss.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) NVIDIA Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Smcfiss
+long_name: M-mode Shadow Stack
+description: |
+  The Smcfiss extension enables Zicfiss shadow stacks in M-mode.
+
+  A PMP entry with E=1 and XWR=010 marks an M-mode shadow-stack region, and
+  mseccfg.MSSE turns the protection on. While MSSE is set, the shadow-stack
+  instructions operate on the region, ordinary stores to it raise a store or
+  AMO access fault, and ordinary loads are permitted.
+
+  Where Smepmp is implemented, writes to MSSE are ignored until reset once any
+  PMP entry is locked and rule-locking bypass is off.
+type: privileged
+versions:
+  - version: "0.1.0"
+    state: development
+    url: "https://github.com/ved-rivos/riscv-isa-manual/blob/smpmpss/src/smcfiss.adoc"
+requirements:
+  extension:
+    allOf:
+      - name: Zicfiss
+        version: "~> 1.0"
+      - name: Smpmpind
+        version: "~> 0.1"

--- a/spec/std/isa/ext/Smcsrind.yaml
+++ b/spec/std/isa/ext/Smcsrind.yaml
@@ -41,5 +41,3 @@ versions:
     state: ratified
     ratification_date: "2024-11"
     url: "https://github.com/riscv/riscv-isa-manual/releases/tag/riscv-isa-release-482805d-2025-03-25"
-requirements:
-  extension: { name: S, version: "~> 1.13" }

--- a/spec/std/isa/ext/Smpmpind.yaml
+++ b/spec/std/isa/ext/Smpmpind.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) NVIDIA Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Smpmpind
+long_name: Indirect access to PMP CSRs
+description: |
+  The Smpmpind extension makes the PMP configuration and address registers
+  reachable through the indirect CSR mechanism that Smcsrind provides, in
+  addition to the direct pmpcfg and pmpaddr CSRs.
+
+  The indirect pmpcfg register is MXLEN wide, wider than the eight-bit field a
+  direct access sees, so it can carry configuration that the direct CSRs do not
+  encode. Smpmpind uses this to add an enable bit, pmpcfg.E, at bit MXLEN-1. The
+  low eight bits of the indirect register alias that entry's eight-bit field in
+  the direct configuration CSR.
+
+  When E is set, every XWR encoding for that entry is reserved unless another
+  extension defines it, and accessing a region with a reserved encoding raises
+  an access fault. Smcfiss and Smucfiss each define one such encoding.
+type: privileged
+versions:
+  - version: "0.1.0"
+    state: development
+    url: "https://github.com/ved-rivos/riscv-isa-manual/blob/smpmpss/src/smcfiss.adoc"
+requirements:
+  extension: { name: Smcsrind, version: "~> 1.0" }

--- a/spec/std/isa/ext/Smucfiss.yaml
+++ b/spec/std/isa/ext/Smucfiss.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) NVIDIA Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Smucfiss
+long_name: U-mode Shadow Stack on M+U-only systems
+description: |
+  The Smucfiss extension enables Zicfiss shadow stacks in U-mode on harts with
+  no S-mode, where page tables are not available to mark shadow-stack pages.
+
+  It reuses the PMP region tagging introduced by Smpmpind and Smcfiss. A PMP
+  entry with E=1 and XWR=110 marks a U-mode shadow-stack region, which M-mode
+  enables by setting menvcfg.SSE.
+type: privileged
+versions:
+  - version: "0.1.0"
+    state: development
+    url: "https://github.com/ved-rivos/riscv-isa-manual/blob/smpmpss/src/smcfiss.adoc"
+requirements:
+  extension:
+    allOf:
+      - name: Zicfiss
+        version: "~> 1.0"
+      - name: Smcfiss
+        version: "~> 0.1"
+      - not:
+          name: S

--- a/spec/std/isa/ext/Sspmpss.yaml
+++ b/spec/std/isa/ext/Sspmpss.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) NVIDIA Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Sspmpss
+long_name: S/U Shadow Stack on MMU-less systems via SPMP
+description: |
+  The Sspmpss extension provides Zicfiss shadow stacks for S-mode and U-mode
+  software on harts that use SPMP rather than page-based translation. An SPMP
+  region with XWR=010 and SHARED=0 is a shadow-stack region.
+
+  Sspmpss applies only while satp.MODE is Bare and menvcfg.SSE is set.
+type: privileged
+versions:
+  - version: "0.1.0"
+    state: development
+    url: "https://github.com/ved-rivos/riscv-isa-manual/blob/smpmpss/src/smcfiss.adoc"
+requirements:
+  extension:
+    allOf:
+      - name: Zicfiss
+        version: "~> 1.0"
+      - name: S
+        version: "~> 1.13"

--- a/spec/std/isa/ext/Zicfiss.yaml
+++ b/spec/std/isa/ext/Zicfiss.yaml
@@ -28,8 +28,12 @@ requirements:
           - name: Zimop
           - name: Zaamo
     - if:
-        extension:
-          name: U
+        allOf:
+          - extension:
+              name: U
+          - not:
+              extension:
+                name: Smucfiss
       then:
         extension:
           name: S


### PR DESCRIPTION
Adds definitions for four pre-ratification extensions that together provide Zicfiss shadow stacks where page
tables are not available. Smpmpind reaches the PMP registers through the Smcsrind indirect window and adds an
enable bit that the direct CSRs do not encode. Smcfiss and Smucfiss use that bit to tag a PMP entry as an
M-mode or U-mode shadow-stack region. Sspmpss instead defines shadow-stack regions through SPMP for
S-mode and U-mode.

This also removes the S requirement from Smcsrind, which should work on M+U harts as well.
