### PR TITLE
feat(Sdtrig): add tinfo and tcontrol CSRs

### DIFF
--- a/spec/std/isa/csr/tcontrol.yaml
+++ b/spec/std/isa/csr/tcontrol.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
+$schema: "csr_schema.json#"
+kind: csr
+name: tcontrol
+long_name: Trigger Control
+address: 0x7A5
+priv_mode: M
+length: XLEN
+writable: true
+description: |
+  This optional register is only accessible in M-mode and Debug Mode and provides
+  various control bits related to triggers.
+definedBy:
+  extension:
+    name: Sdtrig
+fields:
+  MPTE:
+    location: 7
+    description: |
+      M-mode previous trigger enable field.
+      MPTE and MTE provide one solution to a problem regarding triggers with action=0
+      firing in M-mode trap handlers.
+      When any trap into M-mode is taken, MPTE is set to the value of MTE.
+    type: RW-H
+    reset_value: 0
+  MTE:
+    location: 3
+    description: |
+      M-mode trigger enable field.
+      0 (disabled):: Triggers with action=0 do not match/fire while the hart is in M-mode.
+      1 (enabled):: Triggers do match/fire while the hart is in M-mode.
+      When any trap into M-mode is taken, MTE is set to 0. When `mret` is executed, MTE is
+      set to the value of MPTE.
+    type: RW-H
+    reset_value: 0

--- a/spec/std/isa/csr/tinfo.yaml
+++ b/spec/std/isa/csr/tinfo.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
+$schema: "csr_schema.json#"
+kind: csr
+name: tinfo
+long_name: Trigger Info
+address: 0x7A4
+priv_mode: M
+length: XLEN
+writable: true
+description: |
+  This register provides access to the trigger selected by `tselect`.
+  The reset values listed here apply to every underlying trigger.
+
+  This register is optional if no triggers are implemented, or if `type` is not writable
+  and `version` would be 0. In this case the debugger can read the only supported type
+  from `tdata1`.
+
+  Writing this read/write CSR has no effect.
+definedBy:
+  extension:
+    name: Sdtrig
+fields:
+  VERSION:
+    location: 31-24
+    description: |
+      Contains the version of the Sdtrig extension implemented.
+
+      0 (0):: Supports triggers as described in this spec at commit 5a5c078, made on
+      February 2, 2023.
+
+      1 (1):: Supports triggers as described in the ratified version 1.0 of this document.
+    type: RO
+    reset_value: UNDEFINED_LEGAL
+  INFO:
+    location: 15-0
+    description: |
+      One bit for each possible `type` enumerated in `tdata1`. Bit N corresponds to type N.
+      If the bit is set, then that type is supported by the currently selected trigger.
+
+      If the currently selected trigger doesn't exist, this field contains 1.
+    type: RO
+    reset_value: UNDEFINED_LEGAL

--- a/spec/std/isa/csr/tinfo.yaml
+++ b/spec/std/isa/csr/tinfo.yaml
@@ -33,7 +33,7 @@ fields:
       1 (1):: Supports triggers as described in the ratified version 1.0 of this document.
     type: RO
     reset_value: UNDEFINED_LEGAL
-  INFO:
+  TYPES:
     location: 15-0
     description: |
       One bit for each possible `type` enumerated in `tdata1`. Bit N corresponds to type N.


### PR DESCRIPTION
Add the two Trigger Module registers that were missing from UDB.

Note: tinfo's INFO field renamed to TYPES.

The C++ hart generator emits an accessor named after each CSR field. A field named INFO produces INFO(), which collides with Catch2's INFO(msg) logging macro, breaking compilation of test_softfloat_fp.cpp in the rv64_Debug build.

The spec calls this field 'info'. TYPES describes the same contents, since the field is a bitmask of the trigger types supported by the currently selected trigger. The field description keeps the spec's wording.

This is a workaround for a generator-level issue: any CSR field whose name collides with a Catch2 macro (INFO, WARN, FAIL, CHECK, REQUIRE) would hit the same problem.