### PR TITLE
fix(data): make Zbc require Zbkc and define clmul/clmulh in Zbkc

### DIFF
--- a/spec/std/isa/ext/Zbc.yaml
+++ b/spec/std/isa/ext/Zbc.yaml
@@ -17,6 +17,10 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2021-06
+    requirements:
+      extension:
+        name: Zbkc
+        version: "~> 1.0.0"
     repositories:
       - url: https://github.com/riscv/riscv-bitmanip
         branch: main

--- a/spec/std/isa/inst/Zbkc/clmul.yaml
+++ b/spec/std/isa/inst/Zbkc/clmul.yaml
@@ -11,9 +11,7 @@ description: |
   `clmul` produces the lower half of the 2*XLEN carry-less product
 definedBy:
   extension:
-    anyOf:
-      - name: Zbc
-      - name: Zbkc
+    name: Zbkc
 assembly: xd, xs1, xs2
 encoding:
   match: 0000101----------001-----0110011

--- a/spec/std/isa/inst/Zbkc/clmulh.yaml
+++ b/spec/std/isa/inst/Zbkc/clmulh.yaml
@@ -11,9 +11,7 @@ description: |
   `clmulh` produces the upper half of the 2*XLEN carry-less product
 definedBy:
   extension:
-    anyOf:
-      - name: Zbc
-      - name: Zbkc
+    name: Zbkc
 assembly: xd, xs1, xs2
 encoding:
   match: 0000101----------011-----0110011

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -15696,10 +15696,15 @@ Decode Variables::
 Included in::
 
 
-This instruction requires the following:
+[width="100%",cols="1,2",options="header"]
+|===
+| Extension | Version
 
-xref:exts:Zbc.adoc#udb:doc:ext:Zbc[Zbc]
-xref:exts:Zbkc.adoc#udb:doc:ext:Zbkc[Zbkc]
+| *Zbkc*
+| any
+|===
+
+
 
 
 [#udb:doc:inst:clmulh]
@@ -15743,10 +15748,15 @@ Decode Variables::
 Included in::
 
 
-This instruction requires the following:
+[width="100%",cols="1,2",options="header"]
+|===
+| Extension | Version
 
-xref:exts:Zbc.adoc#udb:doc:ext:Zbc[Zbc]
-xref:exts:Zbkc.adoc#udb:doc:ext:Zbkc[Zbkc]
+| *Zbkc*
+| any
+|===
+
+
 
 
 [#udb:doc:inst:clmulr]


### PR DESCRIPTION
Zbkc is a proper subset of Zbc — both define clmul and clmulh, and Zbc adds clmulr — but the database did not record that relationship. Anything that walks requirements to derive implied extensions therefore missed Zbkc for a Zbc implementation; the new ACTs hit this concretely, running only the Zbc test suite for a Zbc implementation even though the hart has the Zbkc instructions.

This applies the same modelling the database already uses for M → Zmmul (added in #2299 for the same "proper subset" reason):

clmul and clmulh move to spec/std/isa/inst/Zbkc/ and are definedBy Zbkc only, instead of anyOf: [Zbc, Zbkc].
Zbc 1.0.0 gains requirements: extension: {name: Zbkc, version: "~> 1.0.0"}, which covers both ratified Zbkc versions (1.0.0 and 1.0.1).
clmulr is untouched — it stays definedBy Zbc, which is where it belongs.
A Zbc implementation still has all three instructions, now by way of the required Zbkc. As with M, Zbc's own directly-defined instruction list is reduced to just its unique instruction.

Verified with ./do test:schema, ./do test:inst_encodings, ./bin/regress --tag smoke (17/17), and pre-commit hooks. ./do gen:cfg produces no changes to the generated profile configs.

Closes #2535 