### PR TITLE
feat(xce_json): add standalone JSON exporter

### DIFF
--- a/backends/xce_json/README.adoc
+++ b/backends/xce_json/README.adoc
@@ -1,0 +1,98 @@
+= XCE JSON Exporter
+
+The XCE JSON backend is a standalone exporter that converts structural UDB
+instruction data into the JSON format consumed by XuanTie Custom Extension
+(XCE) tools. It is exposed through its own Rake task and is not integrated into
+UDB's main generator framework.
+
+== Usage
+
+[source,bash]
+----
+./do gen:xce_json CONFIG=rv64 \
+  EXTENSIONS=I INSTRUCTIONS=add,addi
+----
+
+The task accepts these environment variables:
+
+`CONFIG`:: Required UDB configuration name.
+`OUTPUT_DIR`:: Optional output directory; defaults to `gen/xce_json`.
+`EXTENSIONS`:: Optional comma-separated extension filter.
+`INSTRUCTIONS`:: Optional comma-separated instruction mnemonic filter.
+
+When supplied, `EXTENSIONS` and `INSTRUCTIONS` must each contain at least one
+non-whitespace value. An empty selector is rejected instead of being treated as
+an unfiltered export.
+
+`CONFIG` constrains the export to instructions that are possible in that UDB
+configuration. The configuration must determine MXLEN as 32 or 64; that MXLEN
+selects the instruction encoding and becomes the module `arch`.
+
+To override the default output directory:
+
+[source,bash]
+----
+./do gen:xce_json CONFIG=rv64 OUTPUT_DIR=/tmp/xce-json
+----
+
+The exporter writes one `<extension>.json` file per selected extension. Each
+file represents one XCE module directly; there is no enclosing `module` field.
+
+[source,json]
+----
+{
+  "name": "I",
+  "arch": "rv64",
+  "type": "integer",
+  "instructions": [
+    {
+      "asm": "add $xd, $xs1, $xs2",
+      "encoding": [
+        { "offset": 0, "size": 7, "type": "bits", "value": "0x33" },
+        { "offset": 7, "size": 5, "type": "r", "value": "xd", "constraint": "=" }
+      ],
+      "size": 32,
+      "type": "integer"
+    }
+  ]
+}
+----
+
+The exact instruction fields depend on the UDB definition. The exporter emits
+structural information such as assembly syntax, encoding, instruction size,
+architecture, type, and representable operand constraints. It does not emit
+XCE execution semantics, and regenerating a module replaces that module's
+existing output file.
+
+== Unsupported instructions
+
+Some UDB constructs cannot currently be represented by XCE JSON, including
+split encoding fields and register accesses whose operands cannot be determined
+statically. Instructions whose unexpanded `definedBy` condition contains
+multiple distinct extension names are also unsupported because this format
+cannot express an unambiguous owning module. During an unfiltered or
+extension-filtered export, these instructions are skipped and reported with
+their reason. When an unsupported instruction is selected explicitly with
+`INSTRUCTIONS`, the task fails instead of silently omitting it. If every
+selected instruction is skipped, all skip reasons are printed before the task
+reports that no instructions were generated.
+
+An unfiltered invocation scans every instruction in the selected configuration:
+
+[source,bash]
+----
+./do gen:xce_json CONFIG=rv64
+----
+
+Each JSON file is replaced atomically. An export that writes multiple module
+files is not transactional: if a later file cannot be written, files replaced
+earlier in the same export remain updated. The task reports the affected path
+and exits with an error.
+
+== Current IDL dependency
+
+The operand analysis currently loads `cpp_hart_gen/lib/gen_cpp` because the
+existing IDL pass used to determine register accesses calls helpers provided by
+that backend. The XCE exporter does not generate C++. Removing this coupling
+requires a separate target-neutral UDB/IDL interface change and is outside this
+backend's current scope.

