### PR TITLE
fix(udb): CSR length condition omits U and VU mode

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -517,6 +517,7 @@ jobs:
           - yaml_loader
           - cfg_arch
           - cfg
+          - csr
           - mmr
           - mmr_schema
           - schema_versioning

--- a/tools/ruby-gems/udb/lib/udb/obj/csr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr.rb
@@ -21,9 +21,8 @@ module Udb
     BITS128_TYPE = Idl::Type.new(:bits, width: 128).freeze
     ENCODING_SIZE_VAR = Idl::Var.new("__instruction_encoding_size", BITS6_TYPE, 32).freeze
     # Privilege mode => IDL expression naming the field that selects the effective
-    # XLEN in that mode. Mirrors the mode dispatch in `base32?` in globals.isa.
-    # Debug mode executes at MXLEN, so it shares M-mode's field.
-    XLEN_FIELD_BY_MODE = {
+    # XLEN in that mode. Debug mode executes at MXLEN, so it shares M-mode's field.
+    MODE_TO_XLEN_FIELD = {
       "M" => "CSR[misa].MXL",
       "D" => "CSR[misa].MXL",
       "S" => "CSR[mstatus].SXL",
@@ -31,6 +30,7 @@ module Udb
       "VS" => "CSR[hstatus].VSXL",
       "VU" => "CSR[vsstatus].UXL"
     }.freeze
+    XLEN_TO_ENCODING = { 32 => 0, 64 => 1 }.freeze
     # Add all methods in this module to this type of database object.
     include HasFields
 
@@ -204,9 +204,6 @@ module Udb
         # dynamic if either we don't know VSXLEN or VSXLEN is explicitly mutable
         !cfg_arch.param_values.key?("VSXLEN") || cfg_arch.param_values["VSXLEN"].size > 1
       when "XLEN"
-        # The effective XLEN follows whichever mode is executing, so the length is
-        # dynamic when any mode that can reach this CSR has a variable XLEN.
-        # CsrField#dynamic_location? already asks the question this way.
         modes_with_dynamic_xlen.any?
       else
         raise "Unexpected length"
@@ -354,22 +351,23 @@ module Udb
       modes_with_access.select { |mode| cfg_arch.multi_xlen_in_mode?(mode) }
     end
 
-    # @param encoding [String] "0" for 32-bit, "1" for 64-bit
-    # @return [String] IDL condition of when the effective xlen has the given encoding
-    def length_cond(encoding)
+    # @param xlen [Integer] 32 or 64
+    # @return [String] IDL condition of when the effective xlen is +xlen+
+    def length_cond(xlen)
+      encoding = XLEN_TO_ENCODING.fetch(xlen)
       case @data["length"]
       when "MXLEN"
-        "CSR[misa].MXL == #{encoding}"
+        "#{MODE_TO_XLEN_FIELD['M']} == #{encoding}"
       when "SXLEN"
-        "CSR[mstatus].SXL == #{encoding}"
+        "#{MODE_TO_XLEN_FIELD['S']} == #{encoding}"
       when "VSXLEN"
-        "CSR[hstatus].VSXL == #{encoding}"
+        "#{MODE_TO_XLEN_FIELD['VS']} == #{encoding}"
       when "XLEN"
         modes = modes_with_dynamic_xlen
         raise "No mode with access to #{name} has a dynamic XLEN" if modes.empty?
 
         modes.map { |mode|
-          "(priv_mode() == PrivilegeMode::#{mode} && #{XLEN_FIELD_BY_MODE.fetch(mode)} == #{encoding})"
+          "(priv_mode() == PrivilegeMode::#{mode} && #{MODE_TO_XLEN_FIELD.fetch(mode)} == #{encoding})"
         }.join(" || ")
       else
         raise "Unexpected length #{@data['length']} for #{name}"
@@ -377,10 +375,10 @@ module Udb
     end
 
     # @return [String] IDL condition of when the effective xlen is 32
-    def length_cond32 = length_cond("0")
+    def length_cond32 = length_cond(32)
 
     # @return [String] IDL condition of when the effective xlen is 64
-    def length_cond64 = length_cond("1")
+    def length_cond64 = length_cond(64)
 
     # @param effective_xlen [Integer or nil] 32 or 64 for fixed xlen, nil for dynamic
     # @return [String] Pretty-printed length string
@@ -389,8 +387,8 @@ module Udb
       if dynamic_length?
         if effective_xlen.nil?
           [
-            "* #{length(32)} when #{length_cond('0')}",
-            "* #{length(64)} when #{length_cond('1')}"
+            "* #{length(32)} when #{length_cond(32)}",
+            "* #{length(64)} when #{length_cond(64)}"
           ].join("\n")
         else
           "#{length(effective_xlen)}-bit"

--- a/tools/ruby-gems/udb/lib/udb/obj/csr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr.rb
@@ -20,6 +20,17 @@ module Udb
     BITS6_CONST_TYPE = Idl::Type.new(:bits, width: 6, qualifiers: [:const]).freeze
     BITS128_TYPE = Idl::Type.new(:bits, width: 128).freeze
     ENCODING_SIZE_VAR = Idl::Var.new("__instruction_encoding_size", BITS6_TYPE, 32).freeze
+    # Privilege mode => IDL expression naming the field that selects the effective
+    # XLEN in that mode. Mirrors the mode dispatch in `base32?` in globals.isa.
+    # Debug mode executes at MXLEN, so it shares M-mode's field.
+    XLEN_FIELD_BY_MODE = {
+      "M" => "CSR[misa].MXL",
+      "D" => "CSR[misa].MXL",
+      "S" => "CSR[mstatus].SXL",
+      "U" => "CSR[mstatus].UXL",
+      "VS" => "CSR[hstatus].VSXL",
+      "VU" => "CSR[vsstatus].UXL"
+    }.freeze
     # Add all methods in this module to this type of database object.
     include HasFields
 
@@ -193,14 +204,10 @@ module Udb
         # dynamic if either we don't know VSXLEN or VSXLEN is explicitly mutable
         !cfg_arch.param_values.key?("VSXLEN") || cfg_arch.param_values["VSXLEN"].size > 1
       when "XLEN"
-        # must always have M-mode
-        # SXLEN condition applies if S-mode is possible
-        # VSXLEN condition applies if VS-mode is possible
-        (cfg_arch.mxlen.nil?) || \
-        (cfg_arch.possible_extensions.map(&:name).include?("S") && \
-          (cfg_arch.param_values["SXLEN"].nil? || cfg_arch.param_values["SXLEN"].size > 1)) || \
-        (cfg_arch.possible_extensions.map(&:name).include?("H") && \
-          (cfg_arch.param_values["VSXLEN"].nil? || cfg_arch.param_values["VSXLEN"].size > 1))
+        # The effective XLEN follows whichever mode is executing, so the length is
+        # dynamic when any mode that can reach this CSR has a variable XLEN.
+        # CsrField#dynamic_location? already asks the question this way.
+        modes_with_dynamic_xlen.any?
       else
         raise "Unexpected length"
       end
@@ -341,61 +348,49 @@ module Udb
       end
     end
 
-    # @return [String] IDL condition of when the effective xlen is 32
-    def length_cond32
+    # @return [Array<String>] Modes with access to this CSR whose effective XLEN can
+    #                          vary in this configuration
+    def modes_with_dynamic_xlen
+      modes_with_access.select { |mode| cfg_arch.multi_xlen_in_mode?(mode) }
+    end
+
+    # @param encoding [String] "0" for 32-bit, "1" for 64-bit
+    # @return [String] IDL condition of when the effective xlen has the given encoding
+    def length_cond(encoding)
       case @data["length"]
       when "MXLEN"
-        "CSR[misa].MXL == 0"
+        "CSR[misa].MXL == #{encoding}"
       when "SXLEN"
-        "CSR[mstatus].SXL == 0"
+        "CSR[mstatus].SXL == #{encoding}"
       when "VSXLEN"
-        "CSR[hstatus].VSXL == 0"
+        "CSR[hstatus].VSXL == #{encoding}"
       when "XLEN"
-        "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == 0) || (priv_mode() == PrivilegeMode::S && CSR[mstatus].SXL == 0) || (priv_mode() == PrivilegeMode::VS && CSR[hstatus].VSXL == 0)"
+        modes = modes_with_dynamic_xlen
+        raise "No mode with access to #{name} has a dynamic XLEN" if modes.empty?
+
+        modes.map { |mode|
+          "(priv_mode() == PrivilegeMode::#{mode} && #{XLEN_FIELD_BY_MODE.fetch(mode)} == #{encoding})"
+        }.join(" || ")
       else
         raise "Unexpected length #{@data['length']} for #{name}"
       end
     end
 
+    # @return [String] IDL condition of when the effective xlen is 32
+    def length_cond32 = length_cond("0")
+
     # @return [String] IDL condition of when the effective xlen is 64
-    def length_cond64
-      case @data["length"]
-      when "MXLEN"
-        "CSR[misa].MXL == 1"
-      when "SXLEN"
-        "CSR[mstatus].SXL == 1"
-      when "VSXLEN"
-        "CSR[hstatus].VSXL == 1"
-      when "XLEN"
-        "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == 1) || (priv_mode() == PrivilegeMode::S && CSR[mstatus].SXL == 1) || (priv_mode() == PrivilegeMode::VS && CSR[hstatus].VSXL == 1)"
-      else
-        raise "Unexpected length"
-      end
-    end
+    def length_cond64 = length_cond("1")
 
     # @param effective_xlen [Integer or nil] 32 or 64 for fixed xlen, nil for dynamic
     # @return [String] Pretty-printed length string
     def length_pretty(effective_xlen = nil)
       raise ArgumentError, "effective_xlen is non-nil and is a #{effective_xlen.class} but must be an Integer" unless effective_xlen.nil? || effective_xlen.is_a?(Integer)
       if dynamic_length?
-        cond =
-          case @data["length"]
-          when "MXLEN"
-            "CSR[misa].MXL == %%"
-          when "SXLEN"
-            "CSR[mstatus].SXL == %%"
-          when "VSXLEN"
-            "CSR[hstatus].VSXL == %%"
-          when "XLEN"
-            "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == %%) || (priv_mode() == PrivilegeMode::S && CSR[mstatus].SXL == %%) || (priv_mode() == PrivilegeMode::VS && CSR[hstatus].VSXL == %%)"
-          else
-            raise "Unexpected length '#{@data['length']}'"
-          end
-
         if effective_xlen.nil?
           [
-            "* #{length(32)} when #{cond.sub('%%', '0')}",
-            "* #{length(64)} when #{cond.sub('%%', '1')}"
+            "* #{length(32)} when #{length_cond('0')}",
+            "* #{length(64)} when #{length_cond('1')}"
           ].join("\n")
         else
           "#{length(effective_xlen)}-bit"

--- a/tools/ruby-gems/udb/test/test_csr.rb
+++ b/tools/ruby-gems/udb/test/test_csr.rb
@@ -6,7 +6,6 @@
 
 require_relative "test_helper"
 
-require "ostruct"
 require "concurrent"
 require "sorbet-runtime"
 require "udb/obj/csr"

--- a/tools/ruby-gems/udb/test/test_csr.rb
+++ b/tools/ruby-gems/udb/test/test_csr.rb
@@ -12,42 +12,41 @@ require "sorbet-runtime"
 require "udb/obj/csr"
 require "udb/cfg_arch"
 
-# Tests for Csr#dynamic_length? in the "XLEN" case.
+# Tests for Csr's XLEN reasoning: Csr#dynamic_length?, Csr#length_cond32,
+# Csr#length_cond64 and Csr#length_pretty in the "XLEN" case.
 #
-# An XLEN-length CSR is dynamic when ANY of the following independently holds:
-#   - MXLEN is unknown, OR
-#   - S-mode is possible and SXLEN is unknown/mutable, OR
-#   - H-mode is possible and VSXLEN is unknown/mutable.
-# i.e. the intent is a disjunction of three independent terms (A || B || C), as
-# documented by the method's own comments and mirrored by the sibling
-# "SXLEN" / "VSXLEN" branches (each of which independently signals dynamic).
+# An XLEN-length CSR is dynamic when the effective XLEN can vary in ANY privilege
+# mode that can reach it, which is exactly
+#   modes_with_access.any? { |mode| cfg_arch.multi_xlen_in_mode?(mode) }
+# The per-mode judgement belongs to ConfiguredArchitecture#multi_xlen_in_mode? and
+# is tested there, so these tests stub it and pin how Csr consults it.
 class TestCsr < Minitest::Test
   include Udb
 
   # Build a genuine ConfiguredArchitecture (so Sorbet sig checks pass) with just
-  # enough state injected to exercise Csr#dynamic_length?. Mirrors the approach in
+  # enough state injected to exercise the XLEN paths. Mirrors the approach in
   # test_register_file_obj.rb (allocate + define_singleton_method).
-  def make_cfg_arch(mxlen:, exts:, param_values:)
+  #
+  # @param dynamic_modes [Array<String>] modes whose effective XLEN can vary
+  def make_cfg_arch(dynamic_modes:)
     arch = Udb::ConfiguredArchitecture.allocate
     arch.instance_variable_set(:@objects, Concurrent::Hash.new)
     arch.instance_variable_set(:@object_hashes, Concurrent::Hash.new)
-    ext_objs = exts.map { |name| OpenStruct.new(name: name) }
-    arch.define_singleton_method(:mxlen) { mxlen }
-    arch.define_singleton_method(:possible_extensions) { ext_objs }
-    arch.define_singleton_method(:param_values) { param_values }
+    arch.define_singleton_method(:multi_xlen_in_mode?) { |mode| dynamic_modes.include?(mode) }
     arch
   end
 
   # Build a real Csr with the given length. base is seeded to nil (CSR defined in
   # all bases) so dynamic_length? reaches the length-based branches without invoking
   # the SAT/logic-tree machinery, which would require the full architecture database.
-  def make_csr(arch, length:)
+  def make_csr(arch, length:, priv_mode: "M")
     data = {
       "$schema" => "csr_schema.json#",
       "kind" => "csr",
       "name" => "xtest",
       "long_name" => "Test CSR",
       "length" => length,
+      "priv_mode" => priv_mode,
       "description" => "A test CSR."
     }
     csr = Csr.new(data, Pathname.new("/mock/csr/xtest.yaml"), arch)
@@ -55,50 +54,97 @@ class TestCsr < Minitest::Test
     csr
   end
 
-  # M + S, MXLEN known, SXLEN mutable, NO H extension.
   # S-mode alone makes the effective XLEN variable, so the CSR IS dynamic.
   # (Regression pin: the buggy `A || B && C` precedence returns false here.)
   def test_xlen_dynamic_when_only_sxlen_mutable
-    arch = make_cfg_arch(mxlen: 32, exts: %w[A S], param_values: { "SXLEN" => [32, 64] })
-    csr = make_csr(arch, length: "XLEN")
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[S]), length: "XLEN", priv_mode: "S")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when S-mode is possible and SXLEN is mutable, even without H"
   end
 
