### PR TITLE
fix(idl,cpp): add 8- and 16-bit atomic RMW paths for Zabha

### DIFF
--- a/backends/cpp_hart_gen/cpp/include/udb/hart.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/hart.hpp
@@ -238,6 +238,14 @@ namespace udb {
                                 const PossiblyUnknownBits<32>& pte_len) {
       return atomically_set_pte_a_d(pte_paddr.get(), pte_value.get(), pte_len.get());
     }
+    Bits<8> atomic_read_modify_write_8(const PossiblyUnknownBits<64>& paddr, const PossiblyUnknownBits<8>& value,
+                                       AmoOperation op) {
+      return Bits<8>{m_soc.atomic_read_modify_write_8(paddr.get(), value.get(), op)};
+    }
+    Bits<16> atomic_read_modify_write_16(const PossiblyUnknownBits<64>& paddr, const PossiblyUnknownBits<16>& value,
+                                         AmoOperation op) {
+      return Bits<16>{m_soc.atomic_read_modify_write_16(paddr.get(), value.get(), op)};
+    }
     Bits<32> atomic_read_modify_write_32(const PossiblyUnknownBits<64>& paddr, const PossiblyUnknownBits<32>& value,
                                          AmoOperation op) {
       return Bits<32>{m_soc.atomic_read_modify_write_32(paddr.get(), value.get(), op)};

--- a/backends/cpp_hart_gen/cpp/include/udb/iss_soc_model.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/iss_soc_model.hpp
@@ -216,6 +216,128 @@ namespace udb {
                                    uint32_t pte_len) {
       return true;
     }
+    uint64_t atomic_read_modify_write_8(uint64_t phys_addr, uint64_t value,
+                                        AmoOperation op) {
+      switch (op.value()) {
+        case AmoOperation::Swap: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr, value, 1);
+          return orig;
+        }
+        case AmoOperation::Add: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr, orig + value, 1);
+          return orig;
+        }
+        case AmoOperation::And: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr, orig & value, 1);
+          return orig;
+        }
+        case AmoOperation::Or: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr, orig | value, 1);
+          return orig;
+        }
+        case AmoOperation::Xor: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr, orig ^ value, 1);
+          return orig;
+        }
+        case AmoOperation::Max: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr,
+                         std::max(static_cast<int8_t>(orig),
+                                  static_cast<int8_t>(value & 0xff)),
+                         1);
+          return orig;
+        }
+        case AmoOperation::Maxu: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr,
+                         std::max(orig, static_cast<uint8_t>(value & 0xff)), 1);
+          return orig;
+        }
+        case AmoOperation::Min: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr,
+                         std::min(static_cast<int8_t>(orig),
+                                  static_cast<int8_t>(value & 0xff)),
+                         1);
+          return orig;
+        }
+        case AmoOperation::Minu: {
+          uint8_t orig = m_memory.read(phys_addr, 1);
+          m_memory.write(phys_addr,
+                         std::min(orig, static_cast<uint8_t>(value & 0xff)), 1);
+          return orig;
+        }
+        default:
+          __builtin_unreachable();
+      }
+    }
+    uint64_t atomic_read_modify_write_16(uint64_t phys_addr, uint64_t value,
+                                         AmoOperation op) {
+      switch (op.value()) {
+        case AmoOperation::Swap: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr, value, 2);
+          return orig;
+        }
+        case AmoOperation::Add: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr, orig + value, 2);
+          return orig;
+        }
+        case AmoOperation::And: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr, orig & value, 2);
+          return orig;
+        }
+        case AmoOperation::Or: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr, orig | value, 2);
+          return orig;
+        }
+        case AmoOperation::Xor: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr, orig ^ value, 2);
+          return orig;
+        }
+        case AmoOperation::Max: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr,
+                         std::max(static_cast<int16_t>(orig),
+                                  static_cast<int16_t>(value & 0xffff)),
+                         2);
+          return orig;
+        }
+        case AmoOperation::Maxu: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(
+              phys_addr, std::max(orig, static_cast<uint16_t>(value & 0xffff)),
+              2);
+          return orig;
+        }
+        case AmoOperation::Min: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(phys_addr,
+                         std::min(static_cast<int16_t>(orig),
+                                  static_cast<int16_t>(value & 0xffff)),
+                         2);
+          return orig;
+        }
+        case AmoOperation::Minu: {
+          uint16_t orig = m_memory.read(phys_addr, 2);
+          m_memory.write(
+              phys_addr, std::min(orig, static_cast<uint16_t>(value & 0xffff)),
+              2);
+          return orig;
+        }
+        default:
+          __builtin_unreachable();
+      }
+    }
     uint64_t atomic_read_modify_write_32(uint64_t phys_addr, uint64_t value,
                                          AmoOperation op) {
       switch (op.value()) {

--- a/backends/cpp_hart_gen/cpp/include/udb/soc_model.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/soc_model.hpp
@@ -100,6 +100,16 @@ namespace udb {
                                static_cast<uint32_t>(0))
     } -> std::same_as<uint8_t>;
     {
+      s.atomic_read_modify_write_8(static_cast<uint64_t>(0),
+                                   static_cast<uint8_t>(0),
+                                   AmoOperation::ValueType{})
+    } -> std::same_as<uint64_t>;
+    {
+      s.atomic_read_modify_write_16(static_cast<uint64_t>(0),
+                                    static_cast<uint16_t>(0),
+                                    AmoOperation::ValueType{})
+    } -> std::same_as<uint64_t>;
+    {
       s.atomic_read_modify_write_32(static_cast<uint64_t>(0),
                                     static_cast<uint32_t>(0),
                                     AmoOperation::ValueType{})

--- a/backends/cpp_hart_gen/cpp/src/libhart_renode.cpp
+++ b/backends/cpp_hart_gen/cpp/src/libhart_renode.cpp
@@ -88,6 +88,14 @@ struct RenodeSocModel {
   uint8_t atomic_check_then_write_64(uint64_t, uint64_t, uint64_t) { return 0; }
   uint8_t atomically_set_pte_a(uint64_t, uint64_t, uint32_t) { return 0; }
   uint8_t atomically_set_pte_a_d(uint64_t, uint64_t, uint32_t) { return 0; }
+  uint64_t atomic_read_modify_write_8(uint64_t, uint64_t,
+                                      udb::AmoOperation::ValueType) {
+    return 0;
+  }
+  uint64_t atomic_read_modify_write_16(uint64_t, uint64_t,
+                                       udb::AmoOperation::ValueType) {
+    return 0;
+  }
   uint64_t atomic_read_modify_write_32(uint64_t, uint64_t,
                                        udb::AmoOperation::ValueType) {
     return 0;

--- a/backends/cpp_hart_gen/cpp/test/test_softfloat_fp.cpp
+++ b/backends/cpp_hart_gen/cpp/test/test_softfloat_fp.cpp
@@ -61,6 +61,8 @@ struct NullSocModel {
   uint8_t atomic_check_then_write_64(uint64_t, uint64_t, uint64_t) { return 0; }
   uint8_t atomically_set_pte_a(uint64_t, uint64_t, uint32_t) { return 0; }
   uint8_t atomically_set_pte_a_d(uint64_t, uint64_t, uint32_t) { return 0; }
+  uint64_t atomic_read_modify_write_8(uint64_t, uint8_t, AmoOperation::ValueType) { return 0; }
+  uint64_t atomic_read_modify_write_16(uint64_t, uint16_t, AmoOperation::ValueType) { return 0; }
   uint64_t atomic_read_modify_write_32(uint64_t, uint32_t, AmoOperation::ValueType) { return 0; }
   uint64_t atomic_read_modify_write_64(uint64_t, uint64_t, AmoOperation::ValueType) { return 0; }
   uint8_t pma_applies_Q_(PmaAttribute::ValueType, uint64_t, uint32_t) { return 1; }

--- a/backends/cpp_hart_gen/templates/libhart.h.erb
+++ b/backends/cpp_hart_gen/templates/libhart.h.erb
@@ -84,6 +84,8 @@ LINKAGE typedef struct {
   uint8_t (*atomic_check_then_write_64)(uint64_t, uint64_t, uint64_t);
   uint8_t (*atomically_set_pte_a)(uint64_t, uint64_t, uint32_t);
   uint8_t (*atomically_set_pte_a_d)(uint64_t, uint64_t, uint32_t);
+  uint64_t (*atomic_read_modify_write_8)(uint64_t, uint64_t, AmoOperationValueType);
+  uint64_t (*atomic_read_modify_write_16)(uint64_t, uint64_t, AmoOperationValueType);
   uint64_t (*atomic_read_modify_write_32)(uint64_t, uint64_t, AmoOperationValueType);
   uint64_t (*atomic_read_modify_write_64)(uint64_t, uint64_t, AmoOperationValueType);
 

--- a/backends/cpp_hart_gen/templates/libhart_renode.h.erb
+++ b/backends/cpp_hart_gen/templates/libhart_renode.h.erb
@@ -89,6 +89,8 @@ LINKAGE typedef struct {
   uint8_t (*atomic_check_then_write_64)(uint64_t, uint64_t, uint64_t);
   uint8_t (*atomically_set_pte_a)(uint64_t, uint64_t, uint32_t);
   uint8_t (*atomically_set_pte_a_d)(uint64_t, uint64_t, uint32_t);
+  uint64_t (*atomic_read_modify_write_8)(uint64_t, uint64_t, AmoOperationValueType);
+  uint64_t (*atomic_read_modify_write_16)(uint64_t, uint64_t, AmoOperationValueType);
   uint64_t (*atomic_read_modify_write_32)(uint64_t, uint64_t, AmoOperationValueType);
   uint64_t (*atomic_read_modify_write_64)(uint64_t, uint64_t, AmoOperationValueType);
 

--- a/spec/std/isa/isa/builtin_functions.idl
+++ b/spec/std/isa/isa/builtin_functions.idl
@@ -654,6 +654,38 @@ builtin function atomically_set_pte_a_d {
   }
 }
 
+builtin function atomic_read_modify_write_8 {
+  returns Bits<8>
+  arguments
+    Bits<PHYS_ADDR_WIDTH>  phys_addr,
+    Bits<8>                value,
+    AmoOperation           op
+  description {
+    Atomically read-modify-write 8-bits starting at phys_address using +value+ and +op+.
+
+    Return the original (unmodified) read value.
+
+    All access checks/alignment checks/etc. should be done before calling this function;
+    it's assumed the RMW is OK to proceed.
+  }
+}
+
+builtin function atomic_read_modify_write_16 {
+  returns Bits<16>
+  arguments
+    Bits<PHYS_ADDR_WIDTH>  phys_addr,
+    Bits<16>               value,
+    AmoOperation           op
+  description {
+    Atomically read-modify-write 16-bits starting at phys_address using +value+ and +op+.
+
+    Return the original (unmodified) read value.
+
+    All access checks/alignment checks/etc. should be done before calling this function;
+    it's assumed the RMW is OK to proceed.
+  }
+}
+
 builtin function atomic_read_modify_write_32 {
   returns Bits<32>
   arguments

--- a/spec/std/isa/isa/globals.isa
+++ b/spec/std/isa/isa/globals.isa
@@ -2978,8 +2978,10 @@ function amo {
       return atomic_read_modify_write_16(physical_address, value, op);
     } else if (N == 32) {
       return atomic_read_modify_write_32(physical_address, value, op);
-    } else {
+    } else if (N == 64) {
       return atomic_read_modify_write_64(physical_address, value, op);
+    } else {
+      unreachable();
     }
 
   }

--- a/spec/std/isa/isa/globals.isa
+++ b/spec/std/isa/isa/globals.isa
@@ -2972,7 +2972,11 @@ function amo {
       raise (ExceptionCode::StoreAmoAddressMisaligned, mode(), virtual_address);
     }
 
-    if (N == 32) {
+    if (N == 8) {
+      return atomic_read_modify_write_8(physical_address, value, op);
+    } else if (N == 16) {
+      return atomic_read_modify_write_16(physical_address, value, op);
+    } else if (N == 32) {
       return atomic_read_modify_write_32(physical_address, value, op);
     } else {
       return atomic_read_modify_write_64(physical_address, value, op);


### PR DESCRIPTION
`amo()` only checked for `N == 32` and sent everything else to the 64-bit read-modify-write, because those were the only two RMW builtins that existed. But all 72 non-CAS Zabha instructions call `amo(8, ...)` or `amo(16, ...)`, so every one of them did a 64-bit RMW: reading and writing 8 bytes at a byte address, wrecking up to 7 bytes next to it. `amomax.b`/`amomin.b` were worse, comparing a full doubleword signed against a zero-extended byte.

This adds `atomic_read_modify_write_8` and `_16` next to the existing pair, and makes `amo()` pick between all four widths. On the C++ side that means the two new `SocModel` requirements, the `hart.hpp` wrappers, the real implementations in `iss_soc_model.hpp`, and stubs in the renode and softfloat-test models. Signed `max`/`min` cast to `int8_t`/`int16_t` so the compare happens at the right width. `DenseMemory` already read and wrote 1 and 2 bytes, so nothing changed there.

With #2498 the Zabha byte/halfword AMOs are now right end to end - the RMW happens at the real width, and the `sext()` from that PR puts the correct value in `xd`.

Closes #2432.