--- a/backends/xce_json/lib/encoding_converter.rb
+++ b/backends/xce_json/lib/encoding_converter.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative "errors"
+
+module XceJson
+  module EncodingConverter
+    def self.convert(inst, base, constraints)
+      entries = extract_fixed_bits(inst.encoding_format(base))
+
+      inst.decode_variables(base).each do |var|
+        entries << convert_variable(inst, var, constraints)
+      end
+
+      entries.sort_by { |entry| entry["offset"] }
+    end
+
+    def self.extract_fixed_bits(format_str)
+      entries = []
+      index = format_str.length - 1
+
+      while index >= 0
+        if %w[0 1].include?(format_str[index])
+          offset = format_str.length - 1 - index
+          bits = format_str[index]
+          while index.positive? && %w[0 1].include?(format_str[index - 1])
+            index -= 1
+            bits = format_str[index] + bits
+          end
+          entries << {
+            "offset" => offset,
+            "size" => bits.length,
+            "type" => "bits",
+            "value" => "0x#{bits.to_i(2).to_s(16).upcase}"
+          }
+        end
+        index -= 1
+      end
+
+      entries
+    end
+
+    def self.convert_variable(inst, var, constraints)
+      offset, size = location(inst, var)
+      entry = {
+        "offset" => offset,
+        "size" => size,
+        "type" => operand_type(var),
+        "value" => var.name
+      }
+      constraint = constraints[var.name]
+      entry["constraint"] = constraint if constraint && !constraint.empty?
+      entry
+    end
+
+    def self.location(inst, var)
+      value = var.location.to_s
+      if value.include?("|")
+        raise UnsupportedInstructionError.new(inst.name, "split encoding field '#{var.name}'")
+      end
+
+      bit = /\A(\d+)\z/.match(value)
+      return [bit[1].to_i, 1] if bit
+
+      range = /\A(\d+)-(\d+)\z/.match(value)
+      if range
+        msb = range[1].to_i
+        lsb = range[2].to_i
+        if msb < lsb
+          raise InvalidEncodingError, "Instruction '#{inst.name}' has invalid encoding location '#{value}'"
+        end
+        return [lsb, msb - lsb + 1]
+      end
+
+      raise InvalidEncodingError, "Instruction '#{inst.name}' has invalid encoding location '#{value}'"
+    end
+
+    def self.operand_type(var)
+      name = var.name
+      return "r" if name.start_with?("x")
+      return "f" if name.start_with?("f")
+      return "vm" if name == "vm"
+      return "vr" if name.start_with?("v")
+      return "imm" if var.respond_to?(:sext?) && var.sext?
+
+      "bits"
+    end
+
+    private_class_method :extract_fixed_bits, :convert_variable, :location, :operand_type
+  end
+end

--- a/backends/xce_json/lib/errors.rb
+++ b/backends/xce_json/lib/errors.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module XceJson
+  class Error < StandardError; end
+  class ConfigurationError < Error; end
+  class ExtensionNotFoundError < Error; end
+  class InstructionNotFoundError < Error; end
+  class InvalidEncodingError < Error; end
+  class OutputError < Error; end
+
+  class NoInstructionsGeneratedError < Error
+    attr_reader :skipped
+
+    def initialize(message = "No XCE JSON instructions were generated", skipped: [])
+      @skipped = skipped.freeze
+      super(message)
+    end
+  end
+
+  class UnsupportedInstructionError < Error
+    attr_reader :instruction, :reason
+
+    def initialize(instruction, reason)
+      @instruction = instruction
+      @reason = reason
+      super("Instruction '#{instruction}' is unsupported: #{reason}")
+    end
+  end
+end

--- a/backends/xce_json/lib/errors.rb
+++ b/backends/xce_json/lib/errors.rb
@@ -7,6 +7,7 @@ module XceJson
   class InstructionNotFoundError < Error; end
   class InvalidEncodingError < Error; end
   class OutputError < Error; end
+  class TestError < Error; end
 
   class NoInstructionsGeneratedError < Error
     attr_reader :skipped

