### PR TITLE
feat(vtype): add ALTFMT field defined by Zvfbfa

### DIFF
--- a/spec/std/isa/csr/V/vtype.yaml
+++ b/spec/std/isa/csr/V/vtype.yaml
@@ -36,6 +36,25 @@ fields:
     type: RO-H
     reset_value(): |
       return (FOLLOW_VTYPE_RESET_RECOMMENDATION)? 1 : UNDEFINED_LEGAL;
+  ALTFMT:
+    location: 8
+    description: |
+      Selects the alternate floating-point format for vector floating-point instructions.
+
+      When ALTFMT is zero, the hart behaves as though Zvfbfa were not implemented.
+
+      Setting ALTFMT to one when SEW is greater than or equal to 32 is reserved.
+
+      [NOTE]
+      Implementations should set VILL when a reserved combination of ALTFMT and SEW is selected.
+
+      It is recommended that at reset, vill is set, and the remaining bits in vtype are zero.
+    definedBy:
+      extension:
+        name: Zvfbfa
+    type: RO-H
+    reset_value(): |
+      return (FOLLOW_VTYPE_RESET_RECOMMENDATION)? 0 : UNDEFINED_LEGAL;
   VMA:
     location: 7
     description: |


### PR DESCRIPTION
Adds the `ALTFMT` field to `vtype` per Zvfbfa extension.

Notes on the field definition:

- `type: RO-H` — matches every other `vtype` field. `vtype` sits at
  read-only ("URO") address `0xC21`; software updates it only indirectly via
  `vset{i}vl{i}`, so the field is hardware-updated.
- `reset_value()` — same pattern as the other fields.