### PR TITLE
fix(data): correct Sv32 page table level count from 3 to 2

### DIFF
--- a/spec/std/isa/ext/Sv32.yaml
+++ b/spec/std/isa/ext/Sv32.yaml
@@ -6,8 +6,8 @@
 $schema: "ext_schema.json#"
 kind: extension
 name: Sv32
-long_name: 32-bit virtual address translation (3 level)
-description: 32-bit virtual address translation (3 level)
+long_name: 32-bit virtual address translation (2 level)
+description: 32-bit virtual address translation (2 level)
 type: privileged
 versions:
   - version: "1.0"


### PR DESCRIPTION
Sv32's long_name and description both read "32-bit virtual address translation (3 level)". Sv32 uses a two-level page table — VPN[1] selects a 4 MiB megapage and VPN[0] a 4 KiB page, per the Sv32 section of the Privileged ISA specification. Three levels is Sv39.

Closes #2541 