-  # M + H, MXLEN known, VSXLEN mutable, NO S extension.
-  # H-mode alone makes the effective XLEN variable, so the CSR IS dynamic.
+  # VS-mode alone makes the effective XLEN variable, so the CSR IS dynamic.
   def test_xlen_dynamic_when_only_vsxlen_mutable
-    arch = make_cfg_arch(mxlen: 32, exts: %w[A H], param_values: { "VSXLEN" => [32, 64] })
-    csr = make_csr(arch, length: "XLEN")
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[VS]), length: "XLEN", priv_mode: "S")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when H-mode is possible and VSXLEN is mutable, even without S"
   end
 
-  # Both S and H conditions dynamic -> still dynamic (already true before the fix).
+  # Both S and VS vary -> still dynamic.
   def test_xlen_dynamic_when_both_conditions_hold
-    arch = make_cfg_arch(
-      mxlen: 32, exts: %w[A S H],
-      param_values: { "SXLEN" => [32, 64], "VSXLEN" => [32, 64] }
-    )
-    csr = make_csr(arch, length: "XLEN")
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[S VS]), length: "XLEN", priv_mode: "S")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when both SXLEN and VSXLEN are mutable"
   end
 
-  # MXLEN unknown -> dynamic regardless of S/H.
+  # MXLEN unknown -> M-mode varies -> dynamic regardless of S/H.
   def test_xlen_dynamic_when_mxlen_unknown
