### PR TITLE
fix(csr): forward menvcfgh accesses to the parent menvcfg CSR

### DIFF
--- a/spec/std/isa/csr/menvcfgh.yaml
+++ b/spec/std/isa/csr/menvcfgh.yaml
@@ -24,6 +24,9 @@ fields:
   STCE:
     location: 31
     alias: menvcfg.STCE
+    sw_write(csr_value): |
+      CSR[menvcfg].STCE = csr_value.STCE;
+      return csr_value.STCE;
     description: |
       *STimecmp Enable*
 
@@ -36,6 +39,9 @@ fields:
   PBMTE:
     location: 30
     alias: menvcfg.PBMTE
+    sw_write(csr_value): |
+      CSR[menvcfg].PBMTE = csr_value.PBMTE;
+      return csr_value.PBMTE;
     description: |
       *Page Based Memory Type Enable*
 
@@ -48,6 +54,9 @@ fields:
   ADUE:
     location: 29
     alias: menvcfg.ADUE
+    sw_write(csr_value): |
+      CSR[menvcfg].ADUE = csr_value.ADUE;
+      return csr_value.ADUE;
     description: |
       Alias of `menvcfg.ADUE`
     definedBy:
@@ -57,3 +66,4 @@ fields:
       return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
+sw_read(): return $bits(CSR[menvcfg])[63:32];


### PR DESCRIPTION
## Problem

On RV32, `menvcfgh` is architecturally an alias of bits `[63:32]` of the 64-bit `menvcfg`. UDB declared that relationship with `alias:` on each field, but never implemented the forwarding, so reads and writes landed on `menvcfgh`'s own local storage instead of the parent.

`mstateen0h` already models this correctly and is the pattern followed here:

```yaml
    alias: mstateen0.SE0
    sw_write(csr_value): |
      CSR[mstateen0].SE0 = csr_value.SE0;
      return csr_value.SE0;
...
sw_read(): return $bits(CSR[mstateen0])[63:32];
```

## Fix

Adds the missing forwarding to `menvcfgh`, matching `mstateen0h` exactly:

- CSR-level `sw_read(): return $bits(CSR[menvcfg])[63:32];`
- field-level `sw_write()` forwarding for `STCE`, `PBMTE` and `ADUE`

Bit positions verified against the parent: each high-half field sits at `parent_bit - 32` (`menvcfg.STCE` is bit 63, `menvcfgh.STCE` is bit 31, and so on).

Closes #2377.

## Why this is safe at RV32

The forwarding is only valid if the parent's upper-half fields actually exist in an RV32 configuration. Checked against the `rv32` configured architecture:

| Parent CSR | Fields present at RV32 |
|---|---|
| `mstateen0` (existing merged pattern) | `SE0`, `ENVCFG`, `CSRIND`, `AIA`, `IMSIC`, `CONTEXT`, `P1P13`, `SRMCFG`, `CTR`, ... |
| `menvcfg` (this PR) | `STCE`, `PBMTE`, `ADUE` |

`menvcfg` declares `length: 64` unconditionally and puts no `xlen` guard on `STCE`/`PBMTE`/`ADUE`, exactly like `mstateen0`, so the parent fields are present and writable at RV32.

## Scope

An earlier revision of this PR also added the same forwarding to `mcyclecfgh` and `minstretcfgh`. That was wrong and has been dropped, thanks to the review feedback from Codex and Copilot.

Unlike `menvcfg`, every upper-half field in `mcyclecfg` and `minstretcfg` is guarded by `allOf: [{xlen: 64}, ...]`, so those parents have **no fields at all** at RV32. Forwarding into them would target fields that do not exist in the generated RV32 hart. Confirmed against the `rv32` config: `mcyclecfg` and `minstretcfg` both report zero fields present at RV32, while `menvcfg` reports all three.

That is a pre-existing modeling gap in Smcntrpmf rather than anything introduced here: `mcyclecfgh`/`minstretcfgh` are defined at RV32, but the privilege-mode filtering bits they are supposed to expose are declared RV64-only, so those bits are unreachable on RV32. I will raise that separately.

Also left alone:

- **`henvcfgh`** — same class of defect, but #2415 / PR #2416 is already open against it.
- **`mstatush`** — parent `mstatus` is `length: MXLEN`, not 64, so it is a different mechanism.
- **`mseccfgh`, `medelegh`, `hedelegh`** — declare `fields: {}`, so there is nothing to hook `sw_write()` onto.

## Testing

- `./do test:csrs` — passes
- `./do test:schema` — passes
- `./do test:idlc:unit` — 527 runs, 36,803 assertions, 0 failures
- `./do test:udb:unit` — 3,638 runs, 22,944 assertions, 0 failures
- IDL type-check of the new `sw_read()` and all three `sw_write()` bodies against the `rv32` config, with the existing `mstateen0h` bodies as a control

## Note on #2576

While working in this area I looked at #2576, which asks for a `senvcfgh` CSR. I do not believe that register exists: `riscv-isa-manual` defines `senvcfg` as "an SXLEN-bit read/write register" (not 64-bit, so no upper half), `senvcfgh` has zero occurrences anywhere in that repo, `riscv-opcodes` `csrs32.csv` does not list it, and the proposed address 0x10D is already allocated to `sstateen1`. Details are in a comment on that issue.