--- a/backends/xce_json/lib/exporter.rb
+++ b/backends/xce_json/lib/exporter.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "tempfile"
+require "udb/resolver"
+
+require_relative "errors"
+require_relative "instruction_selector"
+require_relative "instruction_converter"
+
+module XceJson
+  ExportResult = Data.define(:xlen, :exported, :skipped, :output_paths)
+
+  module Exporter
+    def self.generate(cfg_name:, extension_filter: nil, instruction_filter: nil, output_dir:)
+      cfg_arch = load_config(cfg_name)
+      xlen = cfg_arch.mxlen
+      unless [32, 64].include?(xlen)
+        raise ConfigurationError, "Config '#{cfg_name}' must determine MXLEN as 32 or 64"
+      end
+
+      selection = InstructionSelector.select(
+        cfg_arch,
+        xlen:,
+        extension_filter:,
+        instruction_filter:
+      )
+      export_modules(selection, instruction_filter, output_dir, xlen)
+    end
+
+    def self.load_config(cfg_name)
+      Udb::Resolver.new.cfg_arch_for(cfg_name)
+    rescue StandardError => e
+      raise ConfigurationError, "Failed to load config '#{cfg_name}': #{e.message}"
+    end
+
+    def self.export_modules(selection, instruction_filter, output_dir, xlen)
+      exported = 0
+      skipped = selection.skipped.dup
+      output_paths = []
+
+      selection.groups.each do |extension_name, instructions|
+        instruction_data = instructions.filter_map do |instruction|
+          InstructionConverter.convert(instruction, xlen)
+        rescue UnsupportedInstructionError => e
+          raise if instruction_filter && !instruction_filter.empty?
+
+          skipped << SkippedInstruction.new(e.instruction, e.reason)
+          nil
+        end
+        next if instruction_data.empty?
+
+        document = build_module(extension_name, instruction_data, xlen)
+        output_path = File.join(output_dir, "#{extension_name}.json")
+        write_output(document, output_path)
+        output_paths << output_path
+        exported += instruction_data.size
+      end
+
+      raise NoInstructionsGeneratedError.new(skipped:) if exported.zero?
+
+      ExportResult.new(xlen:, exported:, skipped:, output_paths:)
+    end
+
+    def self.build_module(extension_name, instructions, xlen)
+      types = instructions.map { |instruction| instruction["type"] }.uniq
+      {
+        "name" => extension_name,
+        "arch" => "rv#{xlen}",
+        "type" => types.one? ? types.first : "",
+        "instructions" => instructions
+      }
+    end
+
+    def self.write_output(document, path)
+      directory = File.dirname(path)
+      FileUtils.mkdir_p(directory)
+
+      Tempfile.create([".#{File.basename(path)}", ".tmp"], directory) do |file|
+        file.write(JSON.pretty_generate(document))
+        file.write("\n")
+        file.flush
+        file.fsync
+        file.chmod(0o666 & ~File.umask)
+        File.rename(file.path, path)
+      end
+    rescue SystemCallError => e
+      raise OutputError, "Failed to write '#{path}': #{e.message}"
+    end
+
+    private_class_method :load_config, :export_modules, :build_module, :write_output
+  end
+end

--- a/backends/xce_json/lib/instruction_converter.rb
+++ b/backends/xce_json/lib/instruction_converter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "set"
+
+require_relative "operand_constraints"
+require_relative "encoding_converter"
+
+module XceJson
+  module InstructionConverter
+    def self.convert(instruction, xlen)
+      constraints = OperandConstraints.derive(instruction, xlen)
+      attributes = derive_attributes(instruction, xlen)
+
+      result = {
+        "asm" => convert_asm(instruction, xlen),
+        "encoding" => EncodingConverter.convert(instruction, xlen, constraints),
+        "size" => instruction.encoding_width,
+        "type" => attributes[:type]
+      }
+      result["arch"] = attributes[:arch] if attributes[:arch]
+      result
+    end
+
+    def self.convert_asm(instruction, base)
+      assembly = instruction.assembly
+      return instruction.name if assembly.nil? || assembly.empty?
+
+      variable_names = instruction.decode_variables(base).map(&:name).to_set
+      operands = assembly.gsub(/\b(\w+)\b/) do |word|
+        variable_names.include?(word) ? "$#{word}" : word
+      end
+      "#{instruction.name} #{operands}"
+    end
+
+    def self.derive_attributes(instruction, base)
+      variable_names = instruction.decode_variables(base).map(&:name)
+      type = if variable_names.any? { |name| name == "vm" || name.start_with?("v") }
+               "vector"
+             elsif variable_names.any? { |name| name.start_with?("f") }
+               "float"
+             else
+               "integer"
+             end
+
+      attributes = { type: }
+      attributes[:arch] = "rv#{instruction.base}" if instruction.base
+      attributes
+    end
+
+    private_class_method :convert_asm, :derive_attributes
+  end
+end