-    arch = make_cfg_arch(mxlen: nil, exts: %w[A], param_values: {})
-    csr = make_csr(arch, length: "XLEN")
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M]), length: "XLEN", priv_mode: "M")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when MXLEN is unknown"
   end
 
-  # MXLEN known, S-mode possible but SXLEN fixed, no H -> NOT dynamic.
+  # No mode with access varies -> NOT dynamic.
   # Guards against an over-broad fix that makes everything dynamic.
   def test_xlen_not_dynamic_when_fully_pinned
-    arch = make_cfg_arch(mxlen: 32, exts: %w[A S], param_values: { "SXLEN" => [32] })
-    csr = make_csr(arch, length: "XLEN")
+    csr = make_csr(make_cfg_arch(dynamic_modes: []), length: "XLEN", priv_mode: "S")
     refute csr.dynamic_length?,
-      "XLEN CSR must not be dynamic when MXLEN is known and SXLEN is fixed with no H"
+      "XLEN CSR must not be dynamic when no mode with access can change XLEN"
+  end
+
+  # U-mode is reachable for a priv_mode: U CSR, so UXLEN alone makes it dynamic.
+  def test_xlen_dynamic_when_only_umode_varies
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[U]), length: "XLEN", priv_mode: "U")
+    assert csr.dynamic_length?,
+      "XLEN CSR readable in U-mode must be dynamic when UXLEN is mutable"
+  end
+
+  # VU-mode likewise.
+  def test_xlen_dynamic_when_only_vumode_varies
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[VU]), length: "XLEN", priv_mode: "U")
+    assert csr.dynamic_length?,
+      "XLEN CSR readable in VU-mode must be dynamic when VUXLEN is mutable"
+  end
+
+  # A varying mode that cannot reach the CSR must not make it dynamic.
+  def test_xlen_not_dynamic_when_varying_mode_has_no_access
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[U VU]), length: "XLEN", priv_mode: "M")
+    refute csr.dynamic_length?,
+      "M-mode-only CSR must not be dynamic because U-mode XLEN varies"
+  end
+
+  # The emitted condition must name every reachable mode that can vary, U and VU included.
+  def test_length_cond_covers_u_and_vu
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M S U VS VU]), length: "XLEN", priv_mode: "U")
+
+    assert_equal(
+      "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == 0) || " \
+      "(priv_mode() == PrivilegeMode::S && CSR[mstatus].SXL == 0) || " \
+      "(priv_mode() == PrivilegeMode::U && CSR[mstatus].UXL == 0) || " \
+      "(priv_mode() == PrivilegeMode::VS && CSR[hstatus].VSXL == 0) || " \
+      "(priv_mode() == PrivilegeMode::VU && CSR[vsstatus].UXL == 0)",
+      csr.length_cond32
+    )
+    assert_includes csr.length_cond64, "CSR[mstatus].UXL == 1"
+    assert_includes csr.length_cond64, "CSR[vsstatus].UXL == 1"
+  end
+
+  # ...and must name only those modes. An M-mode CSR gets the M disjunct alone.
+  def test_length_cond_is_limited_to_modes_with_access
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M S U VS VU]), length: "XLEN", priv_mode: "M")
+
+    assert_equal "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == 0)", csr.length_cond32
+    refute_includes csr.length_cond32, "SXL"
+    refute_includes csr.length_cond32, "VSXL"
+  end
+
+  # Every disjunct must carry the xlen encoding. The previous String#sub filled in
+  # only the first, leaving a literal "%%" in the rendered docs.
+  def test_length_pretty_fills_every_disjunct
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M S VS]), length: "XLEN", priv_mode: "S")
+
+    pretty = csr.length_pretty
+    refute_includes pretty, "%%", "length_pretty must not leak the substitution placeholder"
+    assert_equal 3, pretty.scan("== 0").size
+    assert_equal 3, pretty.scan("== 1").size
   end
 end

