### PR TITLE
ci: add udb-64-max vector arch-test regression

### DIFF
--- a/cfgs/udb-64-max.yaml
+++ b/cfgs/udb-64-max.yaml
@@ -1,0 +1,566 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/riscv/riscv-unified-db/main/spec/schemas/config_schema.json
+---
+$schema: https://riscv.org/udb/schemas/config_schema-0.1.0.json
+kind: architecture configuration
+type: fully configured
+name: udb-64-max
+description: rv64 with all non-conflicting extensions enabled
+implemented_extensions:
+  - [A, "2.1.0"]
+  - [B, "1.0.0"]
+  - [C, "2.0"]
+  - [D, "2.2.0"]
+  - [F, "2.2.0"]
+  - [H, "1.0.0"]
+  - [I, "2.1"]
+  - [M, "2.0"]
+  - [Q, "2.2.0"]
+  - [S, "1.13.0"]
+  - [Sdext, "1.0.0"]
+  - [Sdtrig, "1.0.0"]
+  - [Sha, "1.0.0"]
+  - [Shcounterenw, "1.0.0"]
+  - [Shgatpa, "1.0.0"]
+  - [Shtvala, "1.0.0"]
+  - [Shvsatpa, "1.0.0"]
+  - [Shvstvala, "1.0.0"]
+  - [Shvstvecd, "1.0.0"]
+  - [Sm, "1.13.0"]
+  - [Smrnmi, "1.0.0"]
+  - [Smaia, "1.0.0"]
+  - [Smcdeleg, "1.0.0"]
+  - [Smcntrpmf, "1.0.0"]
+  - [Smcsrind, "1.0.0"]
+  - [Smctr, "1.0.0"]
+  - [Smdbltrp, "1.0.0"]
+  - [Smepmp, "1.0.0"]
+  - [Smmpm, "1.0.0"]
+  - [Smnpm, "1.0.0"]
+  - [Smstateen, "1.0.0"]
+  - [Ssaia, "1.0.0"]
+  - [Ssccfg, "1.0.0"]
+  - [Ssccptr, "1.0.0"]
+  - [Sscofpmf, "1.0.0"]
+  - [Sscounterenw, "1.0.0"]
+  - [Sscsrind, "1.0.0"]
+  - [Ssctr, "1.0.0"]
+  - [Ssdbltrp, "1.0.0"]
+  - [Ssnpm, "1.0.0"]
+  - [Sspm, "1.0.0"]
+  - [Ssqosid, "1.0.0"]
+  - [Ssstateen, "1.0.0"]
+  - [Ssstrict, "1.0.0"]
+  - [Sstc, "1.0.0"]
+  - [Sstvala, "1.0.0"]
+  - [Sstvecd, "1.0.0"]
+  - [Sstvecv, "1.0.0"]
+  - [Ssu64xl, "1.0.0"]
+  - [Ssube, "1.0.0"]
+  - [Supm, "1.0.0"]
+  - [Sv39, "1.0.0"]
+  - [Sv48, "1.0.0"]
+  - [Sv57, "1.0.0"]
+  - [Svade, "1.0.0"]
+  - [Svadu, "1.0.0"]
+  - [Svbare, "1.0.0"]
+  - [Svinval, "1.0.0"]
+  - [Svnapot, "1.0.0"]
+  - [Svpbmt, "1.0.0"]
+  - [Svrsw60t59b, "1.0.0"]
+  - [Svvptc, "1.0.0"]
+  - [U, "1.0.0"]
+  - [V, "1.0.0"]
+  - [Za128rs, "1.0.0"]
+  - [Za64rs, "1.0.0"]
+  - [Zaamo, "1.0.0"]
+  - [Zabha, "1.0.0"]
+  - [Zacas, "1.0.0"]
+  - [Zalasr, "1.0.0"]
+  - [Zalrsc, "1.0.0"]
+  - [Zama16b, "1.0.0"]
+  - [Zawrs, "1.0.0"]
+  - [Zba, "1.0.0"]
+  - [Zbb, "1.0.0"]
+  - [Zbc, "1.0.0"]
+  - [Zbkb, "1.0.0"]
+  - [Zbkc, "1.0.0"]
+  - [Zbkx, "1.0.0"]
+  - [Zbs, "1.0.0"]
+  - [Zca, "1.0.0"]
+  - [Zcb, "1.0.0"]
+  - [Zcd, "1.0.0"]
+  - [Zcmop, "1.0.0"]
+  - [Zfa, "1.0.0"]
+  - [Zfbfmin, "1.0.0"]
+  - [Zfh, "1.0.0"]
+  - [Zfhmin, "1.0.0"]
+  - [Zic64b, "1.0.0"]
+  - [Zicbom, "1.0.0"]
+  - [Zicbop, "1.0.0"]
+  - [Zicboz, "1.0.0"]
+  - [Ziccamoa, "1.0.0"]
+  - [Ziccamoc, "1.0.0"]
+  - [Ziccif, "1.0.0"]
+  - [Zicclsm, "1.0.0"]
+  - [Ziccrse, "1.0.0"]
+  - [Zicfilp, "1.0.0"]
+  - [Zicfiss, "1.0.0"]
+  - [Zicntr, "2.0"]
+  - [Zicond, "1.0"]
+  - [Zicsr, "2.0"]
+  - [Zifencei, "2.0.0"]
+  - [Zihintntl, "1.0.0"]
+  - [Zihintpause, "2.0.0"]
+  - [Zihpm, "2.0.0"]
+  - [Zimop, "1.0.0"]
+  - [Zk, "1.0.0"]
+  - [Zkn, "1.0.0"]
+  - [Zknd, "1.0.0"]
+  - [Zkne, "1.0.0"]
+  - [Zknh, "1.0.0"]
+  - [Zkr, "1.0.0"]
+  - [Zks, "1.0.0"]
+  - [Zksed, "1.0.0"]
+  - [Zksh, "1.0.0"]
+  - [Zkt, "1.0.0"]
+  - [Zmmul, "1.0.0"]
+  - [Zvbb, "1.0.0"]
+  - [Zvbc, "1.0.0"]
+  - [Zve32f, "1.0.0"]
+  - [Zve32x, "1.0.0"]
+  - [Zve64d, "1.0.0"]
+  - [Zve64f, "1.0.0"]
+  - [Zve64x, "1.0.0"]
+  - [Zvfbfmin, "1.0.0"]
+  - [Zvfbfwma, "1.0.0"]
+  - [Zvfh, "1.0.0"]
+  - [Zvfhmin, "1.0.0"]
+  - [Zvkb, "1.0.0"]
+  - [Zvkg, "1.0.0"]
+  - [Zvkn, "1.0.0"]
+  - [Zvknc, "1.0.0"]
+  - [Zvkned, "1.0.0"]
+  - [Zvkng, "1.0.0"]
+  - [Zvknha, "1.0.0"]
+  - [Zvknhb, "1.0.0"]
+  - [Zvks, "1.0.0"]
+  - [Zvksc, "1.0.0"]
+  - [Zvksed, "1.0.0"]
+  - [Zvksg, "1.0.0"]
+  - [Zvksh, "1.0.0"]
+  - [Zvkt, "1.0.0"]
+  - [Zvl32b, "1.0.0"]
+  - [Zvl64b, "1.0.0"]
+  - [Zvl128b, "1.0.0"]
+params:
+  # A params
+  MISALIGNED_AMO: false
+  LRSC_RESERVATION_STRATEGY: "reserve exactly enough to cover the access"
+  LRSC_FAIL_ON_VA_SYNONYM: false
+  LRSC_MISALIGNED_BEHAVIOR: "always raise access fault"
+  LRSC_FAIL_ON_NON_EXACT_LRSC: true
+  MUTABLE_MISA_A: false
+  # M params
+  MUTABLE_MISA_M: false
+  # F params
+  MUTABLE_MISA_F: false
+  HW_MSTATUS_FS_DIRTY_UPDATE: precise
+  MSTATUS_FS_LEGAL_VALUES: [0, 1, 2, 3]
+  # D params
+  MUTABLE_MISA_D: false
+  # Q params
+  MUTABLE_MISA_Q: false
+  # C params
+  MUTABLE_MISA_C: false
+  # B params
+  MUTABLE_MISA_B: true
+  # V params
+  #MUTABLE_MISA_V: false
+  #HW_MSTATUS_VS_DIRTY_UPDATE: precise
+  # CBO params
+  CACHE_BLOCK_SIZE: 64
+  FORCE_UPGRADE_CBO_INVAL_TO_FLUSH: false
+  # Zicntr params
+  TIME_CSR_IMPLEMENTED: true
+  # U params
+  MUTABLE_MISA_U: false
+  U_MODE_ENDIANNESS: dynamic
+  UXLEN: [64]
+  TRAP_ON_ECALL_FROM_U: true
+  # S params
+  MUTABLE_MISA_S: false
+  ASID_WIDTH: 16
+  S_MODE_ENDIANNESS: dynamic
+  SXLEN: [64]
+  REPORT_VA_IN_MTVAL_ON_LOAD_PAGE_FAULT: true
+  REPORT_VA_IN_MTVAL_ON_STORE_AMO_PAGE_FAULT: true
+  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_PAGE_FAULT: true
+  REPORT_VA_IN_STVAL_ON_BREAKPOINT: true
+  REPORT_VA_IN_STVAL_ON_LOAD_MISALIGNED: true
+  REPORT_VA_IN_STVAL_ON_STORE_AMO_MISALIGNED: true
+  REPORT_VA_IN_STVAL_ON_INSTRUCTION_MISALIGNED: true
+  REPORT_VA_IN_STVAL_ON_LOAD_ACCESS_FAULT: true
+  REPORT_VA_IN_STVAL_ON_STORE_AMO_ACCESS_FAULT: true
+  REPORT_VA_IN_STVAL_ON_INSTRUCTION_ACCESS_FAULT: true
+  REPORT_VA_IN_STVAL_ON_LOAD_PAGE_FAULT: true
+  REPORT_VA_IN_STVAL_ON_STORE_AMO_PAGE_FAULT: true
+  REPORT_VA_IN_STVAL_ON_INSTRUCTION_PAGE_FAULT: true
+  REPORT_ENCODING_IN_STVAL_ON_ILLEGAL_INSTRUCTION: true
+  STVAL_WIDTH: 64
+  SCOUNTENABLE_EN:
+    [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]
+  STVEC_MODES: [0, 1]
+  STVEC_BASE_ALIGNMENT_VECTORED: 4
+  SATP_MODE_BARE: true
+  TRAP_ON_ECALL_FROM_S: true
+  MSTATUS_VS_LEGAL_VALUES: [0, 1, 2, 3]
+  # Sm params
+  MXLEN: 64
+  PRECISE_SYNCHRONOUS_EXCEPTIONS: true
+  TRAP_ON_ECALL_FROM_M: true
+  TRAP_ON_EBREAK: true
+  MARCHID_IMPLEMENTED: true
+  ARCH_ID_VALUE: 0x5
+  MIMPID_IMPLEMENTED: true
+  IMP_ID_VALUE: 0
+  VENDOR_ID_BANK: 0
+  VENDOR_ID_OFFSET: 0
+  MISALIGNED_LDST: true
+  MISALIGNED_LDST_EXCEPTION_PRIORITY: low
+  MISALIGNED_MAX_ATOMICITY_GRANULE_SIZE: 4096
+  MISALIGNED_SPLIT_STRATEGY: sequential_bytes
+  TRAP_ON_UNIMPLEMENTED_INSTRUCTION: true
+  TRAP_ON_RESERVED_INSTRUCTION: true
+  TRAP_ON_UNIMPLEMENTED_CSR: true
+  TRAP_ON_ILLEGAL_WLRL: false
+  REPORT_VA_IN_MTVAL_ON_BREAKPOINT: true
+  REPORT_VA_IN_MTVAL_ON_LOAD_MISALIGNED: true
+  REPORT_VA_IN_MTVAL_ON_STORE_AMO_MISALIGNED: true
+  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_MISALIGNED: true
+  REPORT_VA_IN_MTVAL_ON_LOAD_ACCESS_FAULT: true
+  REPORT_VA_IN_MTVAL_ON_STORE_AMO_ACCESS_FAULT: true
+  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_ACCESS_FAULT: true
+  REPORT_ENCODING_IN_MTVAL_ON_ILLEGAL_INSTRUCTION: true
+  MTVAL_WIDTH: 64
+  CONFIG_PTR_ADDRESS: 0
+  PMA_GRANULARITY: 3
+  PHYS_ADDR_WIDTH: 56
+  M_MODE_ENDIANNESS: dynamic
+  MISA_CSR_IMPLEMENTED: true
+  MTVEC_ACCESS: rw
+  MTVEC_MODES: [0, 1]
+  MTVEC_BASE_ALIGNMENT_DIRECT: 4
+  MTVEC_BASE_ALIGNMENT_VECTORED: 4
+  MTVEC_ILLEGAL_WRITE_BEHAVIOR: retain
+  NUM_PMP_ENTRIES: 0
+  HPM_COUNTER_EN:
+    [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]
+  HPM_EVENTS: [0]
+  MCOUNTINHIBIT_IMPLEMENTED: true
+  COUNTINHIBIT_EN:
+    [
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]
+  MCOUNTENABLE_EN:
+    [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]
+  # Vector params
+  MUTABLE_MISA_V: false
+  VLEN: 128
+  ELEN: 64
+  FOLLOW_VTYPE_RESET_RECOMMENDATION: true
+  HW_MSTATUS_VS_DIRTY_UPDATE: precise
+  RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX: VLMAX
+  SEW_MIN: 8
+  SUPPORT_FRACTIONAL_LMUL_BEYOND_REQUIRED: "no_unrequired_supported"
+  VILL_SET_ON_RESERVED_VTYPE: true
+  RESERVED_VSET_X0X0_VILL_SET: "always"
+  RESERVED_VSET_X0X0_VLMAX_CHANGE: "always"
+  VECTOR_LS_INDEX_MAX_EEW: "XLEN"
+  VECTOR_FF_UPDATE_PAST_TRIM: "update_none"
+  VECTOR_FF_SEG_EXCEPTION_PARTIAL_LOAD: "no_subsegment_loaded"
+  VECTOR_LS_MISALIGNED_LEGAL: true
+  VECTOR_LOAD_PAST_TRAP: false
+  VECTOR_LOAD_SEG_FF_OVERWRITE_ELEMENTS_AFTER_FAULT: "no_overwrite"
+  VECTOR_LS_SEG_PARTIAL_ACCESS: false
+  LEGAL_VSTART: "1_stride"
+  VECTOR_LS_WHOLEREG_MISALIGNED_LEGAL: true
+  VSSTATUS_VS_EXISTS: true
+  VECTOR_FF_NO_EXCEPTION_TRIM: false
+  VFREDUSUM_NAN: "no_change"
+  VFREDUSUM_NODE_ROUNDING_BEHAVIOR: "SEW_precision"
+  VFREDUSUM_INACTIVE_NODE_ELEMENT_BEHAVIOR: "additive_identity"
+  VFREDUSUM_FINAL_NODE_ELEMENT_BEHAVIOR: "additive_identity"
+  IMPRECISE_VECTOR_TRAP_SETTABLE: false
+  # H params
+  MUTABLE_MISA_H: false
+  VSXLEN: [64]
+  VUXLEN: [64]
+  VMID_WIDTH: 14
+  VS_MODE_ENDIANNESS: little
+  VU_MODE_ENDIANNESS: little
+  GSTAGE_MODE_BARE: true
+  VSSTAGE_MODE_BARE: true
+  VSTVEC_MODES: [0, 1]
+  HSTATEEN_ENVCFG_TYPE: rw
+  IGNORE_INVALID_VSATP_MODE_WRITES_WHEN_V_EQ_ZERO: true
+  NUM_EXTERNAL_GUEST_INTERRUPTS: 63
+  REPORT_ENCODING_IN_VSTVAL_ON_ILLEGAL_INSTRUCTION: true
+  REPORT_ENCODING_IN_VSTVAL_ON_VIRTUAL_INSTRUCTION: true
+  REPORT_GPA_IN_HTVAL_ON_GUEST_PAGE_FAULT: true
+  REPORT_GPA_IN_TVAL_ON_INSTRUCTION_GUEST_PAGE_FAULT: true
+  REPORT_GPA_IN_TVAL_ON_INTERMEDIATE_GUEST_PAGE_FAULT: true
+  REPORT_GPA_IN_TVAL_ON_LOAD_GUEST_PAGE_FAULT: true
+  REPORT_GPA_IN_TVAL_ON_STORE_AMO_GUEST_PAGE_FAULT: true
+  REPORT_VA_IN_VSTVAL_ON_BREAKPOINT: true
+  REPORT_VA_IN_VSTVAL_ON_INSTRUCTION_ACCESS_FAULT: true
+  REPORT_VA_IN_VSTVAL_ON_INSTRUCTION_MISALIGNED: true
+  REPORT_VA_IN_VSTVAL_ON_INSTRUCTION_PAGE_FAULT: true
+  REPORT_VA_IN_VSTVAL_ON_LOAD_ACCESS_FAULT: true
+  REPORT_VA_IN_VSTVAL_ON_LOAD_MISALIGNED: true
+  REPORT_VA_IN_VSTVAL_ON_LOAD_PAGE_FAULT: true
+  REPORT_VA_IN_VSTVAL_ON_STORE_AMO_ACCESS_FAULT: true
+  REPORT_VA_IN_VSTVAL_ON_STORE_AMO_MISALIGNED: true
+  REPORT_VA_IN_VSTVAL_ON_STORE_AMO_PAGE_FAULT: true
+  SV39_VSMODE_TRANSLATION: true
+  SV39X4_TRANSLATION: true
+  SV48_VSMODE_TRANSLATION: true
+  SV48X4_TRANSLATION: true
+  SV57_VSMODE_TRANSLATION: true
+  SV57X4_TRANSLATION: true
+  TINST_VALUE_ON_BREAKPOINT: "always zero"
+  TINST_VALUE_ON_FINAL_INSTRUCTION_GUEST_PAGE_FAULT: "always zero"
+  TINST_VALUE_ON_FINAL_LOAD_GUEST_PAGE_FAULT: "always zero"
+  TINST_VALUE_ON_FINAL_STORE_AMO_GUEST_PAGE_FAULT: "always zero"
+  TINST_VALUE_ON_INSTRUCTION_ADDRESS_MISALIGNED: "always zero"
+  TINST_VALUE_ON_LOAD_ACCESS_FAULT: "always zero"
+  TINST_VALUE_ON_LOAD_ADDRESS_MISALIGNED: "always zero"
+  TINST_VALUE_ON_LOAD_PAGE_FAULT: "always zero"
+  TINST_VALUE_ON_MCALL: "always zero"
+  TINST_VALUE_ON_SCALL: "always zero"
+  TINST_VALUE_ON_STORE_AMO_ACCESS_FAULT: "always zero"
+  TINST_VALUE_ON_STORE_AMO_ADDRESS_MISALIGNED: "always zero"
+  TINST_VALUE_ON_STORE_AMO_PAGE_FAULT: "always zero"
+  TINST_VALUE_ON_UCALL: "always zero"
+  TINST_VALUE_ON_VIRTUAL_INSTRUCTION: "always zero"
+  TINST_VALUE_ON_VSCALL: "always zero"
+  TRAP_ON_ECALL_FROM_VS: true
+  HCOUNTENABLE_EN:
+    [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]
+  # Zicfilp params
+  REPORT_CAUSE_IN_MTVAL_ON_LANDING_PAD_SOFTWARE_CHECK: true
+  REPORT_CAUSE_IN_STVAL_ON_LANDING_PAD_SOFTWARE_CHECK: true
+  REPORT_CAUSE_IN_VSTVAL_ON_LANDING_PAD_SOFTWARE_CHECK: true
+  # Zicfiss params
+  REPORT_CAUSE_IN_MTVAL_ON_SHADOW_STACK_SOFTWARE_CHECK: true
+  REPORT_CAUSE_IN_STVAL_ON_SHADOW_STACK_SOFTWARE_CHECK: true
+  REPORT_CAUSE_IN_VSTVAL_ON_SHADOW_STACK_SOFTWARE_CHECK: true
+  # Sdtrig params
+  DBG_HCONTEXT_WIDTH: 14
+  DBG_SCONTEXT_WIDTH: 32
+  DCSR_MPRVEN_TYPE: rw
+  DCSR_STEPIE_TYPE: rw
+  DCSR_STOPCOUNT_TYPE: rw
+  DCSR_STOPTIME_TYPE: rw
+  HCONTEXT_AVAILABLE: true
+  HSTATEEN_CONTEXT_TYPE: rw
+  MCONTEXT_AVAILABLE: true
+  # Pointer masking params
+  PMLEN: 17
+  # Ssqosid params
+  MCID_WIDTH: 12
+  RCID_WIDTH: 12
+  # Smstateen params
+  MSTATEEN_ENVCFG_TYPE: rw
+  MSTATEEN_CONTEXT_TYPE: rw
+  # Csrind params
+  HSTATEEN_CSRIND_TYPE: rw
+  MSTATEEN_CSRIND_TYPE: rw
+  # AIA params
+  HSTATEEN_AIA_TYPE: rw
+  MSTATEEN_AIA_TYPE: rw
+  MSTATEEN_IMSIC_TYPE: rw
+  HSTATEEN_IMSIC_TYPE: rw
+  # Smctr params
+  MCTRCTL_CORSWAPINH_IMPLEMENTED: true
+  MCTRCTL_CUSTOM_IMPLEMENTED: false
+  MCTRCTL_DIRCALLINH_IMPLEMENTED: true
+  MCTRCTL_DIRJMPINH_IMPLEMENTED: true
+  MCTRCTL_DIRLJMPINH_IMPLEMENTED: true
+  MCTRCTL_EXCINH_IMPLEMENTED: true
+  MCTRCTL_INDCALLINH_IMPLEMENTED: true
+  MCTRCTL_INDJMPINH_IMPLEMENTED: true
+  MCTRCTL_INDLJMPINH_IMPLEMENTED: true
+  MCTRCTL_INTRINH_IMPLEMENTED: true
+  MCTRCTL_MTE_IMPLEMENTED: true
+  MCTRCTL_NTBREN_IMPLEMENTED: true
+  MCTRCTL_RASEMU_IMPLEMENTED: true
+  MCTRCTL_RETINH_IMPLEMENTED: true
+  MCTRCTL_STE_IMPLEMENTED: true
+  MCTRCTL_TKBRINH_IMPLEMENTED: true
+  MCTRCTL_TRETINH_IMPLEMENTED: true
+  SCTRDEPTH_DEPTH_LEGAL_VALUES: [16]
+  # Zawrs params
+  ZAWRS_NTO_IS_NOP: true