--- a/backends/xce_json/lib/instruction_selector.rb
+++ b/backends/xce_json/lib/instruction_selector.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "set"
+require_relative "errors"
+
+module XceJson
+  SkippedInstruction = Data.define(:instruction, :reason)
+  SelectionResult = Data.define(:groups, :skipped)
+
+  module InstructionSelector
+    # @param cfg_arch [Udb::ConfiguredArchitecture]
+    # @param extension_filter [Array<String>, nil]
+    # @param instruction_filter [Array<String>, nil]
+    # @return [SelectionResult]
+    def self.select(cfg_arch, xlen:, extension_filter: nil, instruction_filter: nil)
+      candidates = cfg_arch.possible_instructions.select do |instruction|
+        instruction.defined_in_base?(xlen)
+      end
+      validate_extensions!(candidates, extension_filter) if extension_filter
+
+      result = Hash.new { |hash, key| hash[key] = [] }
+      skipped = []
+      seen = Set.new
+      requested = instruction_filter&.to_set
+
+      candidates.each do |instruction|
+        next if requested && !requested.include?(instruction.name)
+
+        names = extension_names(instruction).uniq.sort
+        next if extension_filter && (names & extension_filter).empty?
+
+        begin
+          owner_extension = determine_owner(instruction, names)
+        rescue UnsupportedInstructionError => e
+          raise if requested&.include?(instruction.name)
+
+          skipped << SkippedInstruction.new(e.instruction, e.reason)
+          next
+        end
+
+        next if owner_extension.nil?
+        next if seen.include?(instruction.name)
+
+        seen.add(instruction.name)
+        result[owner_extension] << instruction
+      end
+
+      missing = requested&.difference(seen)
+      unless missing.nil? || missing.empty?
+        raise InstructionNotFoundError,
+              "Instruction(s) not found for the selected config/extensions: #{missing.to_a.sort.join(', ')}"
+      end
+
+      SelectionResult.new(result, skipped)
+    end
+
+    def self.validate_extensions!(candidates, extension_filter)
+      available = candidates.flat_map { |instruction| extension_names(instruction) }.to_set
+      extension_filter.each do |extension_name|
+        unless available.include?(extension_name)
+          raise ExtensionNotFoundError, "Extension '#{extension_name}' is not available in the selected config"
+        end
+      end
+    end
+
+    def self.determine_owner(instruction, names)
+      return nil if names.empty?
+      if names.size > 1
+        raise UnsupportedInstructionError.new(
+          instruction.name,
+          "extension ownership cannot be determined from: #{names.join(', ')}"
+        )
+      end
+
+      names.first
+    end
+
+    def self.extension_names(instruction)
+      instruction.defined_by_condition
+                 .ext_req_terms(expand: false)
+                 .map { |term| term.extension.name }
+    end
+
+    private_class_method :validate_extensions!, :determine_owner, :extension_names
+  end
+end

--- a/backends/xce_json/lib/operand_constraints.rb
+++ b/backends/xce_json/lib/operand_constraints.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "set"
+require "idlc/passes/find_src_registers"
+require_relative "../../cpp_hart_gen/lib/gen_cpp"
+require_relative "errors"
+
+module XceJson
+  module OperandConstraints
+    def self.derive(instruction, base)
+      return {} unless instruction.operation_ast
+
+      pruned_ast = instruction.pruned_operation_ast(base)
+      symtab = instruction.fill_symtab(base, pruned_ast)
+      source_registers = pruned_ast.find_src_registers(symtab)
+      destination_registers = pruned_ast.find_dst_registers(symtab)
+      variable_names = instruction.decode_variables(base).map(&:name).to_set
+      constraints = {}
+
+      source_registers.each do |_register_file, index|
+        name = explicit_operand(variable_names, index)
+        constraints[name] ||= "" if name
+      end
+
+      destination_registers.each do |_register_file, index|
+        name = explicit_operand(variable_names, index)
+        next unless name
+
+        constraints[name] = constraints[name] == "" ? "+" : "="
+      end
+
+      constraints
+    rescue Idl::ComplexRegDetermination
+      raise UnsupportedInstructionError.new(instruction.name, "operand register access cannot be determined")
+    ensure
+      symtab&.release
+    end
+
+    def self.explicit_operand(variable_names, index)
+      name = index.to_s.delete_suffix("()")
+      variable_names.include?(name) ? name : nil
+    end
+
+    private_class_method :explicit_operand
+  end
+end