--- a/tools/ruby-gems/udb/test/test_csr.rb
+++ b/tools/ruby-gems/udb/test/test_csr.rb
@@ -16,10 +16,7 @@ require "udb/cfg_arch"
 # Csr#length_cond64 and Csr#length_pretty in the "XLEN" case.
 #
 # An XLEN-length CSR is dynamic when the effective XLEN can vary in ANY privilege
-# mode that can reach it, which is exactly
-#   modes_with_access.any? { |mode| cfg_arch.multi_xlen_in_mode?(mode) }
-# The per-mode judgement belongs to ConfiguredArchitecture#multi_xlen_in_mode? and
-# is tested there, so these tests stub it and pin how Csr consults it.
+# mode that can reach it.
 class TestCsr < Minitest::Test
   include Udb
 
@@ -57,28 +54,32 @@ class TestCsr < Minitest::Test
   # S-mode alone makes the effective XLEN variable, so the CSR IS dynamic.
   # (Regression pin: the buggy `A || B && C` precedence returns false here.)
   def test_xlen_dynamic_when_only_sxlen_mutable
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[S]), length: "XLEN", priv_mode: "S")
+    arch = make_cfg_arch(dynamic_modes: %w[S])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "S")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when S-mode is possible and SXLEN is mutable, even without H"
   end
 
   # VS-mode alone makes the effective XLEN variable, so the CSR IS dynamic.
   def test_xlen_dynamic_when_only_vsxlen_mutable
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[VS]), length: "XLEN", priv_mode: "S")
+    arch = make_cfg_arch(dynamic_modes: %w[VS])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "S")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when H-mode is possible and VSXLEN is mutable, even without S"
   end
 
   # Both S and VS vary -> still dynamic.
   def test_xlen_dynamic_when_both_conditions_hold
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[S VS]), length: "XLEN", priv_mode: "S")
+    arch = make_cfg_arch(dynamic_modes: %w[S VS])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "S")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when both SXLEN and VSXLEN are mutable"
   end
 
   # MXLEN unknown -> M-mode varies -> dynamic regardless of S/H.
   def test_xlen_dynamic_when_mxlen_unknown
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M]), length: "XLEN", priv_mode: "M")
+    arch = make_cfg_arch(dynamic_modes: %w[M])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "M")
     assert csr.dynamic_length?,
       "XLEN CSR must be dynamic when MXLEN is unknown"
   end
