### PR TITLE
fix(data): correct Zaamo long name

### DIFF
--- a/spec/std/isa/ext/Zaamo.yaml
+++ b/spec/std/isa/ext/Zaamo.yaml
@@ -6,7 +6,7 @@
 $schema: "ext_schema.json#"
 kind: extension
 name: Zaamo
-long_name: Load-acquire/Store-release atomic instructions
+long_name: Atomic Memory Operations
 type: unprivileged
 versions:
   - version: "1.0.0"


### PR DESCRIPTION
Fixes #2543

This corrects Zaamo's `long_name` so it describes the atomic memory operations provided by the extension instead of the unrelated load-acquire/store-release instructions from Zalasr.

Validation: `./do test:schema`, the repository pre-commit hooks for the changed file, and focused YAML semantic assertions pass. `./bin/regress --all --jobs 8` exceeded the 10-minute local validation window, so the complete suite is deferred to CI.