--- a/backends/xce_json/lib/test_runner.rb
+++ b/backends/xce_json/lib/test_runner.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "json"
+require "tmpdir"
+require "yaml"
+require_relative "errors"
+
+module XceJson
+  module TestRunner
+    REQUIRED_FIELDS = %w[name cfg extension instruction expected].freeze
+
+    def self.load_manifest(path)
+      document = YAML.safe_load(File.read(path), permitted_classes: [], aliases: false)
+      cases = document.is_a?(Hash) ? document["cases"] : nil
+      raise TestError, "#{path}: 'cases' must be an array" unless cases.is_a?(Array)
+      raise TestError, "#{path}: 'cases' must not be empty" if cases.empty?
+
+      cases.each_with_index do |test_case, index|
+        entry = "#{path}: test entry #{index + 1}"
+        raise TestError, "#{entry} must be a mapping" unless test_case.is_a?(Hash)
+
+        missing = REQUIRED_FIELDS.reject { |field| test_case.key?(field) }
+        raise TestError, "#{entry} is missing #{missing.join(', ')}" unless missing.empty?
+
+        REQUIRED_FIELDS.each do |field|
+          value = test_case[field]
+          next if value.is_a?(String) && !value.strip.empty?
+
+          raise TestError, "#{entry} field '#{field}' must be a non-empty string"
+        end
+      end
+      cases
+    rescue Psych::Exception => e
+      raise TestError, "#{path}: #{e.message}"
+    end
+
+    def self.verify(cases, test_root, &generator)
+      raise TestError, "backend generator callback is required" unless generator
+
+      Dir.mktmpdir("udb-xce-json-test-") do |dir|
+        cases.group_by { |test_case| [test_case["cfg"], test_case["extension"]] }.each do |selector, grouped|
+          cfg, extension = selector
+          output_dir = File.join(dir, "#{cfg}-#{extension}")
+          mnemonics = grouped.map { |test_case| test_case["instruction"] }
+          result = generator.call(
+            cfg_name: cfg,
+            extension_filter: [extension],
+            instruction_filter: mnemonics,
+            output_dir: output_dir
+          )
+          unless result.exported == mnemonics.size
+            raise TestError, "#{selector.join('/')}: expected #{mnemonics.size} exports, got #{result.exported}"
+          end
+          unless result.skipped.empty?
+            raise TestError, "#{selector.join('/')}: unexpected skipped instructions"
+          end
+          unless [32, 64].include?(result.xlen)
+            raise TestError, "#{selector.join('/')}: exporter returned invalid XLEN #{result.xlen.inspect}"
+          end
+          module_path = File.join(output_dir, "#{extension}.json")
+          raise TestError, "#{selector.join('/')}: output not found" unless File.file?(module_path)
+
+          document = JSON.parse(File.read(module_path))
+          validate_module(document, extension, mnemonics, result.xlen, module_path)
+
+          grouped.each { |test_case| verify_case(test_case, document["instructions"], test_root) }
+        end
+      end
+    rescue JSON::ParserError => e
+      raise TestError, e.message
+    end
+
+    def self.validate_module(document, extension, mnemonics, xlen, path)
+      expected_keys = %w[name arch type instructions]
+      raise TestError, "#{path}: unexpected module fields" unless document.keys.sort == expected_keys.sort
+      raise TestError, "#{path}: wrong module name" unless document["name"] == extension
+      raise TestError, "#{path}: expected arch rv#{xlen}" unless document["arch"] == "rv#{xlen}"
+      raise TestError, "#{path}: type must be a string" unless document["type"].is_a?(String)
+
+      instructions = document["instructions"]
+      raise TestError, "#{path}: flat instructions array not found" unless instructions.is_a?(Array)
+
+      actual = instructions.map { |instruction| instruction["asm"]&.split(" ", 2)&.first }
+      raise TestError, "#{path}: expected only #{mnemonics.join(', ')}" unless actual.sort == mnemonics.sort
+
+      forbidden = %w[execute uses defs etype]
+      unexpected = instructions.flat_map { |instruction| instruction.keys & forbidden }.uniq
+      raise TestError, "#{path}: forbidden instruction fields: #{unexpected.join(', ')}" unless unexpected.empty?
+    end
+
+    def self.verify_case(test_case, instructions, test_root)
+      mnemonic = test_case["instruction"]
+      matches = instructions.select { |instruction| instruction["asm"]&.split(" ", 2)&.first == mnemonic }
+      raise TestError, "#{test_case['name']}: expected one #{mnemonic}, found #{matches.size}" unless matches.one?
+
+      expected_path = File.expand_path(test_case["expected"], test_root)
+      expected = JSON.parse(File.read(expected_path))
+      return if expected == matches.first
+
+      raise TestError, "#{test_case['name']}: generated JSON does not match #{test_case['expected']}"
+    end
+
+    private_class_method :validate_module, :verify_case
+  end
+end