@@ -86,35 +87,40 @@ class TestCsr < Minitest::Test
   # No mode with access varies -> NOT dynamic.
   # Guards against an over-broad fix that makes everything dynamic.
   def test_xlen_not_dynamic_when_fully_pinned
-    csr = make_csr(make_cfg_arch(dynamic_modes: []), length: "XLEN", priv_mode: "S")
+    arch = make_cfg_arch(dynamic_modes: [])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "S")
     refute csr.dynamic_length?,
       "XLEN CSR must not be dynamic when no mode with access can change XLEN"
   end
 
   # U-mode is reachable for a priv_mode: U CSR, so UXLEN alone makes it dynamic.
   def test_xlen_dynamic_when_only_umode_varies
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[U]), length: "XLEN", priv_mode: "U")
+    arch = make_cfg_arch(dynamic_modes: %w[U])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "U")
     assert csr.dynamic_length?,
       "XLEN CSR readable in U-mode must be dynamic when UXLEN is mutable"
   end
 
   # VU-mode likewise.
   def test_xlen_dynamic_when_only_vumode_varies
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[VU]), length: "XLEN", priv_mode: "U")
+    arch = make_cfg_arch(dynamic_modes: %w[VU])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "U")
     assert csr.dynamic_length?,
       "XLEN CSR readable in VU-mode must be dynamic when VUXLEN is mutable"
   end
 
   # A varying mode that cannot reach the CSR must not make it dynamic.
   def test_xlen_not_dynamic_when_varying_mode_has_no_access
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[U VU]), length: "XLEN", priv_mode: "M")
+    arch = make_cfg_arch(dynamic_modes: %w[U VU])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "M")
     refute csr.dynamic_length?,
       "M-mode-only CSR must not be dynamic because U-mode XLEN varies"
   end
 
   # The emitted condition must name every reachable mode that can vary, U and VU included.
   def test_length_cond_covers_u_and_vu
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M S U VS VU]), length: "XLEN", priv_mode: "U")
+    arch = make_cfg_arch(dynamic_modes: %w[M S U VS VU])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "U")
 
     assert_equal(
       "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == 0) || " \
@@ -130,7 +136,8 @@ class TestCsr < Minitest::Test
 
   # ...and must name only those modes. An M-mode CSR gets the M disjunct alone.
   def test_length_cond_is_limited_to_modes_with_access
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M S U VS VU]), length: "XLEN", priv_mode: "M")
+    arch = make_cfg_arch(dynamic_modes: %w[M S U VS VU])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "M")
 
     assert_equal "(priv_mode() == PrivilegeMode::M && CSR[misa].MXL == 0)", csr.length_cond32
     refute_includes csr.length_cond32, "SXL"
