### PR TITLE
fix(spec): update description for Svpbmt extension (#2542)

### DIFF
--- a/spec/std/isa/ext/Svpbmt.yaml
+++ b/spec/std/isa/ext/Svpbmt.yaml
@@ -8,8 +8,8 @@ kind: extension
 name: Svpbmt
 long_name: Page-based memory types
 description: |
-  This extension mandates that the `satp` mode Bare must
-  be supported.
+  This extension specifies page-based memory types, adding the PBMT field
+  to page-table entries to control memory type, cacheability, and ordering attributes.
 type: privileged
 versions:
   - version: "1.0.0"


### PR DESCRIPTION
Updates the description field in spec/std/isa/ext/Svpbmt.yaml. Previously, it contained copy-pasted description text from Svbare.yaml mentioning satp Bare mode. It now accurately describes Page-Based Memory Types (PBMT).

Closes #2542.