### PR TITLE
fix(spec): correct Sv32 page-table levels

### DIFF
--- a/spec/std/isa/ext/Sv32.yaml
+++ b/spec/std/isa/ext/Sv32.yaml
@@ -6,8 +6,8 @@
 $schema: "ext_schema.json#"
 kind: extension
 name: Sv32
-long_name: 32-bit virtual address translation (3 level)
-description: 32-bit virtual address translation (3 level)
+long_name: 32-bit virtual address translation (2 level)
+description: 32-bit virtual address translation (2 level)
 type: privileged
 versions:
   - version: "1.0"


### PR DESCRIPTION
Closes #2541.

Correct the Sv32 extension's `long_name` and `description` to identify its two-level page table. Sv39 remains the neighboring three-level scheme.

The YAML parses successfully and both authoritative fields were checked for the corrected value. AI-assisted with Codex; the change was reviewed against the issue and neighboring extension entries.