@@ -140,7 +147,8 @@ class TestCsr < Minitest::Test
   # Every disjunct must carry the xlen encoding. The previous String#sub filled in
   # only the first, leaving a literal "%%" in the rendered docs.
   def test_length_pretty_fills_every_disjunct
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M S VS]), length: "XLEN", priv_mode: "S")
+    arch = make_cfg_arch(dynamic_modes: %w[M S VS])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "S")
 
     pretty = csr.length_pretty
     refute_includes pretty, "%%", "length_pretty must not leak the substitution placeholder"
@@ -167,7 +175,8 @@ class TestCsr < Minitest::Test
 
   # A CSR of fixed integer width has no xlen condition to report.
   def test_length_cond_raises_for_integer_length
-    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M]), length: 32, priv_mode: "M")
+    arch = make_cfg_arch(dynamic_modes: %w[M])
+    csr = make_csr(arch, length: 32, priv_mode: "M")
 
     err = assert_raises(RuntimeError) { csr.length_cond32 }
     assert_match(/Unexpected length/, err.message)
@@ -176,7 +185,8 @@ class TestCsr < Minitest::Test
   # Asking for the condition when nothing can vary is a caller error, not an
   # empty string. The templates only reach it when some mode does vary.
   def test_length_cond_raises_when_no_mode_varies