--- a/backends/xce_json/tasks.rake
+++ b/backends/xce_json/tasks.rake
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "lib/errors"
+require_relative "lib/exporter"
+
+module XceJson
+  module TaskOptions
+    def self.list(name, value)
+      return nil if value.nil?
+
+      values = value.split(",").map(&:strip).reject(&:empty?).uniq
+      raise ConfigurationError, "#{name} must contain at least one value" if values.empty?
+
+      values
+    end
+  end
+
+  module TaskOutput
+    def self.print_skipped(skipped)
+      skipped.each { |item| warn "SKIP: #{item.instruction} -- #{item.reason}" }
+    end
+  end
+end
+
+namespace :gen do
+  desc <<~DESC
+    Generate structural XCE JSON from UDB instruction data
+
+    Environment variables:
+     * CONFIG       - Configuration name (required, e.g., "rv64")
+     * EXTENSIONS   - Comma-separated extension filter (optional, e.g., "Zicond,Zba")
+     * INSTRUCTIONS - Comma-separated instruction filter (optional, e.g., "add,addi")
+     * OUTPUT_DIR   - Output directory (defaults to "#{$root}/gen/xce_json")
+  DESC
+  task :xce_json do
+    cfg_name = ENV["CONFIG"]&.strip
+    output_dir = ENV["OUTPUT_DIR"]
+    abort "ERROR: CONFIG is required" if cfg_name.nil? || cfg_name.empty?
+    if output_dir&.strip&.empty?
+      abort "ERROR: OUTPUT_DIR must contain at least one non-whitespace character"
+    end
+    output_dir ||= File.join($root, "gen", "xce_json")
+
+    extension_filter = XceJson::TaskOptions.list("EXTENSIONS", ENV["EXTENSIONS"])
+    instruction_filter = XceJson::TaskOptions.list("INSTRUCTIONS", ENV["INSTRUCTIONS"])
+
+    result = XceJson::Exporter.generate(
+      cfg_name: cfg_name,
+      extension_filter: extension_filter,
+      instruction_filter: instruction_filter,
+      output_dir: output_dir
+    )
+    XceJson::TaskOutput.print_skipped(result.skipped)
+    result.output_paths.each { |path| puts "Generated: #{path}" }
+    puts "Done: #{result.exported} exported, #{result.skipped.size} skipped."
+  rescue XceJson::NoInstructionsGeneratedError => e
+    XceJson::TaskOutput.print_skipped(e.skipped)
+    abort "ERROR: #{e.message}"
+  rescue XceJson::Error => e
+    abort "ERROR: #{e.message}"
+  end
+end

--- a/backends/xce_json/tasks.rake
+++ b/backends/xce_json/tasks.rake
@@ -2,6 +2,7 @@
 
 require_relative "lib/errors"
 require_relative "lib/exporter"