--- a/tools/test/gen_regress.py
+++ b/tools/test/gen_regress.py
@@ -32,7 +32,7 @@ def load_yaml(path: Path) -> dict[str, Any]:
 
 def validate_test(test_name: str, test_data: dict[str, Any]) -> None:
     ci_stage = test_data["ci_stage"]
-    if ci_stage not in {"pr", "merge_queue"}:
+    if ci_stage not in {"pr", "merge_queue", "manual"}:
         raise ValueError(f"bad ci_stage in test '{test_name}': {ci_stage}")
 
     matrix = test_data.get("strategy", {}).get("matrix")
@@ -101,13 +101,19 @@ def main() -> None:
     template_job_names = [name for name in regress_yaml["jobs"] if name != "never-runs"]
     tests = load_yaml(TEST_DIR / "regress-tests.yaml")
 
+    ci_tests: dict[str, Any] = {}
     for test_name, test_data in tests["tests"].items():
         validate_test(test_name, test_data)
+        if test_data["ci_stage"] == "manual":
+            continue
+        ci_tests[test_name] = test_data
+
+    for test_name, test_data in ci_tests.items():
         regress_yaml["jobs"][test_name] = create_job(test_data, regress_yaml)
 
     regress_yaml["jobs"]["regress-complete"] = {
         "runs-on": "ubuntu-latest",
-        "needs": list(tests["tests"].keys()) + template_job_names,
+        "needs": list(ci_tests.keys()) + template_job_names,
         "if": "always()",
         "steps": [
             {

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -258,6 +258,22 @@ tests:
       - name: Run vector riscv-tests
         run: ./do test:riscv_vector_tests CONFIG=rv64-vector IGNOREUNDEFINED=YES JOBS=4 BUILD_TYPE=debug
 
+  regress-riscv-arch-test-vector-udb-64-max:
+    ci_stage: manual
+    toolchain_container: true
+    tags:
+      - integration
+      - vector
+    timeout_minutes: 120
+    test:
+      - name: Run udb-64-max vector arch-tests
+        run: >
+          EXTENSIONS=Vx8,Vx16,Vx32,Vx64,Vls8,Vls16,Vls32,Vls64,Vf16,Vf32,Vf64
+          JOBS=4
+          BUILD_TYPE=debug
+          IGNOREUNDEFINED=YES
+          ./tools/test/run_udb_64_max_vector_arch_test.sh
+
   regress-profile-extensions:
     ci_stage: pr
     test:

--- a/tools/test/run_udb_64_max_vector_arch_test.sh
+++ b/tools/test/run_udb_64_max_vector_arch_test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+CONFIG="${CONFIG:-udb-64-max}"
+BUILD_TYPE="${BUILD_TYPE:-debug}"
+IGNOREUNDEFINED="${IGNOREUNDEFINED:-YES}"
+JOBS="${JOBS:-4}"
+EXTENSIONS="${EXTENSIONS:-Vx8,Vx16,Vx32,Vx64,Vls8,Vls16,Vls32,Vls64,Vf16,Vf32,Vf64}"
+
+RISCV_ARCH_TEST_REPO="${RISCV_ARCH_TEST_REPO:-https://github.com/riscv-non-isa/riscv-arch-test.git}"
+RISCV_ARCH_TEST_REF="${RISCV_ARCH_TEST_REF:-ba53eb88ad021dd69419cacfcfc9a3f8c104f988}"
+RISCV_ARCH_TEST_DIR="${RISCV_ARCH_TEST_DIR:-${ROOT}/ext/riscv-arch-test}"
+
+case "${BUILD_TYPE,,}" in
+  debug)
+    BUILD_DIR_TYPE="Debug"
+    ;;
+  release)
+    BUILD_DIR_TYPE="Release"
+    ;;
+  *)
+    echo "Unsupported BUILD_TYPE=${BUILD_TYPE}; expected debug or release." >&2
+    exit 2
+    ;;
+esac
+
+if [ "$CONFIG" != "udb-64-max" ]; then
+  echo "This runner currently supports CONFIG=udb-64-max only." >&2
+  exit 2
+fi
+
+if [ ! -e "${RISCV_ARCH_TEST_DIR}" ]; then
+  mkdir -p "$(dirname "${RISCV_ARCH_TEST_DIR}")"
+  git clone "${RISCV_ARCH_TEST_REPO}" "${RISCV_ARCH_TEST_DIR}"
+  git -C "${RISCV_ARCH_TEST_DIR}" checkout "${RISCV_ARCH_TEST_REF}"
+elif [ ! -d "${RISCV_ARCH_TEST_DIR}/.git" ]; then
+  echo "${RISCV_ARCH_TEST_DIR} exists but is not a Git checkout." >&2
+  exit 2
+fi
+
+echo "Using riscv-arch-test at $(git -C "${RISCV_ARCH_TEST_DIR}" rev-parse --short HEAD)"
+
+SOURCE_CONFIG_DIR="${RISCV_ARCH_TEST_DIR}/config/spike/spike-rv64-max"
+TARGET_CONFIG_DIR="${RISCV_ARCH_TEST_DIR}/config/udb/udb-64-max"
+ISS="${ROOT}/gen/cpp_hart_gen/udb-64-max_${BUILD_DIR_TYPE}/build/iss"
+UDB_CONFIG="${TARGET_CONFIG_DIR}/udb-64-max.yaml"
+
+if [ ! -d "${SOURCE_CONFIG_DIR}" ]; then
+  echo "Missing ${SOURCE_CONFIG_DIR}; selected riscv-arch-test checkout is not compatible." >&2
+  exit 2
+fi
+
+rm -rf "${TARGET_CONFIG_DIR}"
+mkdir -p "$(dirname "${TARGET_CONFIG_DIR}")"
+cp -a "${SOURCE_CONFIG_DIR}" "${TARGET_CONFIG_DIR}"
+rm -f "${TARGET_CONFIG_DIR}/spike-rv64-max.yaml"
+cp "${ROOT}/cfgs/udb-64-max.yaml" "${UDB_CONFIG}"
+
+perl -0pi -e 's/name: spike-rv64-max/name: udb-64-max/' "${TARGET_CONFIG_DIR}/test_config.yaml"
+perl -0pi -e 's/udb_config: spike-rv64-max\.yaml/udb_config: udb-64-max.yaml/' "${TARGET_CONFIG_DIR}/test_config.yaml"
+
+perl -0pi -e 's/"writable_fiom": false/"writable_fiom": true/' "${TARGET_CONFIG_DIR}/sail.json"
+perl -0pi -e 's/"count": 64/"count": 0/' "${TARGET_CONFIG_DIR}/sail.json"
+perl -0pi -e 's/"usable_count": 64/"usable_count": 0/' "${TARGET_CONFIG_DIR}/sail.json"
+perl -0pi -e 's/"arith": true/"arith": false/' "${TARGET_CONFIG_DIR}/sail.json"
+perl -0pi -e 's/"supported": false/"supported": true/' "${TARGET_CONFIG_DIR}/sail.json"
+
+cat > "${TARGET_CONFIG_DIR}/run_cmd.txt" <<EOF
+${ISS} -m udb-64-max -c ${UDB_CONFIG} --uart-base 0x10000000 --clint-base 0x02000000
+EOF
+
+cat > "${TARGET_CONFIG_DIR}/rvmodel_macros.h" <<'EOF'
+// rvmodel_macros.h for UDB ISS.
+// Uses standard HTIF tohost/fromhost termination via 64-bit writes.
+
+#ifndef RVMODEL_MACROS_H
+#define RVMODEL_MACROS_H
+
+#define RVMODEL_DATA_SECTION \
+    .pushsection .tohost,"aw",@progbits; \
+    .balign 8; .global tohost; tohost: .dword 0; \
+    .balign 8; .global fromhost; fromhost: .dword 0; \
+    .popsection;
+
+#define STANDARD_SM_SUPPORTED
+#undef SMRNMI_SUPPORTED
+
+#define UDB_ZAWRS_NTO_IS_NOP
+#define RVMODEL_ACCESS_FAULT_ADDRESS 0x00000000
+
+#define RVMODEL_HALT_PASS \
+    li   t0, 1;                           \
+    la   t1, tohost;                      \
+    sd   t0, 0(t1);                       \
+    1: j 1b;                              \
+
+#define RVMODEL_HALT_FAIL \
+    li   t0, 3;                           \
+    la   t1, tohost;                      \
+    sd   t0, 0(t1);                       \
+    1: j 1b;                              \
+
+#define RVMODEL_IO_INIT(_R1, _R2, _R3)
+#define RVMODEL_IO_WRITE_STR(_R1, _R2, _R3, _STR_PTR) \
+1:                           ;                        \
+  lbu  _R1, 0(_STR_PTR)      ;                        \
+  beqz _R1, 3f               ;                        \
+2:                           ;                        \
+  li   _R2, 0x10000005       ;                        \
+  lbu  _R3, 0(_R2)           ;                        \
+  andi _R3, _R3, 0x20        ;                        \
+  beqz _R3, 2b               ;                        \
+  li   _R2, 0x10000000       ;                        \
+  sb   _R1, 0(_R2)           ;                        \
+  addi _STR_PTR, _STR_PTR, 1 ;                        \
+  j 1b                       ;                        \
+3:
+#define RVMODEL_DATA_BEGIN
+#define RVMODEL_DATA_END
+
+#define RVMODEL_INTERRUPT_LATENCY  10
+#define RVMODEL_TIMER_INT_SOON_DELAY  100
+#define RVMODEL_MTIME_ADDRESS  0x0200BFF8
+#define RVMODEL_MTIMECMP_ADDRESS  0x02004000
+#define RVMODEL_MSIP_ADDRESS  0x02000000
+#define RVMODEL_TEST_INTERRUPT_ADDRESS 0x0c000004
+#define RVMODEL_SET_MEXT_INT(_R1, _R2) \
+    li _R1, (1 << 31) | (1 << 11); \
+    li _R2, RVMODEL_TEST_INTERRUPT_ADDRESS; \
+    sw _R1, 0(_R2)
+#define RVMODEL_CLR_MEXT_INT(_R1, _R2) \
+    li _R1, (1 << 11); \
+    li _R2, RVMODEL_TEST_INTERRUPT_ADDRESS; \
+    sw _R1, 0(_R2)
+#define RVMODEL_SET_MSW_INT(_R1, _R2) \
+    li _R1, 1; \
+    li _R2, RVMODEL_MSIP_ADDRESS; \
+    sw _R1, 0(_R2)
+#define RVMODEL_CLR_MSW_INT(_R1, _R2) \
+    li _R2, RVMODEL_MSIP_ADDRESS; \
+    sw zero, 0(_R2)
+#define RVMODEL_SET_SEXT_INT(_R1, _R2) \
+    li _R1, (1 << 31) | (1 << 9); \
+    li _R2, RVMODEL_TEST_INTERRUPT_ADDRESS; \
+    sw _R1, 0(_R2)
+#define RVMODEL_CLR_SEXT_INT(_R1, _R2) \
+    li _R1, (1 << 9); \
+    li _R2, RVMODEL_TEST_INTERRUPT_ADDRESS; \
+    sw _R1, 0(_R2)
+#define RVMODEL_SET_SSW_INT(_R1, _R2) \
+    li _R1, (1 << 31) | (1 << 1); \
+    li _R2, RVMODEL_TEST_INTERRUPT_ADDRESS; \
+    sw _R1, 0(_R2)
+#define RVMODEL_CLR_SSW_INT(_R1, _R2) \
+    li _R1, (1 << 1); \
+    li _R2, RVMODEL_TEST_INTERRUPT_ADDRESS; \
+    sw _R1, 0(_R2)
+
+#endif // RVMODEL_MACROS_H
+EOF
+
+"${ROOT}/do" build:iss "CONFIG=${CONFIG}" "BUILD_TYPE=${BUILD_TYPE}" \
+  "IGNOREUNDEFINED=${IGNOREUNDEFINED}" "JOBS=${JOBS}"
+
+make -C "${RISCV_ARCH_TEST_DIR}" udb-64-max \
+  "EXTENSIONS=${EXTENSIONS}" \
+  "JOBS=${JOBS}"