-    csr = make_csr(make_cfg_arch(dynamic_modes: []), length: "XLEN", priv_mode: "U")
+    arch = make_cfg_arch(dynamic_modes: [])
+    csr = make_csr(arch, length: "XLEN", priv_mode: "U")
 
     err = assert_raises(RuntimeError) { csr.length_cond32 }
     assert_match(/has a dynamic XLEN/, err.message)

--- a/tools/ruby-gems/udb/test/test_csr.rb
+++ b/tools/ruby-gems/udb/test/test_csr.rb
@@ -147,4 +147,38 @@ class TestCsr < Minitest::Test
     assert_equal 3, pretty.scan("== 0").size
     assert_equal 3, pretty.scan("== 1").size
   end
+
+  # The fixed-width lengths name one field and do not consult the mode list.
+  def test_length_cond_for_fixed_width_lengths
+    arch = make_cfg_arch(dynamic_modes: %w[M S U VS VU])
+
+    mxlen = make_csr(arch, length: "MXLEN", priv_mode: "M")
+    assert_equal "CSR[misa].MXL == 0", mxlen.length_cond32
+    assert_equal "CSR[misa].MXL == 1", mxlen.length_cond64
+
+    sxlen = make_csr(arch, length: "SXLEN", priv_mode: "S")
+    assert_equal "CSR[mstatus].SXL == 0", sxlen.length_cond32
+    assert_equal "CSR[mstatus].SXL == 1", sxlen.length_cond64
+
+    vsxlen = make_csr(arch, length: "VSXLEN", priv_mode: "VS")
+    assert_equal "CSR[hstatus].VSXL == 0", vsxlen.length_cond32
+    assert_equal "CSR[hstatus].VSXL == 1", vsxlen.length_cond64
+  end
+
+  # A CSR of fixed integer width has no xlen condition to report.
+  def test_length_cond_raises_for_integer_length
+    csr = make_csr(make_cfg_arch(dynamic_modes: %w[M]), length: 32, priv_mode: "M")
+
+    err = assert_raises(RuntimeError) { csr.length_cond32 }
+    assert_match(/Unexpected length/, err.message)
+  end
+
+  # Asking for the condition when nothing can vary is a caller error, not an
+  # empty string. The templates only reach it when some mode does vary.
+  def test_length_cond_raises_when_no_mode_varies
+    csr = make_csr(make_cfg_arch(dynamic_modes: []), length: "XLEN", priv_mode: "U")
+
+    err = assert_raises(RuntimeError) { csr.length_cond32 }
+    assert_match(/has a dynamic XLEN/, err.message)
+  end
 end

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -172,6 +172,7 @@ tests:
           - yaml_loader
           - cfg_arch
           - cfg
+          - csr
           - mmr
           - mmr_schema
           - schema_versioning


### PR DESCRIPTION
`Csr` keeps a second copy of the "can the effective XLEN change here" question, hardcoded to M, S and VS. `CsrField#dynamic_location?` already asks it over `modes_with_access` via `multi_xlen_in_mode?`, which covers every mode. This routes `Csr` through the same helper and builds the condition string from that mode list instead of hardcoding it.

Three things the hardcoded string got wrong:

- U and VU are never named, so the nine `priv_mode: U` CSRs with `length: XLEN` (`jvt`, `ssp` and the seven vector CSRs) emit a condition that is false whenever the hart is executing in U-mode.
- `tdata1`, `tdata2`, `tdata3` and `tselect` are M-mode only, but got the S and VS disjuncts anyway.
- `length_pretty` filled the encoding in with `String#sub`, which substitutes only the first of the three placeholders and leaves a literal `%%` in the rendered length line.

The per-mode field mapping follows `base32?` in `spec/std/isa/isa/globals.isa`.

`test_csr.rb` stubs `multi_xlen_in_mode?` rather than `param_values`, since that is the collaborator being consulted now. All five existing cases are kept, with six added for the cases above.

Second of the two PRs from #2463.