+require_relative "lib/test_runner"
 
 module XceJson
   module TaskOptions
@@ -56,6 +57,19 @@ namespace :gen do
   rescue XceJson::NoInstructionsGeneratedError => e
     XceJson::TaskOutput.print_skipped(e.skipped)
     abort "ERROR: #{e.message}"
+  rescue XceJson::Error => e
+    abort "ERROR: #{e.message}"
+  end
+end
+namespace :test do
+  desc "Run XCE JSON tests"
+  task :xce_json do
+    test_root = File.expand_path("test", __dir__)
+    cases = XceJson::TestRunner.load_manifest(File.join(test_root, "manifest.yaml"))
+    XceJson::TestRunner.verify(cases, test_root) do |**options|
+      XceJson::Exporter.generate(**options)
+    end
+    puts "PASS: #{cases.size} XCE JSON test(s)"
   rescue XceJson::Error => e
     abort "ERROR: #{e.message}"
   end

--- a/backends/xce_json/test/integer/add.expected.json
+++ b/backends/xce_json/test/integer/add.expected.json
@@ -1,0 +1,13 @@
+{
+  "asm": "add $xd, $xs1, $xs2",
+  "encoding": [
+    { "offset": 0, "size": 7, "type": "bits", "value": "0x33" },
+    { "offset": 7, "size": 5, "type": "r", "value": "xd", "constraint": "=" },
+    { "offset": 12, "size": 3, "type": "bits", "value": "0x0" },
+    { "offset": 15, "size": 5, "type": "r", "value": "xs1" },
+    { "offset": 20, "size": 5, "type": "r", "value": "xs2" },
+    { "offset": 25, "size": 7, "type": "bits", "value": "0x0" }
+  ],
+  "size": 32,
+  "type": "integer"
+}

--- a/backends/xce_json/test/integer/addi.expected.json
+++ b/backends/xce_json/test/integer/addi.expected.json
@@ -1,0 +1,12 @@
+{
+  "asm": "addi $xd, $xs1, $imm",
+  "encoding": [
+    { "offset": 0, "size": 7, "type": "bits", "value": "0x13" },
+    { "offset": 7, "size": 5, "type": "r", "value": "xd", "constraint": "=" },
+    { "offset": 12, "size": 3, "type": "bits", "value": "0x0" },
+    { "offset": 15, "size": 5, "type": "r", "value": "xs1" },
+    { "offset": 20, "size": 12, "type": "imm", "value": "imm" }
+  ],
+  "size": 32,
+  "type": "integer"
+}

--- a/backends/xce_json/test/manifest.yaml
+++ b/backends/xce_json/test/manifest.yaml
@@ -1,0 +1,12 @@
+cases:
+  - name: integer-r-add
+    cfg: rv64
+    extension: I
+    instruction: add
+    expected: integer/add.expected.json
+
+  - name: integer-i-addi
+    cfg: rv64
+    extension: I
+    instruction: addi
+    expected: integer/addi.expected.json


### PR DESCRIPTION
  ## Summary

  Add a standalone Rake-based exporter that converts structural UDB instruction
  data into the flat JSON module format consumed by XuanTie Custom Extension
  (XCE) tools.

  The exporter:

  - selects instructions from a UDB configuration and optional extension or
    instruction filters;
  - derives RV32/RV64 encodings and representable operand constraints;
  - writes one JSON module per extension;
  - reports instructions whose UDB representation cannot currently be exported.

  ## Scope

  This initial integration exports structural instruction information only. It
  does not add execution semantics, JSON merge support, external XCE toolchain
  tests, or CI integration.

  The operand analysis currently depends on an IDL pass provided by
  `cpp_hart_gen`. This dependency is documented and can be replaced by a
  target-neutral IDL interface separately.

  ## Testing

  The backend includes manually invoked golden tests for the representative
  R-type and I-type instructions `add` and `addi`.

  ```sh
  ./do test:xce_json
  ```

  The exporter can be exercised directly with:

  ```sh
  ./do gen:xce_json CONFIG=rv64 \
    EXTENSIONS=I INSTRUCTIONS=add,addi
  ```

  Related to #1851.