### PR TITLE
fix(test): isolate C++ unit build state

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -576,7 +576,7 @@ jobs:
         with:
           toolchain: true
       - name: Run cpp unit tests
-        run: ./do test:cpp_hart CONFIG=rv64 JOBS=4 BUILD_TYPE=debug
+        run: ./do test:cpp_hart CONFIG=rv64 BUILD_NAME=rv64-unit JOBS=4 BUILD_TYPE=debug
 
   regress-riscv-tests-32:
     runs-on: ubuntu-latest

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -226,7 +226,7 @@ tests:
       - unit
     test:
       - name: Run cpp unit tests
-        run: ./do test:cpp_hart CONFIG=rv64 JOBS=4 BUILD_TYPE=debug
+        run: ./do test:cpp_hart CONFIG=rv64 BUILD_NAME=rv64-unit JOBS=4 BUILD_TYPE=debug
 
   regress-riscv-tests-32:
     ci_stage: pr


### PR DESCRIPTION
The C++ unit regression and RV64 ISS regression both used `rv64_Debug`, but configure that shared CMake cache with incompatible `IGNOREUNDEFINED` values. Running C++ unit first could therefore leave RV64 with stale build state.

Reuse the existing `BUILD_NAME` input to place C++ unit in `rv64-unit_Debug`, while RV64 continues to use `rv64_Debug`. The generated regression workflow is updated from the source YAML.

Validated in an arm64 Linux fresh clone at `4cba519e9cbcd20a3e5eb818518a6d1f46c6391e`: C++ unit followed immediately by RV64 passes without cleaning, the caches retain `IGNOREUNDEFINED=NO` and `YES` respectively, and `./bin/regress --all --jobs 1` passes 67/67. Related to #2567.