--- a/tools/test/run_udb_64_max_vector_arch_test.sh
+++ b/tools/test/run_udb_64_max_vector_arch_test.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+export PATH="${ROOT}/bin:${PATH}"
+
 CONFIG="${CONFIG:-udb-64-max}"
 BUILD_TYPE="${BUILD_TYPE:-debug}"
 IGNOREUNDEFINED="${IGNOREUNDEFINED:-YES}"

--- a/tools/test/tests-schema.json
+++ b/tools/test/tests-schema.json
@@ -95,7 +95,7 @@
               "items": { "type": "string" }
             },
             "ci_stage": {
-              "enum": ["pr", "merge_queue"]
+              "enum": ["pr", "merge_queue", "manual"]
             },
             "gh_save_artifact": {
               "description": "Use this if something from the test should be saved for a later action.\nThe upload *only* occurs when the test is being run on a `push` event to main.\nWhen used, the file or folder at `path` will be uploaded to github after all test steps complete.\n\nThis is typically used to save an artifact to display on the pages deployment.",


### PR DESCRIPTION
## Summary

Add reusable regression plumbing for running the riscv-arch-test vector suite against the UDB `udb-64-max` ISS configuration.

This includes:
- a checked-in `cfgs/udb-64-max.yaml` config used by the generated ISS build
- a `tools/test/run_udb_64_max_vector_arch_test.sh` runner that prepares a local riscv-arch-test UDB DUT config from the existing `spike-rv64-max` config
- a regression entry for `Vx`, `Vls`, and `Vf` vector test groups
- `ci_stage: manual` support so this regression can exist in-tree without being enforced in PR CI yet

## Why this is manual for now

The regression depends on vector ISS support that is being prepared separately. Keeping this as `ci_stage: manual` lets us land the plumbing first without making current upstream PR CI fail. A follow-up ISS-support PR can promote this regression to `ci_stage: pr` once the required support is available upstream.

## Local validation

Ran these lightweight checks on this branch:

```sh
/usr/bin/bash -n tools/test/run_udb_64_max_vector_arch_test.sh
git diff --check
uv run python tools/test/gen_regress.py
```

All passed.

Previously validated the intended command shape locally with the vector-capable tree:

```sh
./do build:iss CONFIG=udb-64-max BUILD_TYPE=DEBUG IGNOREUNDEFINED=YES JOBS=4
make udb-64-max EXTENSIONS=Vx8,Vx16,Vx32,Vx64,Vls8,Vls16,Vls32,Vls64,Vf16,Vf32,Vf64 JOBS=4
```

Result: all 1915 selected arch-tests passed in the vector-port environment.
